### PR TITLE
Update docs/tutorials/wiki/index.rst

### DIFF
--- a/docs/tutorials/wiki/index.rst
+++ b/docs/tutorials/wiki/index.rst
@@ -10,8 +10,8 @@ tutorial, the developer will have created a basic Wiki application with
 authentication.
 
 For cut and paste purposes, the source code for all stages of this
-tutorial can be browsed at `https://github.com/Pylons/pyramid/tree/1.3-branch/docs/tutorials/wiki/src
-<https://github.com/Pylons/pyramid/tree/1.3-branch/docs/tutorials/wiki/src>`_.
+tutorial can be browsed at `https://github.com/Pylons/pyramid/tree/1.4-branch/docs/tutorials/wiki/src
+<https://github.com/Pylons/pyramid/tree/1.4-branch/docs/tutorials/wiki/src>`_.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
ZODB doc. nit: point to http://github.com/.../1.4-branch/... instead of http://github.com/.../1.3-branch/...

Not sure that's the right thing, maybe there's a reason to keep pointing to 1.3. Maybe also it would be better to point to master? Feel free to reject/change.
