### PR TITLE
Create a test to demonstrate that pcreate works with absolute paths.

### DIFF
--- a/pyramid/tests/test_scripts/test_pcreate.py
+++ b/pyramid/tests/test_scripts/test_pcreate.py
@@ -71,6 +71,22 @@ class TestPCreateCommand(unittest.TestCase):
             scaffold.vars,
             {'project': 'Distro', 'egg': 'Distro', 'package': 'distro'})
 
+    def test_known_scaffold_absolute_path(self):
+        import os
+        path = os.path.abspath('Distro')
+        cmd = self._makeOne('-s', 'dummy', path)
+        scaffold = DummyScaffold('dummy')
+        cmd.scaffolds = [scaffold]
+        result = cmd.run()
+        self.assertEqual(result, True)
+        self.assertEqual(
+            scaffold.output_dir,
+            os.path.normpath(os.path.join(os.getcwd(), 'Distro'))
+            )
+        self.assertEqual(
+            scaffold.vars,
+            {'project': 'Distro', 'egg': 'Distro', 'package': 'distro'})
+
     def test_known_scaffold_multiple_rendered(self):
         import os
         cmd = self._makeOne('-s', 'dummy1', '-s', 'dummy2', 'Distro')


### PR DESCRIPTION
Please pretend that I merely forgot to check this in earlier, rather than forgetting to write it. Test checks for a regression on the problem fixed by commit eb6298ca370ee5fcf390e85769f928a85f7060e8
