### PR TITLE
Typo in docs in wiki2 tutorial - there is add_page in edit_page view section.

### DIFF
--- a/docs/tutorials/wiki2/definingviews.rst
+++ b/docs/tutorials/wiki2/definingviews.rst
@@ -164,7 +164,7 @@ The ``edit_page`` view function
 The ``edit_page`` function will be invoked when a user clicks the
 "Edit this Page" button on the view form.  It renders an edit form but
 it also acts as the handler for the form it renders.  The
-``matchdict`` attribute of the request passed to the ``add_page`` view
+``matchdict`` attribute of the request passed to the ``edit_page`` view
 will have a ``pagename`` key matching the name of the page the user
 wants to edit.
 


### PR DESCRIPTION
I fixed the typo in docs in 'Defining Views' chapter in wiki2 tutorial.
