### PR TITLE
_depth argument to view_config is now relative to view_config

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,15 @@
+next release
+============
+
+Backwards Incompatibilities
+---------------------------
+
+- Modified the ``_depth`` argument to ``pyramid.view.view_config`` to accept
+  a value relative to the invocation of ``view_config`` itself. Thus, when it
+  was previously expecting a value of ``1`` or greater, to reflect that
+  the caller of ``view_config`` is 1 stack frame away from ``venusian.attach``,
+  this implementation detail is now hidden.
+
 1.4b1 (2012-11-21)
 ==================
 

--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -541,7 +541,7 @@ class TestViewConfigDecorator(unittest.TestCase):
         self.assertEqual(config.pkg, pyramid.tests)
 
     def test_call_withdepth(self):
-        decorator = self._makeOne(_depth=2)
+        decorator = self._makeOne(_depth=1)
         venusian = DummyVenusian()
         decorator.venusian = venusian
         def foo(): pass

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -178,14 +178,16 @@ class view_config(object):
     out, its default will be the equivalent ``add_view`` default.
 
     An additional keyword argument named ``_depth`` is provided for people who
-    wish to reuse this class from another decorator.  It will be passed in to
-    the :term:`venusian` ``attach`` function as the depth of the callstack when
-    Venusian checks if the decorator is being used in a class or module
-    context.  It's not often used, but it can be useful in this circumstance.
-    See the ``attach`` function in Venusian for more information.
+    wish to reuse this class from another decorator.  The default value is
+    ``0`` and should be specified relative to the ``view_config`` invocation.
+    It will be passed in to the :term:`venusian` ``attach`` function as the
+    depth of the callstack when Venusian checks if the decorator is being used
+    in a class or module context.  It's not often used, but it can be useful
+    in this circumstance.  See the ``attach`` function in Venusian for more
+    information.
 
     See :ref:`mapping_views_using_a_decorator_section` for details about
-    using :class:`view_config`.
+    using :class:`pyramid.view.view_config`.
 
     """
     venusian = venusian # for testing injection
@@ -197,14 +199,14 @@ class view_config(object):
 
     def __call__(self, wrapped):
         settings = self.__dict__.copy()
-        depth = settings.pop('_depth', 1)
+        depth = settings.pop('_depth', 0)
 
         def callback(context, name, ob):
             config = context.config.with_package(info.module)
             config.add_view(view=ob, **settings)
 
         info = self.venusian.attach(wrapped, callback, category='pyramid',
-                                    depth=depth)
+                                    depth=depth + 1)
 
         if info.scope == 'class':
             # if the decorator was attached to a method in a class, or


### PR DESCRIPTION
This hides an implementation detail that view_config is at least 1 level away
from user code.
