### PR TITLE
@@ view names don't work with *traverse

### DIFF
--- a/pyramid/traversal.py
+++ b/pyramid/traversal.py
@@ -622,7 +622,7 @@ class ResourceTreeTraverser(object):
             path = matchdict.get('traverse', '/') or '/'
             if is_nonstr_iter(path):
                 # this is a *traverse stararg (not a {traverse})
-                path = '/'.join([quote_path_segment(x) for x in path]) or '/'
+                path = '/'.join([x for x in path]) or '/'
 
             subpath = matchdict.get('subpath', ())
             if not is_nonstr_iter(subpath):


### PR DESCRIPTION
This commit fixes #382.

I've removed quote_path_segment, the other option was to replace vpath_tuple = traversal_path_info(vpath) with vpath_tuple = traversal_path(vpath) (line 663) but this would result in the path being quoted and then unquoted by traversal_path without being used in the interim, which seems wasteful.
