### PR TITLE
make doc building faster

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,10 +147,6 @@ if 'sphinx-build' in ' '.join(sys.argv):  # protect against dumb importers
 
     parent = os.path.dirname(os.path.dirname(__file__))
     sys.path.append(os.path.abspath(parent))
-    wd = os.getcwd()
-    os.chdir(parent)
-    os.system('%s setup.py test -q' % sys.executable)
-    os.chdir(wd)
 
     for item in os.listdir(parent):
         if item.endswith('.egg'):


### PR DESCRIPTION
Each time one runs 'make html', the Pyramid test suite is also ran, which seems needless, and is time-consuming... me wonders why this was so in the first place (see 9974be2f).
