### PR TITLE
Update docs/tutorials/wiki2/authorization.rst

### DIFF
--- a/docs/tutorials/wiki2/authorization.rst
+++ b/docs/tutorials/wiki2/authorization.rst
@@ -37,8 +37,8 @@ Then we will add the login and logout feature:
   (``view.pt``, ``edit.pt``).
 
 The source code for this tutorial stage can be browsed at
-`http://github.com/Pylons/pyramid/tree/1.3-branch/docs/tutorials/wiki2/src/authorization/
-<http://github.com/Pylons/pyramid/tree/1.3-branch/docs/tutorials/wiki2/src/authorization/>`_.
+`http://github.com/Pylons/pyramid/tree/1.4-branch/docs/tutorials/wiki2/src/authorization/
+<http://github.com/Pylons/pyramid/tree/1.4-branch/docs/tutorials/wiki2/src/authorization/>`_.
 
 Access Control
 --------------


### PR DESCRIPTION
SQLAlchemy doc. nit: point to http://github.com/.../1.4-branch/... instead of http://github.com/.../1.3-branch/...

Not sure that's the right thing, maybe there's a reason to keep pointing to 1.3. Maybe also it would be better to point to master? Feel free to reject/change.
