### PR TITLE
1.2 branch add bpython support to pshell

### DIFF
--- a/docs/narr/commandline.rst
+++ b/docs/narr/commandline.rst
@@ -269,37 +269,23 @@ exposed, and the request is configured to generate urls from the host
 
 .. index::
    single: IPython
+   single: bpython
 
-IPython
-~~~~~~~
+IPython or bpython
+~~~~~~~~~~~~~~~~~~
 
-If you have `IPython <http://en.wikipedia.org/wiki/IPython>`_ installed in
-the interpreter you use to invoke the ``paster`` command, the ``pshell``
-command will use an IPython interactive shell instead of a standard Python
-interpreter shell.  If you don't want this to happen, even if you have
-IPython installed, you can pass the ``--disable-ipython`` flag to the
-``pshell`` command to use a standard Python interpreter shell
-unconditionally.
-
-.. code-block:: text
-
-   [chrism@vitaminf shellenv]$ ../bin/paster pshell --disable-ipython \
-                                development.ini#MyProject
-
-
-bpython
-~~~~~~~
-
-If you have `bpython <http://bpython-interpreter.org/>`_ installed in
-the interpreter you use to invoke the ``pshell`` command, ``pshell`` will use
-a bpython interactive shell instead of a standard Python if you pass the ``-b`` 
-or ``--enable-bpython`` flag to the ``pshell`` command.
+If you have `IPython <http://en.wikipedia.org/wiki/IPython>`_ or  
+`bpython <http://bpython-interpreter.org/>`_ or both installed in
+the interpreter you use to invoke the ``pshell`` command, ``pshell`` will 
+autodiscover them and use the first respectively found in this order :
+IPython, bpython, standard Python interpreter. However you could 
+specifically invoke one of your choice with the ``-p choice`` or  
+``--python-shell choice`` option.
 
 .. code-block:: text
 
-   [chrism@vitaminf shellenv]$ ../bin/paster pshell --enable-bpython \
+   [chrism@vitaminf shellenv]$ ../bin/pshell -p ipython | bpython | python \
                                 development.ini#MyProject
-
 
 
 .. index::

--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -127,14 +127,9 @@ class PShellCommand(PCommand):
     max_args = 1
 
     parser = Command.standard_parser(simulate=True)
-    parser.add_option('-d', '--disable-ipython',
-                      action='store_true',
-                      dest='disable_ipython',
-                      help="Don't use IPython even if it is available")
-    parser.add_option('-b', '--enable-bpython',
-                      action='store_true',
-                      dest='enable_bpython',
-                      help="Use bpython as pshell")
+    parser.add_option('-p', '--python-shell',
+                      action='store', type='string', dest='python_shell',
+                      default = '', help='ipython | bpython | python')
     parser.add_option('--setup',
                       dest='setup',
                       help=("A callable that will be passed the environment "
@@ -226,13 +221,22 @@ class PShellCommand(PCommand):
             for var in sorted(self.object_help.keys()):
                 help += '\n  %-12s %s' % (var, self.object_help[var])
 
-        if shell is None and self.options.enable_bpython:
-            shell = self.make_bpython_shell()
+        user_shell = self.options.python_shell.lower()
+        if not user_shell:
+            if shell is None:
+                shell = self.make_ipython_v0_11_shell()
+                if shell is None:
+                    shell = self.make_ipython_v0_10_shell()
+                if shell is None:
+                    shell = self.make_bpython_shell()
 
-        if shell is None and not self.options.disable_ipython:
+        if shell is None and user_shell == 'ipython':
             shell = self.make_ipython_v0_11_shell()
             if shell is None:
                 shell = self.make_ipython_v0_10_shell()
+
+        if shell is None and user_shell == 'bpython':
+            shell = self.make_bpython_shell()
 
         if shell is None:
             shell = self.make_default_shell()


### PR DESCRIPTION
bpython is a good candidate for interactive interpreter for thus who don't master IPython and want syntax coloration, and help tooltip in the interpreter. 

follow raydeo remarks and design :

If you have IPython or bpython or both installed in the interpreter you use to invoke the pshell command, pshell will autodiscover them and use the first respectively found in this order : IPython, bpython, standard Python interpreter. However you could specifically invoke one of your choice with the -p choice or --python-shell choice option.

::

 bin/pshell -p Ipython | bpython | python  MyProject/development.ini
 or 
 bin/pshell --python-shell  Ipython | bpython | python MyProject/development.ini

tests and docs updated with this support.
Enjoy
