### PR TITLE
Bug fix for config/i18n.py translator() using unsafe call get_current_request()

### DIFF
--- a/pyramid/config/i18n.py
+++ b/pyramid/config/i18n.py
@@ -119,8 +119,14 @@ class I18NConfiguratorMixin(object):
 
         self.action(None, register, introspectables=introspectables)
 
-def translator(msg):
-    request = get_current_request()
+def translator(msg, context = None):
+    request = None
+    if context:
+        try:
+            request = context['request']
+        except Exception:
+            pass
+    if not request:
+        request = get_current_request()
     localizer = get_localizer(request)
     return localizer.translate(msg)
-


### PR DESCRIPTION
This fix assumes translationstring and chameleon will forward the context to translator() so that 'request' can be obtained from context instead of get_current_request() which is not thread safe when it is used with green threads like gevent. Pull request for translationstring and chameleon are being made so that the context with be passed in to translate().
