### PR TITLE
Filenames like app:foo-bar.mako should be valid.

### DIFF
--- a/pyramid/mako_templating.py
+++ b/pyramid/mako_templating.py
@@ -91,7 +91,7 @@ class MakoRendererFactoryHelper(object):
 
     def __call__(self, info):
         p = re.compile(
-                r'(?P<asset>[\w_.:/]+)'
+                r'(?P<asset>[\w_.:/-]+)'
                 r'(?:\#(?P<defname>[\w_]+))?'
                 r'(\.(?P<ext>.*))'
                 )

--- a/pyramid/tests/test_mako_templating.py
+++ b/pyramid/tests/test_mako_templating.py
@@ -31,6 +31,20 @@ class Test_renderer_factory(Base, unittest.TestCase):
         from pyramid.mako_templating import IMakoLookup
         return self.config.registry.getUtility(IMakoLookup, name=name)
 
+    def test_hyphen_filenames(self):
+        from pyramid.mako_templating import renderer_factory
+
+        info = DummyRendererInfo({
+            'name':'app:moon-and-world.mak',
+            'package':None,
+            'registry':self.config.registry,
+            'settings':{},
+            'type': ''
+        })
+
+        result = renderer_factory(info)
+        self.assertEqual(result.path, 'app:moon-and-world.mak')
+
     def test_no_directories(self):
         info = DummyRendererInfo({
             'name':'pyramid.tests:fixtures/helloworld.mak',


### PR DESCRIPTION
Right now if you want to use hyphens in your filenames they wouldn't be allowed.
