### PR TITLE
fix some cross-references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,9 @@ intersphinx_mapping = {
     'toolbar':
         ('http://docs.pylonsproject.org/projects/pyramid_debugtoolbar/en/latest',
          None),
+    'zcml':
+        ('http://docs.pylonsproject.org/projects/pyramid_zcml/en/latest',
+         None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/designdefense.rst
+++ b/docs/designdefense.rst
@@ -514,7 +514,7 @@ the method is called (if possible) with its argument list filled with values
 mentioned therein.  TurboGears and Pylons 1.X operate similarly.
 
 Out of the box, :app:`Pyramid` is configured to have none of these features.
-By default, :mod:`pyramid` view callables always accept only ``request`` and
+By default, :app:`Pyramid` view callables always accept only ``request`` and
 no other arguments.  The rationale: this argument specification matching done
 aggressively can be costly, and :app:`Pyramid` has performance as one of its
 main goals, so we've decided to make people, by default, obtain information
@@ -1678,7 +1678,7 @@ was written to address these issues.
 If it's Zope3-the-web-framework, Pyramid is *definitely* not that.  Making
 use of lots of Zope 3 technologies is territory already staked out by the
 :term:`Grok` project.  Save for the obvious fact that they're both web
-frameworks, :mod:`Pyramid` is very, very different than Grok.  Grok exposes
+frameworks, :app:`Pyramid` is very, very different than Grok.  Grok exposes
 lots of Zope technologies to end users.  On the other hand, if you need to
 understand a Zope-only concept while using Pyramid, then we've failed on some
 very basic axis.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -156,9 +156,9 @@ Glossary
 
    resource
      An object representing a node in the :term:`resource tree` of an
-     application.  If :mod:`traversal` is used, a resource is an element in
+     application.  If :term:`traversal` is used, a resource is an element in
      the resource tree traversed by the system.  When traversal is used, a
-     resource becomes the :term:`context` of a :term:`view`.  If :mod:`url
+     resource becomes the :term:`context` of a :term:`view`.  If :term:`url
      dispatch` is used, a single resource is generated for each request and
      is used as the context resource of a view.
 

--- a/docs/narr/environment.rst
+++ b/docs/narr/environment.rst
@@ -302,7 +302,7 @@ Ideally, you won't need to use the ``pyramid.tweens`` setting at all.  Tweens
 are generally ordered and included "implicitly" when an add-on package which
 registers a tween is "included".  Packages are included when you name a
 ``pyramid.includes`` setting in your configuration or when you call
-:meth:`pyramid.config.Configuration.include`.
+:meth:`pyramid.config.Configurator.include`.
 
 Authors of included add-ons provide "implicit" tween configuration ordering
 hints to Pyramid when their packages are included.  However, the implicit

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -673,7 +673,7 @@ traverser.
 If you've added a traverser, you can change how
 :meth:`~pyramid.request.Request.resource_url` generates a URL for a specific
 type of resource by adding a call to
-:meth:`pyramid.config.add_resource_url_adapter`.
+:meth:`pyramid.config.Configurator.add_resource_url_adapter`.
 
 For example:
 


### PR DESCRIPTION
Also, pyramid_zcml is cross-referenced, so add it to intersphinx_mapping dict.
