### PR TITLE
Fix #406 route_prefix doesn't allow the prefix pattern to match without a trailing slash

### DIFF
--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -382,7 +382,11 @@ class RoutesConfiguratorMixin(object):
             raise ConfigurationError('"pattern" argument may not be None')
 
         if self.route_prefix:
-            pattern = self.route_prefix.rstrip('/') + '/' + pattern.lstrip('/')
+            pattern = pattern.lstrip('/')
+            if pattern:
+                pattern = self.route_prefix.rstrip('/') + '/' + pattern
+            else:
+                pattern = self.route_prefix.rstrip('/')
 
         mapper = self.get_routes_mapper()
 


### PR DESCRIPTION
Don't need add separator to route_prefix if included route's pattern is empty(or equal to slash)
