### PR TITLE
Made static_view raise HTTP exceptions instead of return

### DIFF
--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -108,7 +108,7 @@ class static_view(object):
             resource_path ='%s/%s' % (self.docroot.rstrip('/'), path)
             if resource_isdir(self.package_name, resource_path):
                 if not request.path_url.endswith('/'):
-                    return self.add_slash_redirect(request)
+                    self.add_slash_redirect(request)
                 resource_path = '%s/%s' % (resource_path.rstrip('/'),self.index)
             if not resource_exists(self.package_name, resource_path):
                 raise HTTPNotFound(request.url)
@@ -120,7 +120,7 @@ class static_view(object):
             filepath = normcase(normpath(join(self.norm_docroot, path)))
             if isdir(filepath):
                 if not request.path_url.endswith('/'):
-                    return self.add_slash_redirect(request)
+                    self.add_slash_redirect(request)
                 filepath = join(filepath, self.index)
             if not exists(filepath):
                 raise HTTPNotFound(request.url)
@@ -132,7 +132,7 @@ class static_view(object):
         qs = request.query_string
         if qs:
             url = url + '?' + qs
-        return HTTPMovedPermanently(url)
+        raise HTTPMovedPermanently(url)
 
 _seps = set(['/', os.sep])
 def _contains_slash(item):

--- a/pyramid/tests/test_static.py
+++ b/pyramid/tests/test_static.py
@@ -38,11 +38,17 @@ class Test_static_view_use_subpath_False(unittest.TestCase):
         inst = self._makeOne('pyramid.tests:fixtures/static')
         request = self._makeRequest({'PATH_INFO':''})
         context = DummyContext()
-        response = inst(context, request)
-        response.prepare(request.environ)
-        self.assertEqual(response.status, '301 Moved Permanently')
-        self.assertTrue(b'http://example.com:6543/' in response.body)
-        
+        from pyramid.httpexceptions import HTTPMovedPermanently
+        try:
+            response = inst(context, request)
+        except HTTPMovedPermanently as e:
+            self.assertEqual(e.code, 301)
+            self.assertTrue(b'http://example.com:6543/' in e.location)
+        else:
+            response.prepare(request.environ)
+            self.assertEqual(response.status, '301 Moved Permanently')
+            self.assertTrue(b'http://example.com:6543/' in response.body)
+
     def test_path_info_slash_means_index_html(self):
         inst = self._makeOne('pyramid.tests:fixtures/static')
         request = self._makeRequest()
@@ -258,11 +264,17 @@ class Test_static_view_use_subpath_True(unittest.TestCase):
         request = self._makeRequest({'PATH_INFO':''})
         request.subpath = ()
         context = DummyContext()
-        response = inst(context, request)
-        response.prepare(request.environ)
-        self.assertEqual(response.status, '301 Moved Permanently')
-        self.assertTrue(b'http://example.com:6543/' in response.body)
-        
+        from pyramid.httpexceptions import HTTPMovedPermanently
+        try:
+            response = inst(context, request)
+        except HTTPMovedPermanently as e:
+            self.assertEqual(e.code, 301)
+            self.assertTrue(b'http://example.com:6543/' in e.location)
+        else:
+            response.prepare(request.environ)
+            self.assertEqual(response.status, '301 Moved Permanently')
+            self.assertTrue(b'http://example.com:6543/' in response.body)
+
     def test_path_info_slash_means_index_html(self):
         inst = self._makeOne('pyramid.tests:fixtures/static')
         request = self._makeRequest()


### PR DESCRIPTION
Referencing issue #586. Please note that `HTTPMovedPermanently` is likewise being raised, which may or may not be useful.
