### PR TITLE
add compatibility with ipython 0.11

### DIFF
--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -200,7 +200,7 @@ class PShellCommand(PCommand):
                 except ImportError: #pragma no cover
                     from IPython.Shell import IPShellEmbed
                     IPShell = IPShellEmbed(argv=[], user_ns=env)
-                    IPShell.IP.BANNER = IPShell.IP.BANNER + '\n\n' + help
+                    IPShell.set_banner(IPShell.IP.BANNER + '\n' + help)
             except ImportError: #pragma no cover
                 IPShell = None
 


### PR DESCRIPTION
try to use 0.11 and 0.10 api to open embedded ipython shell
