### PR TITLE
Added links to 'Starting the Application'

### DIFF
--- a/docs/tutorials/wiki/definingmodels.rst
+++ b/docs/tutorials/wiki/definingmodels.rst
@@ -88,7 +88,8 @@ View the Application in a Browser
 
 We can't.  At this point, our system is in a "non-runnable" state; we'll need
 to change view-related files in the next chapter to be able to start the
-application successfully.  If you try to start the application, you'll wind
+application successfully.  If you try to start the application (See
+:ref:`wiki-start-the-application`), you'll wind
 up with a Python traceback on your console that ends with this exception:
 
 .. code-block:: text

--- a/docs/tutorials/wiki/definingviews.rst
+++ b/docs/tutorials/wiki/definingviews.rst
@@ -301,8 +301,8 @@ subdirectories) and are just referred to by URL.
 Viewing the Application in a Browser
 ====================================
 
-We can finally examine our application in a
-browser.  The views we'll try are as follows:
+We can finally examine our application in a browser (See
+:ref:`wiki-start-the-application`).  The views we'll try are as follows:
 
 - Visiting ``http://localhost:6543/`` in a browser invokes the ``view_wiki``
   view.  This always redirects to the ``view_page`` view of the ``FrontPage``

--- a/docs/tutorials/wiki/installation.rst
+++ b/docs/tutorials/wiki/installation.rst
@@ -228,6 +228,8 @@ Looks like the code in the ``zodb`` scaffold for ZODB projects is
 missing some test coverage, particularly in the file named
 ``models.py``.
 
+.. _wiki-start-the-application:
+
 Start the Application
 =====================
 

--- a/docs/tutorials/wiki2/definingmodels.rst
+++ b/docs/tutorials/wiki2/definingmodels.rst
@@ -122,7 +122,8 @@ Viewing the Application in a Browser
 
 We can't.  At this point, our system is in a "non-runnable" state; we'll need
 to change view-related files in the next chapter to be able to start the
-application successfully.  If you try to start the application, you'll wind
+application successfully.  If you try to start the application (See
+:ref:`wiki2-start-the-application`), you'll wind
 up with a Python traceback on your console that ends with this exception:
 
 .. code-block:: text

--- a/docs/tutorials/wiki2/definingviews.rst
+++ b/docs/tutorials/wiki2/definingviews.rst
@@ -323,7 +323,8 @@ something like so:
 Viewing the Application in a Browser
 ====================================
 
-We can finally examine our application in a browser.  The views we'll try are
+We can finally examine our application in a browser (See
+:ref:`wiki2-start-the-application`).  The views we'll try are
 as follows:
 
 - Visiting ``http://localhost:6543`` in a browser invokes the

--- a/docs/tutorials/wiki2/installation.rst
+++ b/docs/tutorials/wiki2/installation.rst
@@ -215,6 +215,8 @@ If successful, you will see output something like this::
 
 Looks like our package doesn't quite have 100% test coverage.
 
+.. _wiki2-start-the-application:
+
 Starting the Application
 ========================
 


### PR DESCRIPTION
This was suggested by @czpython on his review of the SQL wiki tutorial, to make it easier for a newcomer to go back to the right section in a previous chapter.  @audreyr liked it, too,

Regards,
Patricio 
