### PR TITLE
Minor wording change for accuracy

### DIFF
--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -288,7 +288,7 @@ Preventing Cross-Site Request Forgery Attacks
 `Cross-site request forgery
 <http://en.wikipedia.org/wiki/Cross-site_request_forgery>`_ attacks are a
 phenomenon whereby a user with an identity on your website might click on a
-URL or button on another website which unwittingly redirects the user to your
+URL or button on another website which secretly redirects the user to your
 application to perform some command that requires elevated privileges.
 
 You can avoid most of these attacks by making sure that the correct *CSRF


### PR DESCRIPTION
Old sentence was grammatically incorrect, literally meant that the URL or button in question did not realize it was redirecting the user.  It is the user who does not know!  So how about replacing "unwittingly" with "secretly".   "Surreptitiously" would be another accurate alternative but it's a bit long.

An alternative sentence construction that maintains the word "unwittingly" would be, e.g., "...might click on a URL or button on another website and be unwittingly redirected to your application to perform some command that requires elevated privileges."
