### PR TITLE
Added support for removing wildcard domains from auth_tkt.

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -243,6 +243,12 @@ class AuthTktAuthenticationPolicy(CallbackAuthenticationPolicy):
        Default: ``False``. Hide cookie from JavaScript by setting the
        HttpOnly flag. Not honored by all browsers.
        Optional.
+
+    ``wild_domain``
+
+       Default: ``True``. An auth_tkt cookie will be generated for the
+       wildcard domain.
+       Optional.
     """
     implements(IAuthenticationPolicy)
     def __init__(self,

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -548,6 +548,20 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         self.failUnless('; Secure' in result[2][1])
         self.failUnless(result[2][1].startswith('auth_tkt='))
 
+    def test_remember_wild_domain_disabled(self):
+        plugin = self._makeOne('secret', wild_domain=False)
+        request = self._makeRequest()
+        result = plugin.remember(request, 'other')
+        self.assertEqual(len(result), 2)
+
+        self.assertEqual(result[0][0], 'Set-Cookie')
+        self.assertTrue(result[0][1].endswith('; Path=/'))
+        self.failUnless(result[0][1].startswith('auth_tkt='))
+
+        self.assertEqual(result[1][0], 'Set-Cookie')
+        self.assertTrue(result[1][1].endswith('; Path=/; Domain=localhost'))
+        self.failUnless(result[1][1].startswith('auth_tkt='))
+
     def test_remember_string_userid(self):
         plugin = self._makeOne('secret')
         request = self._makeRequest()


### PR DESCRIPTION
AuthTktAuthenticationPolicy currently creates 3 cookies: default domain, current domain, and wildcard domain (current domain prefixed by a '.').

I imagine for some applications, including my own, it's not desirable to support the wildcard domain, especially if you intend to run separation AuthTkt on a subdomain.

I left the default as "wild_domain=True" for bw compat.
