### PR TITLE
Display Mako HTML error template if debug_template = true.

### DIFF
--- a/pyramid/mako_templating.py
+++ b/pyramid/mako_templating.py
@@ -101,16 +101,19 @@ def renderer_factory(info):
             registry.registerUtility(lookup, IMakoLookup)
         finally:
             registry_lock.release()
-            
-    return MakoLookupTemplateRenderer(path, lookup)
+
+    debug_templates = asbool(settings.get('debug_templates', False))
+    return MakoLookupTemplateRenderer(path, lookup,
+                                      debug_templates = debug_templates)
 
 
 class MakoLookupTemplateRenderer(object):
     implements(ITemplateRenderer)
-    def __init__(self, path, lookup):
+    def __init__(self, path, lookup, debug_templates = False):
         self.path = path
         self.lookup = lookup
- 
+        self.debug_templates = debug_templates
+
     def implementation(self):
         return self.lookup.get_template(self.path)
 
@@ -128,5 +131,12 @@ class MakoLookupTemplateRenderer(object):
         template = self.implementation()
         if def_name is not None:
             template = template.get_def(def_name)
-        result = template.render_unicode(**system)
-        return result
+        if self.debug_templates:
+            try:
+                result = template.render_unicode(**system)
+                return result
+            except Exception, e:
+                return exceptions.html_error_template().render()
+        else:
+            result = template.render_unicode(**system)
+            return result


### PR DESCRIPTION
Hello,

I am new to the Pyramid project, but I think I have a funtional solution for this issue:
https://github.com/Pylons/pyramid/issues/204

I call mako.exceptions.html_error_template() if debug_template is enabled in the paste .ini config file. This config variable is used the same way with Chameleon templates.

I recognize that catching Exception is crappy, but in this case I don't see how to do another way.

What do you think about merging this patch ?

Regards,
cbenz
