### PR TITLE
Adding helpful link to installing chapter from firstapp

### DIFF
--- a/docs/narr/firstapp.rst
+++ b/docs/narr/firstapp.rst
@@ -8,7 +8,8 @@ Creating Your First :app:`Pyramid` Application
 
 In this chapter, we will walk through the creation of a tiny :app:`Pyramid`
 application.  After we're finished creating the application, we'll explain in
-more detail how it works.
+more detail how it works. It assumes you already have :app:`Pyramid` installed.
+If you do not, head over to the :ref:`installing_chapter` section.
 
 .. _helloworld_imperative:
 


### PR DESCRIPTION
Will allow us to link directly to firstapp from places like pylonsproject/pyramid Getting Started section and have a nice easy link to installation.
