### PR TITLE
Fixed the README.txt_tmpl to have the correct command to initialize the database in alchemy scaffold

### DIFF
--- a/pyramid/scaffolds/alchemy/README.txt_tmpl
+++ b/pyramid/scaffolds/alchemy/README.txt_tmpl
@@ -8,7 +8,7 @@ Getting Started
 
 - $venv/bin/python setup.py develop
 
-- $venv/bin/populate_{{project}} development.ini
+- $venv/bin/initialize_{{project}}_db development.ini
 
 - $venv/bin/pserve development.ini
 


### PR DESCRIPTION
The README.txt file created as a part of alchemy scaffold, mentions that the command to initialize the database is populate_<project name>, but the actual command is initialize_<project name>_db as per the documentation (http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/tutorials/wiki2/installation.html#initializing-the-database). So I have made the corresponding changes in the README.txt_tmpl and request the changes to be pulled into pyramid.

There is an issue for this - #521
