### PR TITLE
use a Sphinx ref instead of raw url

### DIFF
--- a/docs/narr/threadlocals.rst
+++ b/docs/narr/threadlocals.rst
@@ -62,8 +62,7 @@ Because one :app:`Pyramid` application is permitted to call
 (perhaps as a :term:`WSGI` app with help from the
 :func:`pyramid.wsgi.wsgiapp2` decorator), these variables are
 managed in a *stack* during normal system operations.  The stack
-instance itself is a `threading.local
-<http://docs.python.org/library/threading.html#threading.local>`_.
+instance itself is a :class:`threading.local`.
 
 During normal operations, the thread locals stack is managed by a
 :term:`Router` object.  At the beginning of a request, the Router


### PR DESCRIPTION
Other than reducing ugliness, when building the doc with Python 3,
the target is a Python 3 version of the class; same applies to Python 2.
