### PR TITLE
Pcreate abspath

### DIFF
--- a/pyramid/tests/test_scripts/test_pcreate.py
+++ b/pyramid/tests/test_scripts/test_pcreate.py
@@ -87,6 +87,22 @@ class TestPCreateCommand(unittest.TestCase):
             scaffold.vars,
             {'project': 'Distro', 'egg': 'Distro', 'package': 'distro'})
 
+    def test_known_scaffold_absolute_path(self):
+        import os
+        path = os.path.abspath('Distro')
+        cmd = self._makeOne('-s', 'dummy', path)
+        scaffold = DummyScaffold('dummy')
+        cmd.scaffolds = [scaffold]
+        result = cmd.run()
+        self.assertEqual(result, True)
+        self.assertEqual(
+            scaffold.output_dir,
+            os.path.normpath(os.path.join(os.getcwd(), 'Distro'))
+            )
+        self.assertEqual(
+            scaffold.vars,
+            {'project': 'Distro', 'egg': 'Distro', 'package': 'distro'})
+
     def test_known_scaffold_multiple_rendered(self):
         import os
         cmd = self._makeOne('-s', 'dummy1', '-s', 'dummy2', 'Distro')


### PR DESCRIPTION
Added a regression test (let's pretend that I just forgot to check it in earlier? Heheh... ¬_¬) that checks that pcreate works when called with absolute paths.
