### PR TITLE
handlers chapter no longer exist

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -834,7 +834,7 @@ Glossary
      :meth:`pyramid.config.Configurator.add_route` and
      :meth:`pyramid.config.Configurator.add_view` to make it more
      convenient to register a collection of views as a single class when
-     using :term:`url dispatch`.  See also :ref:`handlers_chapter`.
+     using :term:`url dispatch`.  See also :ref:`views_chapter`.
 
    Deployment settings
      Deployment settings are settings passed to the :term:`Configurator` as a

--- a/docs/zcml/handler.rst
+++ b/docs/zcml/handler.rst
@@ -155,4 +155,4 @@ You can also add a :term:`route configuration` via:
 See Also
 ~~~~~~~~
 
-See also :ref:`handlers_chapter`.
+See also :ref:`views_chapter`.

--- a/pyramid/config.py
+++ b/pyramid/config.py
@@ -923,7 +923,7 @@ class Configurator(object):
 
         Any extra keyword arguments are passed along to ``add_route``.
 
-        See :ref:`handlers_chapter` for more explanatory documentation.
+        See :ref:`views_chapter` for more explanatory documentation.
 
         This method returns the result of add_route."""
         handler = self.maybe_dotted(handler)


### PR DESCRIPTION
and for something related:
1. there is no apidoc for pyramid.view.action
2. how to generate url configured via add_handlers? don't know where to look :)
