### PR TITLE
Add wildcard domain for parent domain in auth ticket cookie

### DIFF
--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -814,6 +814,17 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         self.assertTrue(result[1][1].endswith('; Path=/; Domain=localhost'))
         self.assertTrue(result[1][1].startswith('auth_tkt='))
 
+    def test_remember_sibling_domains_enabled(self):
+        helper = self._makeOne('secret', sibling_domains=True)
+        environ = {'wsgi.version': (1,0)}
+        environ['REMOTE_ADDR'] = '1.1.1.1'
+        environ['SERVER_NAME'] = 'subdomain.localhost.localdomain'
+        request = DummyRequest(environ, cookie=None)
+        result = helper.remember(request, 'other')
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result[3][0], 'Set-Cookie')
+        self.assertIn('Domain=.localhost.localdomain', result[3][1])
+    
     def test_remember_domain_has_port(self):
         helper = self._makeOne('secret', wild_domain=False)
         request = self._makeRequest()


### PR DESCRIPTION
Adds a boolean option to AuthTicketCookieHelper called sibling_domains that will add an extra cookie that sets the wildcard on the domain above the current domain.

Eg if the current domain is x.foo.com this will set a cookie on .foo.com

If the current domain is not a subdomain it will not have any affect as wild_domain would provide the same functionality.

To note: this is in compliance with the RFC ( http://www.ietf.org/rfc/rfc2109.txt section 4.3.2 ) 
