### PR TITLE
remove dependencies related to python 2.5 in alchemy scaffold

### DIFF
--- a/pyramid/scaffolds/alchemy/setup.py_tmpl
+++ b/pyramid/scaffolds/alchemy/setup.py_tmpl
@@ -16,9 +16,6 @@ requires = [
     'zope.sqlalchemy',
     ]
 
-if sys.version_info[:3] < (2,5,0):
-    requires.append('pysqlite')
-
 setup(name='{{project}}',
       version='0.0',
       description='{{project}}',


### PR DESCRIPTION
now that Pyramid requires python >= 2.6, these 2.5 dependencies are useless
