### PR TITLE
Add possibility to specify a mako preprocessor

### DIFF
--- a/pyramid/mako_templating.py
+++ b/pyramid/mako_templating.py
@@ -59,6 +59,7 @@ def renderer_factory(info):
     path = info.name
     registry = info.registry
     settings = info.settings
+    preprocessor = getattr(info, 'preprocessor', None)
     lookup = registry.queryUtility(IMakoLookup)
     if lookup is None:
         reload_templates = settings.get('reload_templates', False)
@@ -95,6 +96,7 @@ def renderer_factory(info):
                                            default_filters=default_filters,
                                            imports=imports,
                                            filesystem_checks=reload_templates,
+                                           preprocessor=preprocessor,
                                            strict_undefined=strict_undefined)
         registry_lock.acquire()
         try:


### PR DESCRIPTION
You can now create your own Renderer which uses the default Mako renderer combined with your own preprocessor.
For example you can create a Renderer that understands pyHAML syntax:

``` python
  import haml
  from pyramid import mako_templating

  class HamlRenderer(object):
      def __init__(self, info):
          setattr(info, 'preprocessor', haml.preprocessor)
          self.makoRenderer = mako_templating.renderer_factory(info)

      def __call__(self, value, system):
          return self.makoRenderer(value, system)
```

And then in YOURPROJECT/__init__.py you can tell pyramid to use your brand new Haml-Renderer for all mako templates:

``` python
    config.add_renderer(".mako", HamlRenderer)
```
