### PR TITLE
A fix for classmethod-based custom predicates with no __text__ property.

### DIFF
--- a/pyramid/config.py
+++ b/pyramid/config.py
@@ -2692,7 +2692,15 @@ def _make_predicates(xhr=None, request_method=None, path_info=None,
     if custom:
         for num, predicate in enumerate(custom):
             if getattr(predicate, '__text__', None) is None:
-                predicate.__text__ = "<unknown custom predicate>"
+                text = '<unknown custom predicate>'
+                try:
+                    predicate.__text__ = text
+                except AttributeError:
+                    # if this happens the predicate is probably a classmethod
+                    if hasattr(predicate, '__func__'):
+                        predicate.__func__.__text__ = text
+                    else: # 2.5 doesn't have __func__
+                        predicate.im_func.__text__ = text
             predicates.append(predicate)
             # using hash() here rather than id() is intentional: we
             # want to allow custom predicates that are part of

--- a/pyramid/tests/test_config.py
+++ b/pyramid/tests/test_config.py
@@ -4626,7 +4626,9 @@ class Test__make_predicates(unittest.TestCase):
             accept='accept',
             containment='containment',
             request_type='request_type',
-            custom=(DummyCustomPredicate(),))
+            custom=(DummyCustomPredicate(),
+                    DummyCustomPredicate.classmethod_predicate,
+                    DummyCustomPredicate.classmethod_predicate_no_text))
         self.assertEqual(predicates[0].__text__, 'xhr = True')
         self.assertEqual(predicates[1].__text__,
                          'request method = request_method')
@@ -4637,6 +4639,8 @@ class Test__make_predicates(unittest.TestCase):
         self.assertEqual(predicates[6].__text__, 'containment = containment')
         self.assertEqual(predicates[7].__text__, 'request_type = request_type')
         self.assertEqual(predicates[8].__text__, 'custom predicate')
+        self.assertEqual(predicates[9].__text__, 'classmethod predicate')
+        self.assertEqual(predicates[10].__text__, '<unknown custom predicate>')
 
 class TestMultiView(unittest.TestCase):
     def _getTargetClass(self):
@@ -5213,6 +5217,15 @@ class DummyStaticURLInfo:
 class DummyCustomPredicate(object):
     def __init__(self):
         self.__text__ = 'custom predicate'
+
+    def classmethod_predicate(*args):
+        pass
+    classmethod_predicate.__text__ = 'classmethod predicate'
+    classmethod_predicate = classmethod(classmethod_predicate)
+
+    @classmethod
+    def classmethod_predicate_no_text(*args):
+        pass
 
 def dummy_view(request):
     return 'OK'


### PR DESCRIPTION
Basically Pyramid would raise an `AttributeError` in the `Configurator` when attempting to set `__text__` on a custom predicate that was actually a `classmethod`.
