### PR TITLE
Language fallback support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -42,6 +42,12 @@ Documentation
 Features
 --------
 
+- Add support for language fallbacks: when trying to translate for a
+  specific territory (such as ``en_GB``) fall back to translations
+  for the language (ie ``en``). This brings the translation behaviour in line
+  with GNU gettext and fixes partially translated texts when using C
+  extensions.
+
 - New authentication policy:
   ``pyramid.authentication.SessionAuthenticationPolicy``, which uses a session
   to store credentials.

--- a/pyramid/i18n.py
+++ b/pyramid/i18n.py
@@ -151,11 +151,16 @@ def make_localizer(current_locale_name, translation_directories):
     translations found in the list of translation directories."""
     translations = Translations()
     translations._catalog = {}
+
+    locales_to_try = [current_locale_name]
+    if '_' in current_locale_name:
+        locales_to_try.append(current_locale_name.split('_')[0])
+
     for tdir in translation_directories:
         locale_dirs = [ (lname, os.path.join(tdir, lname)) for lname in
                         os.listdir(tdir) ]
         for locale_name, locale_dir in locale_dirs:
-            if locale_name != current_locale_name:
+            if locale_name not in locales_to_try:
                 continue
             messages_dir = os.path.join(locale_dir, 'LC_MESSAGES')
             if not os.path.isdir(os.path.realpath(messages_dir)):

--- a/pyramid/tests/test_i18n.py
+++ b/pyramid/tests/test_i18n.py
@@ -200,6 +200,19 @@ class Test_make_localizer(unittest.TestCase):
         self.assertEqual(result.translate('Approve', 'deformsite'),
                          'Approve')
 
+    def test_territory_fallback(self):
+        import os
+        from pyramid.i18n import Localizer
+        here = os.path.dirname(__file__)
+        localedir = os.path.join(here, 'localeapp', 'locale')
+        localedirs = [localedir]
+        locale_name = 'de_DE'
+        result = self._callFUT(locale_name, localedirs)
+        self.assertEqual(result.__class__, Localizer)
+        self.assertEqual(result.translate('Approve', 'deformsite'),
+                         'Genehmigen')
+
+
 class Test_get_localizer(unittest.TestCase):
     def setUp(self):
         cleanUp()


### PR DESCRIPTION
This change adds support for language fallbacks for translations. Essentially if you are trying to translate for specific territory such as nl_NL pyramid will now fall back to translations for nl if no nl_NL translation exists. 

I needed this change to be able to get translations working for apps using C extensions running on Ubuntu: current versions of Ubuntu do not allow you to set the current locale to a language but force you to use a territory. Translations handled in C code work fine in this setup since GNU libc will fall back to using translations for the language, but texts in pyramid remained untranslated since pyramid did not support that fallback.

This change is fully backwards compatible.
