### PR TITLE
Fix to starter scaffold template to use request.static_url for resources

### DIFF
--- a/pyramid/scaffolds/starter/+package+/templates/mytemplate.pt_tmpl
+++ b/pyramid/scaffolds/starter/+package+/templates/mytemplate.pt_tmpl
@@ -5,19 +5,19 @@
   <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
   <meta name="keywords" content="python web application" />
   <meta name="description" content="pyramid web application" />
-  <link rel="shortcut icon" href="/static/favicon.ico" />
-  <link rel="stylesheet" href="/static/pylons.css" type="text/css" media="screen" charset="utf-8" />
+  <link rel="shortcut icon" href="${request.static_url('{{package}}:static/favicon.ico')}" />
+  <link rel="stylesheet" href="${request.static_url('{{package}}:static/pylons.css')}" type="text/css" media="screen" charset="utf-8" />
   <link rel="stylesheet" href="http://static.pylonsproject.org/fonts/nobile/stylesheet.css" media="screen" />
   <link rel="stylesheet" href="http://static.pylonsproject.org/fonts/neuton/stylesheet.css" media="screen" />
   <!--[if lte IE 6]>
-  <link rel="stylesheet" href="/static/ie6.css" type="text/css" media="screen" charset="utf-8" />
+  <link rel="stylesheet" href="${request.static_url('{{package}}:static/ie6.css')}" type="text/css" media="screen" charset="utf-8" />
   <![endif]-->
 </head>
 <body>
   <div id="wrap">
     <div id="top">
       <div class="top align-center">
-        <div><img src="/static/pyramid.png" width="750" height="169" alt="pyramid"/></div>
+          <div><img src="${request.static_url('{{package}}:static/pyramid.png')}" width="750" height="169" alt="pyramid"/></div>
       </div>
     </div>
     <div id="middle">


### PR DESCRIPTION
The starter template used hard-coded static url paths such as `/static/favicon.ico`. This did not work if the application was installed to a path that was not the document root. Any changes that altered the document path in the application's `config.add_static_view(name=...)` had no effect on the starter template. 
