### PR TITLE
Fix for issue #151

### DIFF
--- a/docs/tutorials/wiki/installation.rst
+++ b/docs/tutorials/wiki/installation.rst
@@ -65,12 +65,12 @@ Preparation, UNIX
 
      $ bin/easy_install pyramid
 
-#. Use ``easy_install`` to install ``docutils``, ``repoze.tm``,
+#. Use ``easy_install`` to install ``docutils``, ``repoze.tm2``,
    ``repoze.zodbconn``, ``nose`` and ``coverage``:
 
    .. code-block:: text
 
-     $ bin/easy_install docutils repoze.tm repoze.zodbconn \
+     $ bin/easy_install docutils repoze.tm2 repoze.zodbconn \
                nose coverage
 
 Preparation, Windows
@@ -117,12 +117,12 @@ Preparation, Windows
 
      c:\pyramidtut> Scripts\easy_install pyramid
 
-#. Use ``easy_install`` to install ``docutils``, ``repoze.tm``,
+#. Use ``easy_install`` to install ``docutils``, ``repoze.tm2``,
    ``repoze.zodbconn``, ``nose`` and ``coverage``:
 
    .. code-block:: text
 
-     c:\pyramidtut> Scripts\easy_install docutils repoze.tm \
+     c:\pyramidtut> Scripts\easy_install docutils repoze.tm2 \
            repoze.zodbconn nose coverage
 
 .. _making_a_project:


### PR DESCRIPTION
The documentation for the wiki tutorial erroneously referred to repoze.tm instead of repoze.tm2.
