### PR TITLE
Support adding WSGI applications as views during configuration

### DIFF
--- a/pyramid/tests/test_wsgi.py
+++ b/pyramid/tests/test_wsgi.py
@@ -12,6 +12,14 @@ class WSGIAppTests(unittest.TestCase):
         response = decorator(context, request)
         self.assertEqual(response, dummyapp)
 
+    def test_decorator_object_instance(self):
+        context = DummyContext()
+        request = DummyRequest()
+        app = DummyApp()
+        decorator = self._callFUT(app)
+        response = decorator(context, request)
+        self.assertEqual(response, app)
+
 class WSGIApp2Tests(unittest.TestCase):
     def _callFUT(self, app):
         from pyramid.wsgi import wsgiapp2
@@ -84,8 +92,24 @@ class WSGIApp2Tests(unittest.TestCase):
         self.assertEqual(request.environ['PATH_INFO'], '/')
         self.assertEqual(request.environ['SCRIPT_NAME'], '')
 
+    def test_decorator_on_callable_object_instance(self):
+        context = DummyContext()
+        request = DummyRequest()
+        request.subpath = ()
+        request.environ = {'SCRIPT_NAME':'/foo', 'PATH_INFO':'/'}
+        app = DummyApp()
+        decorator = self._callFUT(app)
+        response = decorator(context, request)
+        self.assertEqual(response, app)
+        self.assertEqual(request.environ['PATH_INFO'], '/')
+        self.assertEqual(request.environ['SCRIPT_NAME'], '/foo')
+
 def dummyapp(environ, start_response):
     """ """
+
+class DummyApp(object):
+    def __call__(self, environ, start_response):
+        """ """
 
 class DummyContext:
     pass

--- a/pyramid/wsgi.py
+++ b/pyramid/wsgi.py
@@ -31,7 +31,11 @@ def wsgiapp(wrapped):
     """
     def decorator(context, request):
         return request.get_response(wrapped)
-    return wraps(wrapped)(decorator)
+
+    # Support case where wrapped is a callable object instance
+    if getattr(wrapped, '__name__', None):
+        return wraps(wrapped)(decorator)
+    return wraps(wrapped, ('__module__', '__doc__'))(decorator)
 
 def wsgiapp2(wrapped):
     """ Decorator to turn a WSGI application into a :app:`Pyramid`
@@ -67,4 +71,8 @@ def wsgiapp2(wrapped):
 
     def decorator(context, request):
         return call_app_with_subpath_as_path_info(request, wrapped)
-    return wraps(wrapped)(decorator)
+
+    # Support case where wrapped is a callable object instance
+    if getattr(wrapped, '__name__', None):
+        return wraps(wrapped)(decorator)
+    return wraps(wrapped, ('__module__', '__doc__'))(decorator)


### PR DESCRIPTION
Support passing callable object instances as WSGI applications to the
`pyramid.wsgi.wsgiapp` and `pyramid.wsgi.wsgiapp2` decorators.

This allows us to configure pyramid like so:

```
config.add_view(pyramid.wsgi.wsgiapp2(MyWSGIApp(settings)))
```
