### PR TITLE
To make the dummy csrf token have the same length as a real one.

### DIFF
--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -632,7 +632,7 @@ class DummySession(dict):
         return storage
 
     def new_csrf_token(self):
-        token = 'csrft'
+        token = '0123456789012345678901234567890123456789'
         self['_csrft_'] = token
         return token
 


### PR DESCRIPTION
It's not bug. The reason I do that is that I met a issue when I use the csrf token as an initial vector for AES encryption. It didn't pass my unit-test because the length of a csrf token of a dummy request is not long enough.
