### PR TITLE
Request.json_body decorated with reify to parse request's body only once

### DIFF
--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -376,7 +376,7 @@ class Request(BaseRequest, DeprecatedRequestMethodsMixin, URLMethodsMixin,
             return False
         return adapted is ob
 
-    @property
+    @reify
     def json_body(self):
         return json.loads(text_(self.body, self.charset))
 


### PR DESCRIPTION
It is a really small change for a really little optimization which permits to avoid `json.loads` on request's body being called multiple times.
