### PR TITLE
give virtualenv directory a more generic name

### DIFF
--- a/docs/make_book
+++ b/docs/make_book
@@ -1,4 +1,4 @@
 #!/bin/sh
-make clean latex SPHINXBUILD=../env26/bin/sphinx-build BOOK=1
+make clean latex SPHINXBUILD=../env/bin/sphinx-build BOOK=1
 cd _build/latex && make all-pdf
 

--- a/docs/make_epub
+++ b/docs/make_epub
@@ -1,2 +1,2 @@
 #!/bin/sh
-make clean epub SPHINXBUILD=../env26/bin/sphinx-build
+make clean epub SPHINXBUILD=../env/bin/sphinx-build

--- a/docs/make_pdf
+++ b/docs/make_pdf
@@ -1,4 +1,4 @@
 #!/bin/sh
-make clean latex SPHINXBUILD=../env26/bin/sphinx-build
+make clean latex SPHINXBUILD=../env/bin/sphinx-build
 cd _build/latex && make all-pdf
 


### PR DESCRIPTION
pros:
- Installation instructions uses the same name
- The old name assumes user would be using Python 2.6
