### PR TITLE
Improve include mechanism with not None route_prefix

### DIFF
--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -382,7 +382,9 @@ class RoutesConfiguratorMixin(object):
             raise ConfigurationError('"pattern" argument may not be None')
 
         if self.route_prefix:
-            pattern = self.route_prefix.rstrip('/') + '/' + pattern.lstrip('/')
+            if pattern != '':
+                pattern = '/' + pattern.lstrip('/') 
+            pattern = self.route_prefix.rstrip('/') + pattern
 
         mapper = self.get_routes_mapper()
 


### PR DESCRIPTION
Let's suppose we have:

``` python
def add_cabinet_routes(config):
    config.add_route('cabinet.index_not_slashed', '')
    config.add_route('cabinet.index_slashed', '/')
    # much more routes

# in main() 
config.include(add_cabinet_routes, prefix_url='/cabinet')
```

Now: we will have 2 equivalent urls: `/cabinet/` and `/cabinet/`
Will be: we will have 2 distinct urls: `/cabinet` and `/cabinet/`

So now we can't add base url without trailing slash with existent `route_prefix`.
