### PR TITLE
'pyramid.url.resource_url' no longer quotes '@' in '*elements'.

### DIFF
--- a/pyramid/tests/test_url.py
+++ b/pyramid/tests/test_url.py
@@ -49,6 +49,14 @@ class ResourceURLTests(unittest.TestCase):
         self.assertEqual(result,
                      'http://example.com/context/La%20Pe%C3%B1a')
 
+    def test_at_sign_in_element_names(self):
+        request = _makeRequest()
+        self._registerContextURL(request.registry)
+        context = DummyContext()
+        result = self._callFUT(context, request, '@@myview')
+        self.assertEqual(result,
+                     'http://example.com/context/@@myview')
+
     def test_element_names_url_quoted(self):
         request = _makeRequest()
         self._registerContextURL(request.registry)

--- a/pyramid/traversal.py
+++ b/pyramid/traversal.py
@@ -509,6 +509,7 @@ def traversal_path(path):
     return tuple(clean)
 
 _segment_cache = {}
+path_safe = ':@&+$,'
 
 def quote_path_segment(segment):
     """ Return a quoted representation of a 'path segment' (such as
@@ -540,9 +541,9 @@ def quote_path_segment(segment):
         return _segment_cache[segment]
     except KeyError:
         if segment.__class__ is unicode: # isinstance slighly slower (~15%)
-            result = url_quote(segment.encode('utf-8'))
+            result = url_quote(segment.encode('utf-8'), path_safe)
         else:
-            result = url_quote(str(segment))
+            result = url_quote(str(segment), path_safe)
         # we don't need a lock to mutate _segment_cache, as the below
         # will generate exactly one Python bytecode (STORE_SUBSCR)
         _segment_cache[segment] = result


### PR DESCRIPTION
See http://groups.google.com/group/pylons-discuss/browse_thread/thread/ebb8e0196858a48
