### PR TITLE
Enhancement: Route-Prefixing re Issue #406

### DIFF
--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -71,7 +71,7 @@ from pyramid.config.tweens import TweensConfiguratorMixin
 from pyramid.config.util import (
     action_method,
     ActionInfo,
-    route_pattern_list,
+    route_pattern,
     )
 from pyramid.config.views import ViewsConfiguratorMixin
 from pyramid.config.zca import ZCAConfiguratorMixin
@@ -692,23 +692,21 @@ class Configurator(
         The ``route_prefix`` parameter is new as of Pyramid 1.2.
 
         When the ``route_prefix`` parameter is provided to the outer-most
-        ``include`` it has a special configurative property. If
-        ``route_prefix`` ends with a ``/`` then the route will end with a
-        ``/``. If the ``route_prefix`` does not end with a ``/`` then the
-        route created will also not end with a ``/``. In this way
-        implementers may mount existing callables or third-party modules
-        with a slash-appended-style that matches the rest of their
-        application.
+        ``include`` it has a special configurative property. If ``route_prefix``
+        ends with a ``/`` then the route will end with a ``/``. If the
+        ``route_prefix`` does not end with a ``/`` then the route created will
+        also not end with a ``/``. In this way implementers may mount existing
+        callables or third-party modules with a slash-appended-style that
+        matches the rest of their application.
 
         The above configurative behaviour of ``route_prefix`` is new as of
         Pyramid 1.X.
 
-        The ``route_suffix`` parameter complements ``route_prefix``,
-        allowing a suffix to be appended to included routes. However
-        ``route_suffix`` does not have the same configurative property as
-        ``route_prefix``, since ``route_prefix`` ultimately decides whether
-        the mounted routes (including the suffix) will be slash-appended or
-        not.
+        The ``route_suffix`` parameter complements ``route_prefix``, allowing a
+        suffix to be appended to included routes. However ``route_suffix`` does
+        not have the same configurative property as ``route_prefix``, since
+        ``route_prefix`` ultimately decides whether the mounted routes
+        (including the suffix) will be slash-appended or not.
 
         The ``route_suffix`` parameter is new as of Pyramid 1.X.
 
@@ -718,11 +716,11 @@ class Configurator(
         action_state = self.action_state
 
         if not route_prefix is None:
-            route_prefix = route_pattern_list(
+            route_prefix = route_pattern(
                 (self.route_prefix or []) + [route_prefix]
                 )
         if not route_suffix is None:
-            route_suffix = route_pattern_list(
+            route_suffix = route_pattern(
                 [route_suffix] + (self.route_suffix or [])
                 )
 

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -15,7 +15,7 @@ from pyramid.config.util import (
     action_method,
     make_predicates,
     as_sorted_tuple,
-    route_pattern_list,
+    route_pattern,
     )
 
 class RoutesConfiguratorMixin(object):
@@ -369,17 +369,13 @@ class RoutesConfiguratorMixin(object):
         if pattern is None:
             raise ConfigurationError('"pattern" argument may not be None')
 
-        route_prefix = self.route_prefix or []
-        route_suffix = self.route_suffix or []
+        pattern = route_pattern(
+            (self.route_prefix or []) + [pattern] + (self.route_suffix or [])
+            )
+        if self.route_prefix:
+            pattern.match_slash_style = True
 
-        pattern = route_pattern_list(route_prefix + [pattern] + route_suffix)
         pattern = str(pattern)
-
-        if len(route_prefix):
-            if route_prefix[0].endswith('/'):
-                pattern = pattern.rstrip('/') + '/'
-            else:
-                pattern = pattern.rstrip('/')
 
         mapper = self.get_routes_mapper()
 

--- a/pyramid/config/util.py
+++ b/pyramid/config/util.py
@@ -291,13 +291,27 @@ def as_sorted_tuple(val):
     val = tuple(sorted(val))
     return val
 
-class route_pattern_list(list):
-    """ Utility: extends Python ``list`` to simplify operations with
-    route-patterns. """
+class route_pattern(list):
+    """ Utility: centralise route-pattern operations.
+
+    If ``match_slash_style`` is ``True`` then the slash-style of the first-item
+    determines the slash-style of the route-pattern; if the first-item is
+    slash-appended then the route-pattern will be slash-appended, otherwise the
+    route-pattern will be non-slash-appended. """
+
+    def __init__(self, *args):
+        super(route_pattern, self).__init__(*args)
+        self.match_slash_style = False
 
     def __str__(self):
-        l = ''
+        l = None
         for r in self:
+            if l is not None and self.match_slash_style:
+                r = r.rstrip('/')
+                if l.endswith('/'):
+                    r = '%s/' % r
+            if l is None:
+                l = ''
             if l and r:
                 l = '%s/%s' % (l.rstrip('/'), r.lstrip('/'))
             else:


### PR DESCRIPTION
https://github.com/Pylons/pyramid/issues/406

> route_prefix doesn't allow the prefix pattern to match without a
> trailing slash

Suggested solution:
- Create a `route_pattern` class (extending `list`) to centralise route joining operations, principally providing a `__str__` method.
- Implement @mmerickel's `route_prefix` configurative behaviour via `route_pattern.match_slash_style` bool attribute, where left-most item influences the route-pattern slash-style (slash-appended or non-slash-appended).
- Provide (optional) `route_suffix` as the logical compliment to `route_prefix`, but having no configurative behaviour; `route_prefix` affects the route-pattern _after_ the addition of any suffixes. Route-suffixes are added outward with the outer-most `include`'s route-suffix added last.
