### PR TITLE
simplify and shorten an overlong sentence

### DIFF
--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -821,10 +821,8 @@ class Configurator(
 
     def with_package(self, package):
         """ Return a new Configurator instance with the same registry
-        as this configurator using the package supplied as the
-        ``package`` argument to the new configurator.  ``package`` may
-        be an actual Python package object or a :term:`dotted Python name`
-        representing a package."""
+        as this configurator. ``package`` may be an actual Python package
+        object or a :term:`dotted Python name` representing a package."""
         configurator = self.__class__(
             registry=self.registry,
             package=package,


### PR DESCRIPTION
Also, the removed info should be obvious... it is redundant I think.
