### PR TITLE
Handle MIME content-encoding.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -148,3 +148,5 @@ Contributors
 - Shane Hathaway, 2011/07/22
 
 - Manuel Hermann, 2011/07/11
+
+- Klee Dienes, 2011/10/30

--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -43,10 +43,11 @@ class _FileResponse(Response):
     def __init__(self, path, cache_max_age):
         super(_FileResponse, self).__init__(conditional_response=True)
         self.last_modified = getmtime(path)
-        content_type = mimetypes.guess_type(path, strict=False)[0]
+        content_type, content_encoding = mimetypes.guess_type(path, strict=False)
         if content_type is None:
             content_type = 'application/octet-stream'
         self.content_type = content_type
+        self.content_encoding = content_encoding
         content_length = getsize(path)
         self.app_iter = _FileIter(open(path, 'rb'), content_length)
         # assignment of content_length must come after assignment of app_iter


### PR DESCRIPTION
This allows Pyramid to properly handle gzip-encoded files such as .svgz .svg.gz, and others.

It doesn't do anything except use the result provided by mimetypes.guess_type ().
