### PR TITLE
no need to qualify Python interactive sessions

### DIFF
--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -252,25 +252,19 @@ that were added to the flash queue, and empties the queue.
 
 .. method:: pop_flash(queue='')
 
-.. code-block:: python
-   :linenos:
-
-   >>> request.session.flash('info message')
-   >>> request.session.pop_flash()
-   ['info message']
+>>> request.session.flash('info message')
+>>> request.session.pop_flash()
+['info message']
 
 Calling ``session.pop_flash()`` again like above without a corresponding call
 to ``session.flash()`` will return an empty list, because the queue has already
 been popped.
 
-.. code-block:: python
-   :linenos:
-
-   >>> request.session.flash('info message')
-   >>> request.session.pop_flash()
-   ['info message']
-   >>> request.session.pop_flash()
-   []
+>>> request.session.flash('info message')
+>>> request.session.pop_flash()
+['info message']
+>>> request.session.pop_flash()
+[]
 
 .. index::
    single: session.peek_flash
@@ -285,18 +279,15 @@ popped from flash storage.
 
 .. method:: peek_flash(queue='')
 
-.. code-block:: python
-   :linenos:
-
-   >>> request.session.flash('info message')
-   >>> request.session.peek_flash()
-   ['info message']
-   >>> request.session.peek_flash()
-   ['info message']
-   >>> request.session.pop_flash()
-   ['info message']
-   >>> request.session.peek_flash()
-   []
+>>> request.session.flash('info message')
+>>> request.session.peek_flash()
+['info message']
+>>> request.session.peek_flash()
+['info message']
+>>> request.session.pop_flash()
+['info message']
+>>> request.session.peek_flash()
+[]
 
 .. index::
    single: preventing cross-site request forgery attacks

--- a/pyramid/decorator.py
+++ b/pyramid/decorator.py
@@ -15,16 +15,14 @@ class reify(object):
 
     And usage of Foo:
 
-    .. code-block:: text
-
-       >>> f = Foo()
-       >>> v = f.jammy
-       'jammy called'
-       >>> print v
-       1
-       >>> f.jammy
-       1
-       >>> # jammy func not called the second time; it replaced itself with 1
+    >>> f = Foo()
+    >>> v = f.jammy
+    'jammy called'
+    >>> print v
+    1
+    >>> f.jammy
+    1
+    >>> # jammy func not called the second time; it replaced itself with 1
     """
     def __init__(self, wrapped):
         self.wrapped = wrapped

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -234,18 +234,15 @@ def object_description(object):
     """ Produce a human-consumable text description of ``object``,
     usually involving a Python dotted name. For example:
 
-    .. code-block:: python
-
-       >>> object_description(None)
-       u'None'
-       >>> from xml.dom import minidom
-       >>> object_description(minidom)
-       u'module xml.dom.minidom'
-       >>> object_description(minidom.Attr)
-       u'class xml.dom.minidom.Attr'
-       >>> object_description(minidom.Attr.appendChild)
-       u'method appendChild of class xml.dom.minidom.Attr'
-       >>> 
+    >>> object_description(None)
+    u'None'
+    >>> from xml.dom import minidom
+    >>> object_description(minidom)
+    u'module xml.dom.minidom'
+    >>> object_description(minidom.Attr)
+    u'class xml.dom.minidom.Attr'
+    >>> object_description(minidom.Attr.appendChild)
+    u'method appendChild of class xml.dom.minidom.Attr'
 
     If this method cannot identify the type of the object, a generic
     description ala ``object <object.__name__>`` will be returned.


### PR DESCRIPTION
Sphinx automatically notices them as Python snippets and gives
them syntax highlighting.

These snippets are also too short to deserve linenos.
