### PR TITLE
Add paster_plugins=['pyramid'] to all setup.py_tmpl files

### DIFF
--- a/pyramid/paster_templates/alchemy/setup.py_tmpl
+++ b/pyramid/paster_templates/alchemy/setup.py_tmpl
@@ -40,6 +40,7 @@ setup(name='{{project}}',
       entry_points = """\
       [paste.app_factory]
       app = {{package}}:app
-      """
+      """,
+      paster_plugins=['pyramid'],
       )
 

--- a/pyramid/paster_templates/pylons_basic/setup.py_tmpl
+++ b/pyramid/paster_templates/pylons_basic/setup.py_tmpl
@@ -31,6 +31,7 @@ setup(name='{{project}}',
       entry_points = """\
       [paste.app_factory]
       main = {{package}}:main
-      """
+      """,
+      paster_plugins=['pyramid'],
       )
 

--- a/pyramid/paster_templates/pylons_minimal/setup.py_tmpl
+++ b/pyramid/paster_templates/pylons_minimal/setup.py_tmpl
@@ -31,6 +31,7 @@ setup(name='{{project}}',
       entry_points = """\
       [paste.app_factory]
       main = {{package}}:main
-      """
+      """,
+      paster_plugins=['pyramid'],
       )
 

--- a/pyramid/paster_templates/pylons_sqla/setup.py_tmpl
+++ b/pyramid/paster_templates/pylons_sqla/setup.py_tmpl
@@ -43,6 +43,7 @@ setup(name='{{project}}',
       entry_points = """\
       [paste.app_factory]
       main = {{package}}:main
-      """
+      """,
+      paster_plugins=['pyramid'],
       )
 

--- a/pyramid/paster_templates/routesalchemy/setup.py_tmpl
+++ b/pyramid/paster_templates/routesalchemy/setup.py_tmpl
@@ -40,6 +40,7 @@ setup(name='{{project}}',
       entry_points = """\
       [paste.app_factory]
       app = {{package}}:app
-      """
+      """,
+      paster_plugins=['pyramid'],
       )
 

--- a/pyramid/paster_templates/starter/setup.py_tmpl
+++ b/pyramid/paster_templates/starter/setup.py_tmpl
@@ -31,6 +31,7 @@ setup(name='{{project}}',
       entry_points = """\
       [paste.app_factory]
       app = {{package}}:app
-      """
+      """,
+      paster_plugins=['pyramid'],
       )
 

--- a/pyramid/paster_templates/starter_zcml/setup.py_tmpl
+++ b/pyramid/paster_templates/starter_zcml/setup.py_tmpl
@@ -31,6 +31,7 @@ setup(name='{{project}}',
       entry_points = """\
       [paste.app_factory]
       app = {{package}}:app
-      """
+      """,
+      paster_plugins=['pyramid'],
       )
 

--- a/pyramid/paster_templates/zodb/setup.py_tmpl
+++ b/pyramid/paster_templates/zodb/setup.py_tmpl
@@ -36,6 +36,7 @@ setup(name='{{project}}',
       entry_points = """\
       [paste.app_factory]
       app = {{package}}:app
-      """
+      """,
+      paster_plugins=['pyramid'],
       )
 


### PR DESCRIPTION
The pyramid docs indicate the usage of paster pshell http://docs.pylonshq.com/pyramid/dev/narr/project.html#the-interactive-shell and say that you might be able to get away without the --plugin=pyramid. This patch allows you to dispense with that. Pshell as well as any other local commands in pyramid will now be accessible in projects created from pyramid templates.

Note: http://pythonpaste.org/script/developer.html#templates specifies how to use paste script local commands but is apparently obsolete (according to a message from paster create) and so the paster_plugins=[...] method was used.
