### PR TITLE
preliminary fix for refactorings from 4d2602ce

### DIFF
--- a/pyramid/router.py
+++ b/pyramid/router.py
@@ -103,7 +103,7 @@ class Router(object):
                             request.path_info,
                             route.pattern,
                             match,
-                            ', '.join([p.__text__ for p in route.predicates]))
+                            ', '.join([p.text() for p in route.predicates]))
                         )
                     logger and logger.debug(msg)
 

--- a/pyramid/scripts/pviews.py
+++ b/pyramid/scripts/pviews.py
@@ -187,7 +187,7 @@ class PViewsCommand(object):
         self.out("%sroute pattern: %s" % (indent, route.pattern))
         self.out("%sroute path: %s" % (indent, route.path))
         self.out("%ssubpath: %s" % (indent, '/'.join(attrs['subpath'])))
-        predicates = ', '.join([p.__text__ for p in route.predicates])
+        predicates = ', '.join([p.text() for p in route.predicates])
         if predicates != '':
             self.out("%sroute predicates (%s)" % (indent, predicates))
 


### PR DESCRIPTION
with the change from `__text__` to `text()` the code putting together the output used when `debug_routematch` is set was broken.  it still uses `.__text__`.  the same is true for the `pviews` script.  however, simply changing things to use `.text()` breaks `test_views_command_single_view_route_with_route_predicates` and i'm not sure if the function used for a predicate there can be changed into a class, or if function predicates should still be supported...
