### PR TITLE
This patch adds the 'Pyramid' egg_plugin to the templates

### DIFF
--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -10,41 +10,49 @@ from paste.util.template import paste_script_template_renderer
 from pyramid.scripting import get_root
 
 class StarterProjectTemplate(Template):
+    egg_plugins = [ 'Pyramid' ]
     _template_dir = 'paster_templates/starter'
     summary = 'pyramid starter project'
     template_renderer = staticmethod(paste_script_template_renderer)
 
 class StarterZCMLProjectTemplate(Template):
+    egg_plugins = [ 'Pyramid' ]
     _template_dir = 'paster_templates/starter_zcml'
     summary = 'pyramid starter project (ZCML)'
     template_renderer = staticmethod(paste_script_template_renderer)
 
 class ZODBProjectTemplate(Template):
+    egg_plugins = [ 'Pyramid' ]
     _template_dir = 'paster_templates/zodb'
     summary = 'pyramid ZODB starter project'
     template_renderer = staticmethod(paste_script_template_renderer)
 
 class RoutesAlchemyProjectTemplate(Template):
+    egg_plugins = [ 'Pyramid' ]
     _template_dir = 'paster_templates/routesalchemy'
     summary = 'pyramid SQLAlchemy project using Routes (no traversal)'
     template_renderer = staticmethod(paste_script_template_renderer)
 
 class AlchemyProjectTemplate(Template):
+    egg_plugins = [ 'Pyramid' ]
     _template_dir = 'paster_templates/alchemy'
     summary = 'pyramid SQLAlchemy project using traversal'
     template_renderer = staticmethod(paste_script_template_renderer)
 
 class PylonsBasicProjectTemplate(Template):
+    egg_plugins = [ 'Pyramid' ]
     _template_dir = 'paster_templates/pylons_basic'
     summary = 'Pylons basic project'
     template_renderer = staticmethod(paste_script_template_renderer)
 
 class PylonsMinimalProjectTemplate(Template):
+    egg_plugins = [ 'Pyramid' ]
     _template_dir = 'paster_templates/pylons_minimal'
     summary = 'Pylons minimal project'
     template_renderer = staticmethod(paste_script_template_renderer)
 
 class PylonsSQLAlchemyProjectTemplate(Template):
+    egg_plugins = [ 'Pyramid' ]
     _template_dir = 'paster_templates/pylons_sqla'
     summary = 'Pylons SQLAlchemy project'
     template_renderer = staticmethod(paste_script_template_renderer)


### PR DESCRIPTION
The pyramid docs indicate the usage of paster pshell http://docs.pylonshq.com/pyramid/dev/narr/project.html#the-interactive-shell and say that you _might_ be able to get away without the --plugin=pyramid.  This patch allows you to dispense with that.  Pshell as well as any other local commands in pyramid will now be accessible in projects created from pyramid templates.

Note: http://pythonpaste.org/script/developer.html#templates specifies how to use paste script local commands.
