### PR TITLE
I was looking for the docs to those things, and couldn't find them on the web. This adds them to the rendered output.

### DIFF
--- a/docs/api/authentication.rst
+++ b/docs/api/authentication.rst
@@ -9,15 +9,18 @@ Authentication Policies
 .. automodule:: pyramid.authentication
 
   .. autoclass:: AuthTktAuthenticationPolicy
-
+     :members:
+     
   .. autoclass:: RepozeWho1AuthenticationPolicy
+     :members:
 
   .. autoclass:: RemoteUserAuthenticationPolicy
+     :members:
 
 Helper Classes
 ~~~~~~~~~~~~~~
 
   .. autoclass:: AuthTktCookieHelper
-
+     :members:
 
 


### PR DESCRIPTION
Add documentation of the members of AuthTktAuthPolicy and the others in the authentication API docs.
