### PR TITLE
make sphinx compile strictly by turning all warnings into errors and fix up existing warnings (1.1-branch)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
-import sys, os
+import sys
+import os
 import datetime
 import inspect
 import warnings
@@ -389,7 +390,7 @@ def frontmatter(name, arguments, options, content, lineno,
 % reset page counter
 \setcounter{page}{1}
 % suppress first toc pagenum
-\addtocontents{toc}{\protect\thispagestyle{empty}} 
+\addtocontents{toc}{\protect\thispagestyle{empty}}
 """,
         format='latex')]
 
@@ -402,7 +403,7 @@ def mainmatter(name, arguments, options, content, lineno,
 % allow part/chapter/section numbering
 \setcounter{secnumdepth}{2}
 % get headers back
-\pagestyle{fancy} 
+\pagestyle{fancy}
 \fancyhf{}
 \renewcommand{\headrulewidth}{0.5pt}
 \renewcommand{\footrulewidth}{0pt}
@@ -488,7 +489,10 @@ epub_uid = 'The Pyramid Web Application Development Framework, Version 1.1'
 #epub_post_files = []
 
 # A list of files that should not be packed into the epub file.
-#epub_exclude_files = []
+epub_exclude_files = ['_static/opensearch.xml', '_static/doctools.js',
+    '_static/jquery.js', '_static/searchtools.js', '_static/underscore.js',
+    '_static/basic.css', 'search.html']
+
 
 # The depth of the table of contents in toc.ncx.
 epub_tocdepth = 3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -202,3 +202,12 @@ Index and Glossary
 * :ref:`glossary`
 * :ref:`genindex`
 * :ref:`search`
+
+.. add glossary, foreword, and latexindex in a hidden toc to avoid warnings
+
+.. toctree::
+   :hidden:
+
+   glossary
+   foreword.rst
+   latexindex.rst


### PR DESCRIPTION
make sphinx compile strictly by turning all warnings into errors and fix up existing warnings
