### PR TITLE
Replacement markers of url dispatcher can contain regex with colons.

### DIFF
--- a/pyramid/tests/test_urldispatch.py
+++ b/pyramid/tests/test_urldispatch.py
@@ -311,6 +311,14 @@ class TestCompileRoute(unittest.TestCase):
         self.assertEqual(matcher('foo/baz/biz/buz/bar'), None)
         self.assertEqual(generator({'baz':1, 'buz':2, 'bar': 'html'}),
                          '/foo/1/biz/2.html')
+    
+    def test_custom_regex_with_colons(self):
+        matcher, generator = self._callFUT('foo/{baz}/biz/{buz:(?:[^/\.]+)}.{bar}')
+        self.assertEqual(matcher('/foo/baz/biz/buz.bar'),
+                         {'baz':'baz', 'buz':'buz', 'bar':'bar'})
+        self.assertEqual(matcher('foo/baz/biz/buz/bar'), None)
+        self.assertEqual(generator({'baz':1, 'buz':2, 'bar': 'html'}),
+                         '/foo/1/biz/2.html')
 
     def test_mixed_newstyle_oldstyle_pattern_defaults_to_newstyle(self):
         # pattern: '\\/foo\\/(?P<baz>abc)\\/biz\\/(?P<buz>[^/]+)\\/bar$'

--- a/pyramid/urldispatch.py
+++ b/pyramid/urldispatch.py
@@ -148,7 +148,9 @@ def _compile_route(route):
         name = pat.pop() # unicode
         name = name[1:-1]
         if ':' in name:
-            name, reg = name.split(':')
+            # reg may contain colons as well,
+            # so we must strictly split name into two parts
+            name, reg = name.split(':', 1)
         else:
             reg = '[^/]+'
         gen.append('%%(%s)s' % native_(name)) # native


### PR DESCRIPTION
Fix for [#629](https://github.com/Pylons/pyramid/issues/629)
