### PR TITLE
Mention ZopeTransactionExtension and pyramid_tm in SQLAlchemy scaffold tutorial

### DIFF
--- a/docs/tutorials/wiki2/installation.rst
+++ b/docs/tutorials/wiki2/installation.rst
@@ -303,6 +303,9 @@ the following assumptions:
 
 - you are willing to use :term:`url dispatch` to map URLs to code.
 
+- you want to use ``ZopeTransactionExtension`` and ``pyramid_tm`` to scope
+  sessions to requests
+
 .. note::
 
    :app:`Pyramid` supports any persistent storage mechanism (e.g. object


### PR DESCRIPTION
If this page is found via web search while trying to configure SQLAlchemy from scratch without a scaffold, it is helpful to mention `pyramid_tm` as a requirement somewhere. Otherwise, a hapless user such as your humble author might spend lots of time wondering why his sessions aren't getting committed after his requests despite his best efforts to properly configure SQLAlchemy and `ZopeTransactionExtension`.

Possible further improvements:
- Dedicated section on configuring SQLAlchemy from scratch
- Add `ZopeTransactionExtension` and `pyramid_tm` to the glossary so they can be made linkable
