### PR TITLE
remove copyright bits from the tutorial examples

### DIFF
--- a/docs/tutorials/wiki/src/authorization/tutorial/templates/edit.pt
+++ b/docs/tutorials/wiki/src/authorization/tutorial/templates/edit.pt
@@ -54,9 +54,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/authorization/tutorial/templates/login.pt
+++ b/docs/tutorials/wiki/src/authorization/tutorial/templates/login.pt
@@ -50,9 +50,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/authorization/tutorial/templates/mytemplate.pt
+++ b/docs/tutorials/wiki/src/authorization/tutorial/templates/mytemplate.pt
@@ -69,8 +69,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer">&copy; Copyright 2008-2012, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/authorization/tutorial/templates/view.pt
+++ b/docs/tutorials/wiki/src/authorization/tutorial/templates/view.pt
@@ -57,9 +57,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/basiclayout/tutorial/templates/mytemplate.pt
+++ b/docs/tutorials/wiki/src/basiclayout/tutorial/templates/mytemplate.pt
@@ -69,8 +69,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer">&copy; Copyright 2008-2012, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/models/tutorial/templates/mytemplate.pt
+++ b/docs/tutorials/wiki/src/models/tutorial/templates/mytemplate.pt
@@ -69,8 +69,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer">&copy; Copyright 2008-2012, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/tests/tutorial/templates/edit.pt
+++ b/docs/tutorials/wiki/src/tests/tutorial/templates/edit.pt
@@ -54,9 +54,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/tests/tutorial/templates/login.pt
+++ b/docs/tutorials/wiki/src/tests/tutorial/templates/login.pt
@@ -50,9 +50,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/tests/tutorial/templates/mytemplate.pt
+++ b/docs/tutorials/wiki/src/tests/tutorial/templates/mytemplate.pt
@@ -69,8 +69,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer">&copy; Copyright 2008-2012, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki/src/tests/tutorial/templates/view.pt
+++ b/docs/tutorials/wiki/src/tests/tutorial/templates/view.pt
@@ -57,9 +57,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/basiclayout/tutorial/templates/mytemplate.pt
+++ b/docs/tutorials/wiki2/src/basiclayout/tutorial/templates/mytemplate.pt
@@ -69,8 +69,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer">&copy; Copyright 2008-2012, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/models/tutorial/templates/mytemplate.pt
+++ b/docs/tutorials/wiki2/src/models/tutorial/templates/mytemplate.pt
@@ -69,8 +69,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer">&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/tests/tutorial/templates/edit.pt
+++ b/docs/tutorials/wiki2/src/tests/tutorial/templates/edit.pt
@@ -54,9 +54,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/tests/tutorial/templates/login.pt
+++ b/docs/tutorials/wiki2/src/tests/tutorial/templates/login.pt
@@ -50,9 +50,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/tests/tutorial/templates/mytemplate.pt
+++ b/docs/tutorials/wiki2/src/tests/tutorial/templates/mytemplate.pt
@@ -69,8 +69,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer">&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/tests/tutorial/templates/view.pt
+++ b/docs/tutorials/wiki2/src/tests/tutorial/templates/view.pt
@@ -57,9 +57,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/views/tutorial/templates/edit.pt
+++ b/docs/tutorials/wiki2/src/views/tutorial/templates/edit.pt
@@ -50,9 +50,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/views/tutorial/templates/mytemplate.pt
+++ b/docs/tutorials/wiki2/src/views/tutorial/templates/mytemplate.pt
@@ -69,8 +69,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer">&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>

--- a/docs/tutorials/wiki2/src/views/tutorial/templates/view.pt
+++ b/docs/tutorials/wiki2/src/views/tutorial/templates/view.pt
@@ -53,9 +53,5 @@
       </div>
     </div>
   </div>
-  <div id="footer">
-    <div class="footer"
-         >&copy; Copyright 2008-2011, Agendaless Consulting.</div>
-  </div>
 </body>
 </html>


### PR DESCRIPTION
We don't want to have to keep remembering to update these if there's a change,
and apparently it's also overkill according to https://github.com/Pylons/pyramid/pull/953#issuecomment-15654314.
