### PR TITLE
BFG_ -> PYRAMID_

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -67,7 +67,7 @@ Terminology Changes
 
   - The setting previously known as ``BFG_RELOAD_RESOURCES`` (envvar) or
     ``reload_resources`` (config file) is now known, respectively, as
-    ``BFG_RELOAD_ASSETS`` and ``reload_assets``.
+    ``PYRAMID_RELOAD_ASSETS`` and ``reload_assets``.
 
   Backwards compatibility shims have been left in place in all cases.  They
   will continue to work "forever".
@@ -103,7 +103,7 @@ Documentation
 - Added "Debugging Route Matching" section to the urldispatch narrative
   documentation chapter.
 
-- Added reference to ``BFG_DEBUG_ROUTEMATCH`` envvar and ``debug_routematch``
+- Added reference to ``PYRAMID_DEBUG_ROUTEMATCH`` envvar and ``debug_routematch``
   config file setting to the Environment narrative docs chapter.
 
 - Changed "Project" chapter slightly to expand on use of ``paster pshell``.

--- a/docs/narr/security.rst
+++ b/docs/narr/security.rst
@@ -496,12 +496,12 @@ Debugging View Authorization Failures
 
 If your application in your judgment is allowing or denying view
 access inappropriately, start your application under a shell using the
-``BFG_DEBUG_AUTHORIZATION`` environment variable set to ``1``.  For
+``PYRAMID_DEBUG_AUTHORIZATION`` environment variable set to ``1``.  For
 example:
 
 .. code-block:: text
 
-  $ BFG_DEBUG_AUTHORIZATION=1 bin/paster serve myproject.ini
+  $ PYRAMID_DEBUG_AUTHORIZATION=1 bin/paster serve myproject.ini
 
 When any authorization takes place during a top-level view rendering,
 a message will be logged to the console (to stderr) about what ACE in

--- a/docs/narr/templates.rst
+++ b/docs/narr/templates.rst
@@ -614,12 +614,12 @@ In order to turn on template exception debugging, you can use an
 environment variable setting or a configuration file setting.
 
 To use an environment variable, start your application under a shell
-using the ``BFG_DEBUG_TEMPLATES`` operating system environment
+using the ``PYRAMID_DEBUG_TEMPLATES`` operating system environment
 variable set to ``1``, For example:
 
 .. code-block:: text
 
-  $ BFG_DEBUG_TEMPLATES=1 bin/paster serve myproject.ini
+  $ PYRAMID_DEBUG_TEMPLATES=1 bin/paster serve myproject.ini
 
 To use a setting in the application ``.ini`` file for the same
 purpose, set the ``debug_templates`` key to ``true`` within the
@@ -777,12 +777,12 @@ In order to turn on automatic reloading of templates, you can use an
 environment variable, or a configuration file setting.
 
 To use an environment variable, start your application under a shell
-using the ``BFG_RELOAD_TEMPLATES`` operating system environment
+using the ``PYRAMID_RELOAD_TEMPLATES`` operating system environment
 variable set to ``1``, For example:
 
 .. code-block:: text
 
-  $ BFG_RELOAD_TEMPLATES=1 bin/paster serve myproject.ini
+  $ PYRAMID_RELOAD_TEMPLATES=1 bin/paster serve myproject.ini
 
 To use a setting in the application ``.ini`` file for the same
 purpose, set the ``reload_templates`` key to ``true`` within the

--- a/docs/narr/urldispatch.rst
+++ b/docs/narr/urldispatch.rst
@@ -1207,7 +1207,7 @@ Debugging Route Matching
 
 It's useful to be able to take a peek under the hood when requests that enter
 your application arent matching your routes as you expect them to.  To debug
-route matching, use the ``BFG_DEBUG_ROUTEMATCH`` environment variable or the
+route matching, use the ``PYRAMID_DEBUG_ROUTEMATCH`` environment variable or the
 ``debug_routematch`` configuration file setting (set either to ``true``).
 Details of the route matching decision for a particular request to the
 :app:`Pyramid` application will be printed to the ``stderr`` of the console
@@ -1216,7 +1216,7 @@ which you started the application from.  For example:
 .. code-block:: text
    :linenos:
 
-    [chrism@thinko pylonsbasic]$ BFG_DEBUG_ROUTEMATCH=true \
+    [chrism@thinko pylonsbasic]$ PYRAMID_DEBUG_ROUTEMATCH=true \
                                  bin/paster serve development.ini 
     Starting server in PID 13586.
     serving on 0.0.0.0:6543 view at http://127.0.0.1:6543

--- a/docs/narr/views.rst
+++ b/docs/narr/views.rst
@@ -1230,7 +1230,7 @@ for more information about changing the default notfound view.
 
 It's useful to be able to debug :exc:`NotFound` error responses when they
 occur unexpectedly due to an application registry misconfiguration.  To debug
-these errors, use the ``BFG_DEBUG_NOTFOUND`` environment variable or the
+these errors, use the ``PYRAMID_DEBUG_NOTFOUND`` environment variable or the
 ``debug_notfound`` configuration file setting.  Details of why a view was not
 found will be printed to ``stderr``, and the browser representation of the
 error will include the same information.  See :ref:`environment_chapter` for


### PR DESCRIPTION
make it consistent with CHANGES:
- All environment variables which used to be prefixed with `BFG_` are now
  prefixed with `PYRAMID_` (e.g. `BFG_DEBUG_NOTFOUND` is now
  `PYRAMID_DEBUG_NOTFOUND`)
