### PR TITLE
1.3 branch

### DIFF
--- a/pyramid/compat.py
+++ b/pyramid/compat.py
@@ -219,7 +219,10 @@ except ImportError: # pragma: no cover
 
 # "json" is not an API; it's here to support older pyramid_debugtoolbar
 # versions which attempt to import it
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
     
 if PY3: # pragma: no cover

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -1,4 +1,7 @@
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 import os
 import pkg_resources
 import threading

--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -1,4 +1,7 @@
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 from zope.deprecation import deprecate
 from zope.deprecation.deprecation import deprecated

--- a/pyramid/tests/test_request.py
+++ b/pyramid/tests/test_request.py
@@ -258,7 +258,10 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(request.json_body, {'a':1})
 
     def test_json_body_alternate_charset(self):
-        import json
+        try:
+            import simplejson as json
+        except ImportError:
+            import json
         request = self._makeOne({'REQUEST_METHOD':'POST'})
         inp = text_(
             b'/\xe6\xb5\x81\xe8\xa1\x8c\xe8\xb6\x8b\xe5\x8a\xbf',


### PR DESCRIPTION
As the 1.3 branch will not be able to switch the JSON serializer, at least provide the oportunity to take advantage of newer simplejson versions for an added speed.
