### PR TITLE
fix "test_directories_list" in test_mako_templating.py for when tests are run with "python ./setup.py test"

### DIFF
--- a/pyramid/tests/test_mako_templating.py
+++ b/pyramid/tests/test_mako_templating.py
@@ -75,6 +75,10 @@ class Test_renderer_factory(Base, unittest.TestCase):
         self._callFUT(info)
         lookup = self.config.registry.getUtility(IMakoLookup)
         module_path = os.path.dirname(sys.modules['__main__'].__file__)
+        # if tests are run with "python ./setup test" as opposite to the "python
+        # setup.py test" the dirname for the file will be ".". so fix it up.
+        if module_path == '.':
+            module_path = ''
         self.assertEqual(lookup.directories, [
             os.path.join(module_path, 'a'),
             os.path.join(module_path, 'b')])


### PR DESCRIPTION
 fix "test_directories_list" in test_mako_templating.py which prepended "." when tests are run with "python ./setup.py test"  vs "python setup.py test" (note the "./")

This fixes the following traceback:
# 
## FAIL: test_directories_list (pyramid.tests.test_mako_templating.Test_renderer_factory)

Traceback (most recent call last):
  File "/home/user/code/pyramid/pyramid/tests/test_mako_templating.py", line 84, in test_directories_list
    os.path.join(module_path, 'b')])
AssertionError: Lists differ: ['a', 'b'] != ['./a', './b']

First differing element 0:
a
./a
- ['a', 'b']
- ['./a', './b']
  ?   ++     ++
