### PR TITLE
Possible fix for view_config() referencing old registry

### DIFF
--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -384,6 +384,24 @@ class TestViewConfigDecorator(unittest.TestCase):
         self.assertEqual(renderer.package, pyramid.tests)
         self.assertEqual(renderer.registry.__class__, DummyRegistry)
 
+    def test_venusian_call_updates_renderer(self):
+        import pyramid.tests
+        decorator = self._makeOne(renderer='fixtures/minimal.test')
+        venusian = DummyVenusian()
+        decorator.venusian = venusian
+        def foo(): pass
+        wrapped = decorator(foo)
+        self.assertTrue(wrapped is foo)
+        settings = call_venusian(venusian)
+        self.assertEqual(len(settings), 1)
+        renderer = settings[0]['renderer']
+        registry1 = renderer.registry
+        settings = call_venusian(venusian)
+        self.assertEqual(len(settings), 1)
+        renderer = settings[0]['renderer']
+        registry2 = renderer.registry     
+        self.assertNotEqual(registry1, registry2)
+
     def test_call_with_renderer_dict(self):
         decorator = self._makeOne(renderer={'a':1})
         venusian = DummyVenusian()

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -205,6 +205,12 @@ class view_config(object):
                 renderer = RendererHelper(name=renderer,
                                           package=info.module,
                                           registry=context.config.registry)
+            else:
+                if renderer is not None and hasattr(renderer, "name"):
+                    renderer = RendererHelper(name=renderer.name,
+                                              package=info.module,
+                                              registry=context.config.registry)
+
             settings['renderer'] = renderer
             context.config.add_view(view=ob, **settings)
 


### PR DESCRIPTION
view_config decorators are called only once for an entire test suite execution.
After tearDown() is called once, further calls to config.scan() fail to update
the registry of the associated renderer of a view, which causes test cases to
fail.

This patch contains a test case to highlight the problem, and a proposed fix.

I have first observed the problem when trying to register some classes during integration testing, and using them for views registered via the view_config() decorator. The first test would pass, and the rest of the tests would fail.

I tracked the problem down to Renderer not picking up my registered renderers after testing.tearDown() is called. Eventually, view_config() turned out to be the cause.

I could have made a more targeted fix that would check config.registry and renderer.registry, and reallocate if they are different, but I chose to re-allocate a renderer every time config.scan() is called.
