### PR TITLE
Typo fixed in deprecation warning

### DIFF
--- a/pyramid/settings.py
+++ b/pyramid/settings.py
@@ -88,7 +88,7 @@ def get_settings():
 deprecated(
     'get_settings',
     '(pyramid.settings.get_settings is deprecated as of Pyramid 1.0.  Use'
-    '``pyramid.threadlocals.get_current_registry().settings`` instead or use '
+    '``pyramid.threadlocal.get_current_registry().settings`` instead or use '
     'the ``settings`` attribute of the registry available from the request '
     '(``request.registry.settings``)).')
 


### PR DESCRIPTION
I was thinking I was stupid until realize there was no "s" :)
