### PR TITLE
Try to stop a daemonized process by sending SIGINT before SIGTERM

### DIFF
--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -14,6 +14,7 @@ import logging
 import optparse
 import os
 import re
+import signal
 import subprocess
 import sys
 import textwrap
@@ -450,7 +451,11 @@ class PServeCommand(object):
         for j in range(10):
             if not live_pidfile(pid_file):
                 break
-            import signal
+            os.kill(pid, signal.SIGINT)
+            time.sleep(1)
+        for j in range(10):
+            if not live_pidfile(pid_file):
+                break
             os.kill(pid, signal.SIGTERM)
             time.sleep(1)
         else:


### PR DESCRIPTION
Currently sending SIGTERM as first choice means the daemonized process doesn't have chance to shut down properly. In the case of Python processes, this specifically means that any functions registered using the atexit module of the standard library will not be called. This patch attempts SIGINT first, then tries to send SIGTERM if SIGINT has failed for 10 seconds.

This is particularly problematic in the specific case of Chameleon which uses atexit hooks to remove temporary directories created to contain compiled templates.

TL;DR: atexit isn't currently supported for processes daemonized by pastescript; it should be.

See also: https://bitbucket.org/ianb/pastescript/pull-request/2/try-to-stop-a-daemonized-process-by & http://awesomeco.de/blog/pastescript-deform-chameleon-and-a-whole-load-of-temporary-files/
