### PR TITLE
Overriding renderer utility at runtime

### DIFF
--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -295,6 +295,12 @@ class RendererHelper(object):
                 
 
     def render(self, value, system_values, request=None):
+        if request is not None and hasattr(request, 'response_renderer'):
+            renderer_name = request.response_renderer
+            del request.response_renderer
+            helper = RendererHelper(renderer_name, registry=self.registry)
+            return helper.render(value, system_values, request)
+
         renderer = self.renderer
         if system_values is None:
             system_values = {
@@ -304,7 +310,6 @@ class RendererHelper(object):
                 'context':getattr(request, 'context', None),
                 'request':request,
                 }
-
         registry = self.registry
         globals_factory = registry.queryUtility(IRendererGlobalsFactory)
 

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -478,6 +478,16 @@ class Test_render(unittest.TestCase):
         renderer.assert_(a=1)
         renderer.assert_(request=request)
 
+    def test_it_with_request_response_renderer(self):
+        renderer = self.config.testing_add_renderer(
+            'pyramid.tests:abc/def.pt')
+        renderer.string_response = '{"a": 1}'
+        request = testing.DummyRequest()
+        request.response_renderer = 'json'
+        result = self._callFUT('abc/def.pt',
+                               dict(a=1), request=request)
+        self.assertEqual(result, '{"a": 1}')
+
 class Test_render_to_response(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()
@@ -509,7 +519,18 @@ class Test_render_to_response(unittest.TestCase):
         self.assertEqual(response.body, 'abc')
         renderer.assert_(a=1)
         renderer.assert_(request=request)
-    
+
+    def test_it_with_request_response_renderer(self):
+        renderer = self.config.testing_add_renderer(
+            'pyramid.tests:abc/def.pt')
+        request = testing.DummyRequest()
+        request.response_renderer = 'json'
+        response = self._callFUT('abc/def.pt',
+                               dict(a=1), request=request)
+        self.assertEqual(response.body, '{"a": 1}')
+        self.assertEqual(response.content_type, 'application/json')
+
+
 class Test_get_renderer(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()


### PR DESCRIPTION
For now you have a single way to render a view with the renderer parameter and no way to override it.
I like to allow to override this if a request.response_renderer is defined

My patch allow this:

```
@view_config(renderer='my.pt')
def my_view(request):
    if request.is_xhr:
        request.response_renderer = 'json'
    return {}
```

This will render the view result as json if request.is_xhr is True and my.pt in other case.
This will help to build web services. A single url for two or more format without duplicated callable.
