### PR TITLE
Accept unicode token instances with ascii content (1.2 branch)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,13 @@ Dependencies
 - Pyramid now depends on a ``zope.interface`` version greater than or equal
   to 3.8.0.
 
+Bug Fixes
+---------
+
+- Update auth_tkt authentication policy to accept unicode tokens as long as
+  they only contain ASCII content. See
+  https://github.com/Pylons/pyramid/issues/293.
+
 1.2 (2011-09-12)
 ================
 

--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -725,6 +725,11 @@ class AuthTktCookieHelper(object):
             user_data = 'userid_type:%s' % encoding
         
         for token in tokens:
+            if isinstance(token, unicode):
+                try:
+                    token = token.encode('ascii')
+                except UnicodeEncodeError:
+                    pass
             if not (isinstance(token, str) and VALID_TOKEN.match(token)):
                 raise ValueError("Invalid token %r" % (token,))
 

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -666,6 +666,7 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         helper = self._makeOne('secret', timeout=10, reissue_time=0)
         now = time.time()
         helper.auth_tkt.timestamp = now
+        helper.auth_tkt.tokens = (u'foo',)
         helper.now = now + 1
         request = self._makeRequest('bogus')
         result = helper.identify(request)
@@ -899,11 +900,16 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         self.assertEqual(result[2][0], 'Set-Cookie')
         self.assertTrue("'tokens': ('foo', 'bar')" in result[2][1])
 
-    def test_remember_non_string_token(self):
+    def test_remember_token_unicode_with_ascii_data(self):
+        helper = self._makeOne('secret')
+        request = self._makeRequest()
+        helper.remember(request, 'other', tokens=(u'foo',))
+
+    def test_remember_token_full_on_unicode(self):
         helper = self._makeOne('secret')
         request = self._makeRequest()
         self.assertRaises(ValueError, helper.remember, request, 'other',
-                          tokens=(u'foo',))
+                          tokens=(u'f\u1234',))
 
     def test_remember_invalid_token_format(self):
         helper = self._makeOne('secret')


### PR DESCRIPTION
This is required when reissueing cookies which include a token: WebOb returns the tokens from a cookie as unicode instances, so remember() must be able to deal with them when refreshing.

This is a backport of dd5a91eb937369d06f3fc438c817e046fc81f891 to the 1.2 branch.
