### PR TITLE
Convert unicode tokens to 'str'

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -726,7 +726,8 @@ class AuthTktCookieHelper(object):
             encoding, encoder = encoding_data
             userid = encoder(userid)
             user_data = 'userid_type:%s' % encoding
-        
+
+        new_tokens = []
         for token in tokens:
             if isinstance(token, text_type):
                 try:
@@ -735,6 +736,8 @@ class AuthTktCookieHelper(object):
                     raise ValueError("Invalid token %r" % (token,))
             if not (isinstance(token, str) and VALID_TOKEN.match(token)):
                 raise ValueError("Invalid token %r" % (token,))
+            new_tokens.append(token)
+        tokens = tuple(new_tokens)
 
         if hasattr(request, '_authtkt_reissued'):
             request._authtkt_reissue_revoked = True

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -703,7 +703,7 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         request.callbacks[0](None, response)
         self.assertEqual(len(response.headerlist), 3)
         self.assertEqual(response.headerlist[0][0], 'Set-Cookie')
-        self.assertTrue("'tokens': []" in response.headerlist[0][1])
+        self.assertTrue("'tokens': ()" in response.headerlist[0][1])
 
     def test_remember(self):
         helper = self._makeOne('secret')
@@ -912,7 +912,9 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         helper = self._makeOne('secret')
         request = self._makeRequest()
         la = text_(b'foo', 'utf-8')
-        helper.remember(request, 'other', tokens=(la,))
+        result = helper.remember(request, 'other', tokens=(la,))
+        # tokens must be str type on both Python 2 and 3
+        self.assertTrue("'tokens': ('foo',)" in result[0][1])
 
     def test_remember_nonascii_token(self):
         helper = self._makeOne('secret')


### PR DESCRIPTION
This was resulting in unicode cookie values (and thus headers) on
Python 2 causing mod_wsgi to complain:
        TypeError: expected string object for header value

PEP 3333 also says:
  "Native" strings (which are always implemented using the type named
  str) that are used for request/response headers and metadata

So mod_wsgi is right to complain about unicode headers and Pyramid is
wrong to send them.
