### PR TITLE
Fixed typos and added clarifications in a tutorial 

### DIFF
--- a/docs/tutorials/wiki2/authorization.rst
+++ b/docs/tutorials/wiki2/authorization.rst
@@ -76,7 +76,14 @@ For any :app:`Pyramid` application to perform authorization, we need to add a
 
 We'll change our ``__init__.py`` file to enable an
 ``AuthTktAuthenticationPolicy`` and an ``ACLAuthorizationPolicy`` to enable
-declarative security checking.
+declarative security checking. We need to import the new policies:
+
+.. literalinclude:: src/authorization/tutorial/__init__.py
+   :lines: 2-3,8
+   :linenos:
+   :language: python
+
+Then, we'll add those policies to the configuration:
 
 .. literalinclude:: src/authorization/tutorial/__init__.py
    :lines: 15-21
@@ -97,12 +104,19 @@ We'll also change ``__init__.py``, adding a call to
 :term:`view callable`.  This is also known as a :term:`forbidden view`:
 
 .. literalinclude:: src/authorization/tutorial/__init__.py
-   :lines: 24-26
+   :lines: 24-26,40-42
    :linenos:
    :language: python
 
 A forbidden view configures our newly created login view to show up when
 :app:`Pyramid` detects that a view invocation can not be authorized.
+
+A ``logout`` :term:`view callable` will allow users to log out later:
+
+.. literalinclude:: src/authorization/tutorial/__init__.py
+   :lines: 27-28
+   :linenos:
+   :language: python
 
 We'll also add ``view_permission`` arguments with the value ``edit`` to the
 ``edit_page`` and ``add_page`` routes.  This indicates that the view

--- a/docs/tutorials/wiki2/basiclayout.rst
+++ b/docs/tutorials/wiki2/basiclayout.rst
@@ -98,7 +98,7 @@ names a ``view_renderer``, which is a template which lives in the
 ``tutorial.views.my_view`` view returns a dictionary, a :term:`renderer` will
 use this template to create a response.
 
-Fimnally, we use the :meth:`pyramid.config.Configurator.make_wsgi_app`
+Finally, we use the :meth:`pyramid.config.Configurator.make_wsgi_app`
 method to return a :term:`WSGI` application:
 
    .. literalinclude:: src/basiclayout/tutorial/__init__.py

--- a/docs/tutorials/wiki2/definingmodels.rst
+++ b/docs/tutorials/wiki2/definingmodels.rst
@@ -26,6 +26,14 @@ The first thing we want to do is remove the stock ``MyModel`` class from the
 generated ``models.py`` file.  The ``MyModel`` class is only a sample and
 we're not going to use it.
 
+Next, we'll remove the :class:`sqlalchemy.Unicode` import and replace it
+with :class:`sqlalchemy.Text`.
+
+.. literalinclude:: src/models/tutorial/models.py
+   :lines: 5
+   :linenos:
+   :language: py
+
 Then, we'll add a ``Page`` class.  Because this is a SQLAlchemy
 application, this class should inherit from an instance of
 :class:`sqlalchemy.ext.declarative.declarative_base`.  Declarative


### PR DESCRIPTION
I was working through the wiki2 tutorial this morning and found some slightly confusing bits. As I went along, I added the suggested changes to my local files to make them match the tutorial's version, but found several times that key parts were missing.

I'm not new to Python so this didn't slow me down, but thought some clarifications might help new users.
