### PR TITLE
CSRF token not being converted to unicode properly.

### DIFF
--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -87,7 +87,7 @@ def UnencryptedCookieSessionFactoryConfig(
     cookie_max_age=None,
     cookie_path='/',
     cookie_domain=None,
-    cookie_secure=False, 
+    cookie_secure=False,
     cookie_httponly=False,
     cookie_on_exception=True,
     signed_serialize=signed_serialize,
@@ -246,7 +246,7 @@ def UnencryptedCookieSessionFactoryConfig(
         # CSRF API methods
         @manage_accessed
         def new_csrf_token(self):
-            token = text_(binascii.hexlify(os.urandom(20)))
+            token = binascii.hexlify(os.urandom(20)).decode('ascii')
             self['_csrft_'] = token
             return token
 


### PR DESCRIPTION
On Python 3.3:

```
>>> my_bytestring = b'Nobody expects this conversion to work'
>>> str(my_bytestring)
"b'Nobody expects this conversion to work'"
```

Instead of the above, one must call .decode('ascii').

All tests pass, on Python 2.7 and 3.3b2.
