### PR TITLE
Fix bug with registration of identical views with same 'accept'.

### DIFF
--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -514,7 +514,7 @@ class MultiView(object):
         else:
             subset = self.media_views.setdefault(accept, [])
             for i, (s, v, h) in enumerate(list(subset)):
-                if phash == h and order == s:
+                if phash == h:
                     subset[i] = (order, view, phash)
                     return
             else:


### PR DESCRIPTION
In Kotti I register two views for HTTPForbidden:

```
config.add_view(
    forbidden_redirect,
    context=HTTPForbidden,
    accept='text/html',
    )

config.add_view(
    forbidden_view,
    context=HTTPForbidden,
    )
```

With this configuration, and due to the bug, it's not possible to override the first registration (the one with the accept).  The following call will work (given `autocommit=True` or similar) but will fail to override the existing view; the result is that both views are registered in the `MultiView` but the first is _sometimes_ preferred (both will have the same 'order'):

```
config.add_view(
    another_forbidden_view,
    context=HTTPForbidden,
    accept='text/html',
    )
```

Note: the fix looks very similar to the overwriting a couple lines above.  However, I've added the check for `order == s`, since tests (`TestMultiView.test_add`) expect views with same 'accept' but different 'order' to live alongside each other.

```
    if phash == h and order == s:
        subset[i] = (order, view, phash)
        return
```
