### PR TITLE
pyramid scaffolding collides with jinja2 templating

### DIFF
--- a/pyramid/scaffolds/template.py
+++ b/pyramid/scaffolds/template.py
@@ -35,7 +35,8 @@ class Template(object):
         content = native_(content, fsenc)
         try:
             return bytes_(
-                substitute_double_braces(content, TypeMapper(vars)), fsenc)
+                substitute_escaped_double_braces(
+                    substitute_double_braces(content, TypeMapper(vars))), fsenc)
         except Exception as e:
             _add_except(e, ' in file %s' % filename)
             raise
@@ -149,6 +150,14 @@ def substitute_double_braces(content, values):
         return values[value]
     return double_brace_pattern.sub(double_bracerepl, content)
     
+escaped_double_brace_pattern = re.compile(r'\\{\\{(?P<escape_braced>.*?)\\}\\}')
+
+def substitute_escaped_double_braces(content):
+    def escaped_double_bracerepl(match):
+        value = match.group('escape_braced').strip()
+        return "{{%(value)s}}" % locals()
+    return escaped_double_brace_pattern.sub(escaped_double_bracerepl, content)
+ 
 def _add_except(exc, info): # pragma: no cover
     if not hasattr(exc, 'args') or exc.args is None:
         return


### PR DESCRIPTION
When Pyramid scaffolding finds files with the suffix _templ, it inspects the file for variables such as {{project}}, {{package}}, and {{package_logger}} and replaces them. However, when using Jinja2 templates, this collides with standard variable replacement, and the outcome is that pcreate dies.

To solve this problem, I've added a function `substitute_escaped_double_braces` that takes values the following string: `"\{\{ mystring \}\}"` and exports `"{{ mystring }}"`. This is handy because it allows a developer to use other templating languages without generating collisions.
