### PR TITLE
Renamed 'home' route to 'view_wiki' for consistency with the following __init__.py examples. 

### DIFF
--- a/docs/tutorials/wiki2/src/views/tutorial/__init__.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/__init__.py
@@ -10,7 +10,7 @@ def main(global_config, **settings):
     initialize_sql(engine)
     config = Configurator(settings=settings)
     config.add_static_view('static', 'tutorial:static')
-    config.add_route('home', '/', view='tutorial.views.view_wiki')
+    config.add_route('view_wiki', '/', view='tutorial.views.view_wiki')
     config.add_route('view_page', '/{pagename}',
                      view='tutorial.views.view_page',
                      view_renderer='tutorial:templates/view.pt')


### PR DESCRIPTION
Also view_wiki is mentioned in the preceding text before code example instead of 'home' for the / mount point.
