### PR TITLE
Fix default mako template filter.

### DIFF
--- a/pyramid/mako_templating.py
+++ b/pyramid/mako_templating.py
@@ -65,7 +65,7 @@ def renderer_factory(info):
         module_directory = settings.get('mako.module_directory')
         input_encoding = settings.get('mako.input_encoding', 'utf-8')
         error_handler = settings.get('mako.error_handler', None)
-        default_filters = settings.get('mako.default_filters', [])
+        default_filters = settings.get('mako.default_filters', None)
         imports = settings.get('mako.imports', [])
         if directories is None:
             raise ConfigurationError(


### PR DESCRIPTION
By default, mako filters all strings with 'unicode'. When Pyramid added hooks to let the default filter by changed, they changed the default to be empty, rather then None, which overrides mako's defaults.

This patch just sets the default to 'None' which then lets mako's default takeover.
