### PR TITLE
"IAuthorizationPolicy" -> "AuthorizationPolicy" in example custom auth

### DIFF
--- a/docs/narr/security.rst
+++ b/docs/narr/security.rst
@@ -631,7 +631,7 @@ following interface:
 .. code-block:: python
     :linenos:
 
-    class IAuthorizationPolicy(object):
+    class AuthorizationPolicy(object):
         """ An object representing a Pyramid authorization policy. """
         def permits(self, context, principals, permission):
             """ Return ``True`` if any of the ``principals`` is allowed the


### PR DESCRIPTION
"IAuthorizationPolicy" -> "AuthorizationPolicy".  The example custom authentication policy did not have an 'I' before its name, so having one for the example custom authorization policy appears to be more typo than meaningful.
