### PR TITLE
Untitled

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ Bug Fixes
   Instead of trying to resolve the view, if it cannot, it will now just print
   ``<unknown>``.
 
+- The `self` argument was included in new methods of the ISession interface
+  signature.
+
 Documentation
 -------------
 

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -480,11 +480,11 @@ class ISession(Interface):
         :meth:`pyramid.interfaces.ISesssion.flash`
         """
 
-    def new_csrf_token(self):
+    def new_csrf_token():
         """ Create and set into the session a new, random cross-site request
         forgery protection token.  Return the token.  It will be a string."""
 
-    def get_csrf_token(self):
+    def get_csrf_token():
         """ Get the CSRF token previously added to the session via
         ``new_csrf_token``, and return the token.  If no CSRF token exists,
         the value returned will be ``None``.


### PR DESCRIPTION
This issue is currently causing pyramid_beaker tests to fail with BrokenMethodImplementation.
