### PR TITLE
Accept unicode token instances with ascii content

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -729,7 +729,7 @@ class AuthTktCookieHelper(object):
         for token in tokens:
             if isinstance(token, text_type):
                 try:
-                    token.encode('ascii')
+                    token = token.encode('ascii')
                 except UnicodeEncodeError:
                     raise ValueError("Invalid token %r" % (token,))
             if not (isinstance(token, str) and VALID_TOKEN.match(token)):

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -616,6 +616,7 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         now = time.time()
         helper.auth_tkt.timestamp = now
         helper.now = now + 1
+        helper.auth_tkt.tokens = (u'a', )
         request = self._makeRequest('bogus')
         result = helper.identify(request)
         self.assertTrue(result)
@@ -906,6 +907,12 @@ class TestAuthTktCookieHelper(unittest.TestCase):
 
         self.assertEqual(result[2][0], 'Set-Cookie')
         self.assertTrue("'tokens': ('foo', 'bar')" in result[2][1])
+
+    def test_remember_unicode_but_ascii_token(self):
+        helper = self._makeOne('secret')
+        request = self._makeRequest()
+        la = text_(b'foo', 'utf-8')
+        helper.remember(request, 'other', tokens=(la,))
 
     def test_remember_nonascii_token(self):
         helper = self._makeOne('secret')


### PR DESCRIPTION
This is required when reissueing cookies which include a token: WebOb returns the tokens from a cookie as unicode instances, so remember() must be able to deal with them when refreshing.
