### PR TITLE
Fix bar*fizzle type of url dispatch

### DIFF
--- a/pyramid/tests/test_urldispatch.py
+++ b/pyramid/tests/test_urldispatch.py
@@ -269,6 +269,8 @@ class TestCompileRoute(unittest.TestCase):
         self.assertEqual(matcher('/foo/baz/biz/buz/bar/everything/else/here'),
                          {'baz':'baz', 'buz':'buz',
                           'traverse':('everything', 'else', 'here')})
+        self.assertEqual(matcher('/foo/baz/biz/buz/bareverything/else/here'),
+                         None)
         self.assertEqual(matcher('foo/baz/biz/buz/bar'), None)
         self.assertEqual(generator(
             {'baz':1, 'buz':2, 'traverse':'/a/b'}), '/foo/1/biz/2/bar/a/b')
@@ -365,6 +367,9 @@ class TestCompileRouteFunctional(unittest.TestCase):
         self.matches('zzz/{x}*traverse', '/zzz/abc', {'x':'abc', 'traverse':()})
         self.matches('zzz/{x}*traverse', '/zzz/abc/def/g',
                      {'x':'abc', 'traverse':('def', 'g')})
+        self.matches('zzz/abc*traverse', '/zzz/abc', {'traverse':()})
+        self.matches('zzz/abc*traverse', '/zzz/abc/def/g',
+                     {'traverse':('def', 'g')})
         self.matches('*traverse', '/zzz/abc', {'traverse':('zzz', 'abc')})
         self.matches('*traverse', '/zzz/ abc', {'traverse':('zzz', ' abc')})
         #'/La%20Pe%C3%B1a'

--- a/pyramid/urldispatch.py
+++ b/pyramid/urldispatch.py
@@ -118,6 +118,7 @@ def _compile_route(route):
     rpat.append(re.escape(prefix))
     gen.append(prefix)
 
+    s = None
     while pat:
         name = pat.pop()
         name = name[1:-1]
@@ -134,7 +135,10 @@ def _compile_route(route):
             gen.append(s)
 
     if star:
-        rpat.append('(?P<%s>.*?)' % star)
+        if route.endswith('/') or not s:
+            rpat.append('(?P<%s>.*?)' % star)
+        else:
+            rpat.append('(?P<%s>(?:\/.*?)?)' % star)
         gen.append('%%(%s)s' % star)
 
     pattern = ''.join(rpat) + '$'


### PR DESCRIPTION
/bar*fizzle match /barabc and /bar/abc and fizzle = ['abc'] but generate /bar/abc
Fix to match only /bar/abc
