### PR TITLE
Change the example script's description string to match the console_script's name: show_settings

### DIFF
--- a/docs/narr/commandline.rst
+++ b/docs/narr/commandline.rst
@@ -718,7 +718,7 @@ we'll pretend you have a distribution with a package in it named
    def settings_show():
        description = """\
        Print the deployment settings for a Pyramid application.  Example:
-       'psettings deployment.ini'
+       'show_settings deployment.ini'
        """
        usage = "usage: %prog config_uri"
        parser = optparse.OptionParser(


### PR DESCRIPTION
'psettings' is not mentioned elsewhere on this page.
