### PR TITLE
Allow for a view_selector of any length.

### DIFF
--- a/pyramid/traversal.py
+++ b/pyramid/traversal.py
@@ -614,11 +614,12 @@ class ResourceTreeTraverser(object):
             # and this hurts readability; apologies
             i = 0
             view_selector = self.VIEW_SELECTOR
+            view_selector_len = len(view_selector)
             vpath_tuple = traversal_path(vpath)
             for segment in vpath_tuple:
-                if segment.startswith(view_selector):
+                if segment[:view_selector_len] == view_selector:
                     return {'context':ob,
-                            'view_name':segment[len(view_selector):],
+                            'view_name':segment[view_selector_len:],
                             'subpath':vpath_tuple[i+1:],
                             'traversed':vpath_tuple[:vroot_idx+i+1],
                             'virtual_root':vroot,


### PR DESCRIPTION
I would like to be able to change the view selector in my app from '@@' to '+'. Someone showed me how to change the view selector by subclassing ResourceTreeTraverser [1].  But this only allows for a view selector of a length of 2. 

This small patch allows for one to use the above mentioned method to use a view selector of any length.

[1] http://stackoverflow.com/questions/4427617/change-the-view-prefix-in-pyramid-traversal-from-to
