### PR TITLE
html_render_factory and easier support for custom content/type render factories

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -198,3 +198,5 @@ Contributors
 - Georges Dubus, 2013/03/21
 
 - Jason McKellar, 2013/03/28
+
+- Jonathan Vanasco, 2013/04/29

--- a/pyramid/config/rendering.py
+++ b/pyramid/config/rendering.py
@@ -23,6 +23,7 @@ DEFAULT_RENDERERS = (
     ('.mako', mako_renderer_factory),
     ('json', renderers.json_renderer_factory),
     ('string', renderers.string_renderer_factory),
+    ('html', renderers.html_renderer_factory),
     )
 
 class RenderingConfiguratorMixin(object):

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -151,7 +151,7 @@ def get_renderer(renderer_name, package=None):
 
 # concrete renderer factory implementations (also API)
 
-def string_renderer_factory(info):
+def abstract_renderer_factory(info,default_content_type='text/plain'):
     def _render(value, system):
         if not isinstance(value, string_types):
             value = str(value)
@@ -160,9 +160,15 @@ def string_renderer_factory(info):
             response = request.response
             ct = response.content_type
             if ct == response.default_content_type:
-                response.content_type = 'text/plain'
+                response.content_type = default_content_type
         return value
     return _render
+    
+def string_renderer_factory(info):
+    return abstract_renderer_factory(info,default_content_type='text/plain')
+
+def html_renderer_factory(info):
+    return abstract_renderer_factory(info,default_content_type='text/html')
 
 _marker = object()
 


### PR DESCRIPTION
I made this patch earlier today, which I ended up not needing , because i just needed to `return Response(string)` , but I wanted to submit this anyways.  it might make be useful to someone else.  it also might be a very stupid patch.

I refactored `string_render_factory` into `abstract_renderer_factory`, which accepts and uses a `default_content_type`

This makes the following 2 renderers a one-liner, and also makes it trivial to create new renderers that accept strings and do the correct content-type setting.
- `string_renderer_factory` returns `abstract_renderer_factory(info,default_content_type='text/plain')`
- `html_renderer_factory` returns `abstract_renderer_factory(info,default_content_type='text/html')`

now you could conceivably do things like:

```
def ical_renderer_factory(info):
    return abstract_renderer_factory(info,default_content_type='text/calendar')

return render_to_response( 'ical', text, request=request )
```

this probably makes `@view_config( 'ical'....`   easy too, but i never use that context so don't know how to test.
