### PR TITLE
View authorization and predicate mismatch exceptions have prettier (simpler) messages

### DIFF
--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -180,7 +180,7 @@ class ViewDeriver(object):
                 if result:
                     return view(context, request)
                 msg = getattr(request, 'authdebug_message',
-                              'Unauthorized: %s failed permission check' % view)
+                              'Unauthorized: %s failed permission check' % view.__name__)
                 raise HTTPForbidden(msg, result=result)
             _secured_view.__call_permissive__ = view
             _secured_view.__permitted__ = _permitted
@@ -231,7 +231,7 @@ class ViewDeriver(object):
             if all((predicate(context, request) for predicate in predicates)):
                 return view(context, request)
             raise PredicateMismatch(
-                'predicate mismatch for view %s' % view)
+                'predicate mismatch for view %s' % view.__name__)
         def checker(context, request):
             return all((predicate(context, request) for predicate in
                         predicates))


### PR DESCRIPTION
Exception message for authorization failures and predicates look like:
- Unauthorized: function_name failed permission check
- predicate mismatch for view function_name

rather than:
- Unauthorized: <function function_name at 0x9359064> failed permission check
- predicate mismatch for view <function function_name at 0x9359064>

Since both of these exceptions inherit from httpexceptions.HTTPClientError, we should be able to use a custom handler to return the exception's message field without it A) looking scary and B) revealing server internals
