### PR TITLE
match_param missing from view_config decorator

### DIFF
--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -276,13 +276,14 @@ class TestViewConfigDecorator(unittest.TestCase):
     def test_create_nondefaults(self):
         decorator = self._makeOne(name=None, request_type=None, for_=None,
                                   permission='foo', mapper='mapper',
-                                  decorator='decorator')
+                                  decorator='decorator', match_param='match_param')
         self.assertEqual(decorator.name, None)
         self.assertEqual(decorator.request_type, None)
         self.assertEqual(decorator.context, None)
         self.assertEqual(decorator.permission, 'foo')
         self.assertEqual(decorator.mapper, 'mapper')
         self.assertEqual(decorator.decorator, 'decorator')
+        self.assertEqual(decorator.match_param, 'match_param')
         
     def test_call_function(self):
         decorator = self._makeOne()

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -175,7 +175,7 @@ class view_config(object):
                  containment=None, attr=None, renderer=None, wrapper=None,
                  xhr=False, accept=None, header=None, path_info=None,
                  custom_predicates=(), context=None, decorator=None,
-                 mapper=None, http_cache=None):
+                 mapper=None, http_cache=None, match_param=None):
         self.name = name
         self.request_type = request_type
         self.context = context or for_
@@ -195,6 +195,7 @@ class view_config(object):
         self.decorator = decorator
         self.mapper = mapper
         self.http_cache = http_cache
+        self.match_param = match_param
 
     def __call__(self, wrapped):
         settings = self.__dict__.copy()


### PR DESCRIPTION
I was excited to try out the new to 1.2 match_param option for view configuration but I noticed it doesn't work with the view_config decorator. I've fixed that bug (and updated the view_config tests to test match_param)
