### PR TITLE
Suggestion : giving at least the name the command to use as an indication

### DIFF
--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -908,7 +908,7 @@ is restarted.
 Using the Interactive Shell
 ---------------------------
 
-It is possible to use a Python interpreter prompt loaded with a similar
+It is possible to use the ``pshell`` command to load a Python interpreter prompt with a similar
 configuration as would be loaded if you were running your Pyramid application
 via ``pserve``.  This can be a useful debugging tool.  See
 :ref:`interactive_shell` for more details.


### PR DESCRIPTION
Even if this information it's not enough, when you read the doc via pdf that give you which command to use without having to jump of section. I find it better for the learning flow of the reader than jumping around.
