### PR TITLE
Get rid of monkeypatch of Request and Response in pyramid.__init__

### DIFF
--- a/pyramid/__init__.py
+++ b/pyramid/__init__.py
@@ -1,5 +1,0 @@
-from pyramid.request import Request
-from pyramid.response import Response
-Response.RequestClass = Request
-Request.ResponseClass = Response
-del Request, Response

--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -9,6 +9,7 @@ from webob import BaseRequest
 
 from pyramid.interfaces import (
     IRequest,
+    IRequestFactory,
     IResponse,
     ISessionFactory,
     IResponseFactory,
@@ -27,6 +28,12 @@ from pyramid.decorator import reify
 from pyramid.response import Response
 from pyramid.url import URLMethodsMixin
 from pyramid.util import InstancePropertyMixin
+
+
+@implementer(IRequestFactory)
+def default_request_factory(environ):
+	return Request(environ, ResponseClass=Response)
+
 
 class TemplateContext(object):
     pass

--- a/pyramid/router.py
+++ b/pyramid/router.py
@@ -25,7 +25,8 @@ from pyramid.events import (
     )
 
 from pyramid.httpexceptions import HTTPNotFound
-from pyramid.request import Request
+from pyramid.request import default_request_factory
+from pyramid.response import Response
 from pyramid.threadlocal import manager
 
 from pyramid.traversal import (
@@ -48,7 +49,7 @@ class Router(object):
         self.logger = q(IDebugLogger)
         self.root_factory = q(IRootFactory, default=DefaultRootFactory)
         self.routes_mapper = q(IRoutesMapper)
-        self.request_factory = q(IRequestFactory, default=Request)
+        self.request_factory = q(IRequestFactory, default=default_request_factory)
         self.request_extensions = q(IRequestExtensions)
         tweens = q(ITweens)
         if tweens is None:


### PR DESCRIPTION
Added `request.default_request_factory()`, which is now used as the default
request factory in the `Router` constructor instead of using the `Request`
class directly as the default request factory.

Fixes #702
