### PR TITLE
Fixes tests in python 3.2.

### DIFF
--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -4,9 +4,9 @@ from functools import wraps
 
 from zope.interface import (
     Interface,
-    classProvides,
     implementedBy,
     implementer,
+    provider,
     )
 
 from zope.interface.interfaces import IInterface
@@ -376,8 +376,8 @@ class ViewDeriver(object):
         return decorator(view)
 
 @implementer(IViewMapper)
+@provider(IViewMapperFactory)
 class DefaultViewMapper(object):
-    classProvides(IViewMapperFactory)
     def __init__(self, **kw):
         self.attr = kw.get('attr')
 


### PR DESCRIPTION
Previously failed with `TypeError: Class advice impossible in Python3.  Use the @provider class decorator instead.`
