### PR TITLE
Fix typo in log message

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -74,7 +74,7 @@ class CallbackAuthenticationPolicy(object):
         userid = self.unauthenticated_userid(request)
         if userid is None:
             debug and self._log(
-                'authenticated_userid returned %r; returning %r' % (
+                'unauthenticated_userid returned %r; returning %r' % (
                     userid, effective_principals),
                 'effective_principals',
                 request

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -83,7 +83,7 @@ class TestCallbackAuthenticationPolicyDebugging(unittest.TestCase):
         self.assertEqual(
             self.messages[0],
             "pyramid.tests.test_authentication.MyAuthenticationPolicy."
-            "effective_principals: authenticated_userid returned None; "
+            "effective_principals: unauthenticated_userid returned None; "
             "returning ['system.Everyone']")
 
     def test_effective_principals_no_callback(self):


### PR DESCRIPTION
authenticated_userid -> unauthenticated_userid
