### PR TITLE
Zap word "either" describing acceptable values to Configurator.add_view() "request_method" kwarg. By my reading, the word "eit

### DIFF
--- a/pyramid/config.py
+++ b/pyramid/config.py
@@ -1157,7 +1157,7 @@ class Configurator(object):
 
         request_method
 
-          This value can either be one of the strings ``GET``,
+          This value can be one of the strings ``GET``,
           ``POST``, ``PUT``, ``DELETE``, or ``HEAD`` representing an
           HTTP ``REQUEST_METHOD``.  A view declaration with this
           argument ensures that the view will only be called when the


### PR DESCRIPTION
Zap word "either" describing acceptable values to Configurator.add_view() "request_method" kwarg. By my reading, the word "either" implies there is an alternative to one of the listed strings (perhaps that you can pass some other kind of value such as a sequence of allowed request methods - which is not the case).
