### PR TITLE
Fix favicon_view example: open the file in binary mode.

### DIFF
--- a/docs/narr/assets.rst
+++ b/docs/narr/assets.rst
@@ -374,7 +374,7 @@ do so, do things "by hand".  First define the view callable.
 
    def favicon_view(request):
        here = os.path.dirname(__file__)
-       icon = open(os.path.join(here, 'static', 'favicon.ico'))
+       icon = open(os.path.join(here, 'static', 'favicon.ico'), 'rb')
        return Response(content_type='image/x-icon', app_iter=icon)
 
 The above bit of code within ``favicon_view`` computes "here", which is a


### PR DESCRIPTION
Without this fix Python 3 users might get Unicode errors, and Windows
users might get data corruption.

The app_iter one line down is not right either: it splits binary image data into chunks terminated by newlines.  I'm not fixing it right now, given yesterday's IRC conversation where mcdonc objected to `body=icon.read()` on people-will-copy-paste-it-without-understanding principles.
