### PR TITLE
Document PredicateMismatch for exception contexts

### DIFF
--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -5,6 +5,8 @@
 
 .. automodule:: pyramid.exceptions
 
+  .. autoclass:: PredicateMismatch
+
   .. autoclass:: Forbidden
 
   .. autoclass:: NotFound

--- a/pyramid/exceptions.py
+++ b/pyramid/exceptions.py
@@ -10,11 +10,29 @@ CR = '\n'
 
 class PredicateMismatch(HTTPNotFound):
     """
-    Internal exception (not an API) raised by multiviews when no
-    view matches.  This exception subclasses the ``NotFound``
-    exception only one reason: if it reaches the main exception
-    handler, it should be treated like a ``NotFound`` by any exception
-    view registrations.
+    This exception is raised by multiviews when no view matches
+    all given predicates.
+
+    This exception subclasses the :class:`HTTPNotFound` exception for a
+    specific reason: if it reaches the main exception handler, it should
+    be treated as :class:`HTTPNotFound`` by any exception view
+    registrations. Thus, typically, this exception will not be seen
+    publicly.
+    
+    However, this exception will be raised if the predicates of all
+    views configured to handle another exception context cannot be
+    successfully matched.  For instance, if a view is configured to
+    handle a context of ``HTTPForbidden`` and the configured with
+    additional predicates, then :class:`PredicateMismatch` will be
+    raised if:
+
+    * An original view callable has raised :class:`HTTPForbidden` (thus
+      invoking an exception view); and
+    * The given request fails to match all predicates for said
+      exception view associated with :class:`HTTPForbidden`.
+
+    The same applies to any type of exception being handled by an
+    exception view.
     """
 
 class URLDecodeError(UnicodeDecodeError):


### PR DESCRIPTION
After recently attempting to add custom forbidden views to my application (Pyramid 1.4), I've found myself hitting PredicateMismatch exceptions. The following is a simplified example:

```
@forbidden_view_config([some predicates])
class ForbiddenView(object):
   ...

@view_config(route_name='my_route')
class MyView(object):
    def __call__(self):
        raise HTTPForbidden()
```

If a request comes for MyView, and that request fails to match the predicates specified for the ForbiddenView, a PredicateMismatch exception is raised.  This exception isn't publicly documented, so I was unsure what this meant until I read the source code.  

My suggestion is to document PredicateMismatch when it might occur (eg if predicates don't match for an exception context; eg at line 40 of pyramid/tweens.py when attempting to call an exception view) and what it means when you encounter one.  I've done my best, but my documentation may need clarification.

I also think it would be useful to include a mention to PredicateMismatch somewhere more 'obvious' related to exception handling -- like http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/views.html#custom-exception-views.
