### PR TITLE
Clarified instructions in wiki2 tutorial

### DIFF
--- a/docs/tutorials/wiki2/basiclayout.rst
+++ b/docs/tutorials/wiki2/basiclayout.rst
@@ -16,8 +16,10 @@ Application Configuration with ``__init__.py``
 A directory on disk can be turned into a Python :term:`package` by containing
 an ``__init__.py`` file.  Even if empty, this marks a directory as a Python
 package.  We use ``__init__.py`` both as a marker indicating the directory
-it's contained within is a package, and to contain configuration code.  Our
-``__init__.py`` file will look like this:
+it's contained within is a package, and to contain configuration code.
+
+Open the ``tutorial/tutorial/__init__.py`` file.  It should already contain
+the following:
 
    .. literalinclude:: src/basiclayout/tutorial/__init__.py
       :linenos:

--- a/docs/tutorials/wiki2/definingmodels.rst
+++ b/docs/tutorials/wiki2/definingmodels.rst
@@ -21,11 +21,15 @@ Making Edits to ``models.py``
   (or they may live in a Python subpackage of your application package named
   ``models``) , but this is only by convention.
 
-Here's what our ``models.py`` file should look like after this step:
+Open ``tutorial/tutorial/models.py`` file and edit it to look like the 
+following:
 
 .. literalinclude:: src/models/tutorial/models.py
    :linenos:
    :language: py
+   :emphasize-lines: 19-21,24,26,28
+
+(The highlighted lines are the ones that need to be changed.)
 
 The first thing we've done is to do is remove the stock ``MyModel`` class
 from the generated ``models.py`` file.  The ``MyModel`` class is only a


### PR DESCRIPTION
It wasn't clear that the user has to open **init**.py to see the specified code sample, and to open/edit models.py to look like the specified code sample.  

I've made this clarification.  @michr came over and reviewed this.
