### PR TITLE
DummySession: Correctly implement ISession by generating CSRF token if it

### DIFF
--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -620,7 +620,11 @@ class DummySession(dict):
         return token
 
     def get_csrf_token(self):
-        return self.get('_csrft_', None)
+        token = self.get('_csrft_', None)
+        if token is None:
+            token = self.new_csrf_token()
+        return token
+
         
 @implementer(IRequest)
 class DummyRequest(DeprecatedRequestMethodsMixin, URLMethodsMixin,

--- a/pyramid/tests/test_testing.py
+++ b/pyramid/tests/test_testing.py
@@ -894,6 +894,11 @@ class TestDummySession(unittest.TestCase):
         self.assertEqual(token, 'token')
         self.assertTrue('_csrft_' in session)
 
+    def test_get_csrf_token_generates_token(self):
+        session = self._makeOne()
+        token = session.get_csrf_token()
+        self.assertNotEqual(token, None)
+        self.assertTrue(len(token) >= 1)
 
 from zope.interface import Interface
 from zope.interface import implementer


### PR DESCRIPTION
DummySession: Correctly implement ISession by generating CSRF token if it's missing

applies cleanly to the 1.2 branch as well
