### PR TITLE
Key and value are inverted in the assertion error message in "DummyTemplateRenderer.assert_()"

### DIFF
--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -515,7 +515,7 @@ class DummyTemplateRenderer(object):
             if myval != v:
                 raise AssertionError(
                     '\nasserted value for %s: %r\nactual value: %r' % (
-                    v, k, myval))
+                    k, v, myval))
         return True
 
 class DummyResource:


### PR DESCRIPTION
Currently, when using a dummy template renderer (`pyramid.testing.DummTemplateRenderer`), one gets the following assertion error message (when using the `assert_()` method):

```
AssertionError: 
asserted value for 1: 'var'
actual value: 2
```

The key and its value are inverted. With the patch, we get the correct assertion error message:

```
AssertionError: 
asserted value for var: 1
actual value: 2
```
