### PR TITLE
Fix typo and markup in docs/whatsnew-1.4.rst

### DIFF
--- a/docs/whatsnew-1.4.rst
+++ b/docs/whatsnew-1.4.rst
@@ -63,7 +63,7 @@ Partial Mako and Chameleon Template Renderings
   of rendering the entire template.  An example asset spec:
   ``package:path/to/template#macroname.pt``.  This will render the macro
   defined as ``macroname`` within the ``template.pt`` template instead of the
-  entire templae.
+  entire template.
 
 Subrequest Support
 ~~~~~~~~~~~~~~~~~~
@@ -78,7 +78,7 @@ Minor Feature Additions
 -----------------------
 
 - :meth:`pyramid.config.Configurator.add_directive` now accepts arbitrary
-  callables like partials or objects implementing ``__call__`` which dont
+  callables like partials or objects implementing ``__call__`` which don't
   have ``__name__`` and ``__doc__`` attributes.  See
   https://github.com/Pylons/pyramid/issues/621 and
   https://github.com/Pylons/pyramid/pull/647.
@@ -112,7 +112,7 @@ Minor Feature Additions
 - An :meth:`pyramid.config.Configurator.add_permission` directive method was
   added to the Configurator.  This directive registers a free-standing
   permission introspectable into the Pyramid introspection system.
-  Frameworks built atop Pyramid can thus use the the ``permissions``
+  Frameworks built atop Pyramid can thus use the ``permissions``
   introspectable category data to build a comprehensive list of permissions
   supported by a running system.  Before this method was added, permissions
   were already registered in this introspectable category as a side effect of
@@ -172,7 +172,7 @@ Backwards Incompatibilities
   ``bfg.routes.matchdict`` to the request's WSGI environment dictionary.
   These values were docs-deprecated in ``repoze.bfg`` 1.0 (effectively seven
   minor releases ago).  If your code depended on these values, use
-  request.matched_route and request.matchdict instead.
+  ``request.matched_route`` and ``request.matchdict`` instead.
 
 - It is no longer possible to pass an environ dictionary directly to
   ``pyramid.traversal.ResourceTreeTraverser.__call__`` (aka
@@ -223,7 +223,7 @@ Backwards Incompatibilities
   * ``registerEventListener``, use
     :meth:`pyramid.config.Configurator.testing_add_subscriber` instead.
 
-  * ``registerTemplateRenderer`` (aka `registerDummyRenderer``), use
+  * ``registerTemplateRenderer`` (aka ``registerDummyRenderer``), use
     :meth:`pyramid.config.Configurator.testing_add_template` instead.
 
   * ``registerView``, use :meth:`pyramid.config.Configurator.add_view` instead.


### PR DESCRIPTION
templae -> template
dont -> don't
the the -> the

request.matched_route and request.matchdict: quote with double backticks
`registerDummyRenderer``: add missing backtick
