### PR TITLE
Handle the case where an empty range is requested

### DIFF
--- a/pyramid/response.py
+++ b/pyramid/response.py
@@ -92,7 +92,10 @@ class FileIter(object):
         return self
 
     def next(self):
-        val = self.file.read(self.block_size)
+        val = ''
+        if self.block_size > 0:
+            # If the client requests an empty or malformed range
+            val = self.file.read(self.block_size)
         if not val:
             raise StopIteration
         return val


### PR DESCRIPTION
If a client makes a request to a static resource with a range header (for example) of 400-400 (valid HTTP), this iterator will fail at this point. It is better to check the block size here, as we would still want to raise other errors at this point.
