### PR TITLE
Fix for issue #721

### DIFF
--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -230,6 +230,22 @@ class RenderViewToIterableTests(BaseTest, unittest.TestCase):
         iterable = self._callFUT(context, request, name='registered',
                                  secure=False)
         self.assertEqual(iterable, ['anotherview'])
+    def test_verify_output_bytestring(self):
+        from pyramid.request import Request
+        from pyramid.config import Configurator
+        from pyramid.view import render_view
+        from webob.compat import text_type
+        config = Configurator(settings={})
+        def view(request):
+            request.response.text = text_type('<body></body>')
+            return request.response
+
+        config.add_view(name='test', view=view)
+        config.commit()
+
+        r = Request({})
+        r.registry = config.registry
+        self.assertEqual(render_view(object(), r, 'test'), b'<body></body>')
 
     def test_call_request_has_no_registry(self):
         request = self._makeRequest()
@@ -261,7 +277,7 @@ class RenderViewTests(BaseTest, unittest.TestCase):
         view = make_view(response)
         self._registerView(request.registry, view, 'registered')
         s = self._callFUT(context, request, name='registered', secure=True)
-        self.assertEqual(s, '')
+        self.assertEqual(s, b'')
 
     def test_call_view_registered_insecure_no_call_permissive(self):
         context = self._makeContext()
@@ -270,7 +286,7 @@ class RenderViewTests(BaseTest, unittest.TestCase):
         view = make_view(response)
         self._registerView(request.registry, view, 'registered')
         s = self._callFUT(context, request, name='registered', secure=False)
-        self.assertEqual(s, '')
+        self.assertEqual(s, b'')
 
     def test_call_view_registered_insecure_with_call_permissive(self):
         context = self._makeContext()
@@ -282,7 +298,7 @@ class RenderViewTests(BaseTest, unittest.TestCase):
         view.__call_permissive__ = anotherview
         self._registerView(request.registry, view, 'registered')
         s = self._callFUT(context, request, name='registered', secure=False)
-        self.assertEqual(s, 'anotherview')
+        self.assertEqual(s, b'anotherview')
 
 class TestIsResponse(unittest.TestCase):
     def setUp(self):

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -2,6 +2,8 @@ import venusian
 
 from zope.interface import providedBy
 from zope.deprecation import deprecated
+from webob.compat import text_type
+
 
 from pyramid.interfaces import (
     IRoutesMapper,
@@ -136,7 +138,7 @@ def render_view(context, request, name='', secure=True):
     iterable = render_view_to_iterable(context, request, name, secure)
     if iterable is None:
         return None
-    return ''.join(iterable)
+    return b''.join((x.encode('utf-8') if isinstance(x, text_type) else x for x in  iterable))
 
 class view_config(object):
     """ A function, class or method :term:`decorator` which allows a


### PR DESCRIPTION
Commit 6ec5a699bbd24e fixes issue #721 by forcing input to be basestring and returning basestring according PEP-3333. I used python version detection using webob.compat.text_type.

Tested on Python 2.7.3rc2 and Python 3.2.3.

Also I fixed several related tests, so they expect render_view to return basestring.
