### PR TITLE
Mark the docs as outdated to warn the users

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,8 +159,9 @@ html_theme_path = ['_themes']
 html_theme = 'pyramid'
 html_theme_options = dict(
     github_url='https://github.com/Pylons/pyramid',
-#    in_progress='true',
-    )
+    latest_url='http://docs.pylonsproject.org/projects/pyramid/en/latest/',
+    outdated='true',
+)
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.


### PR DESCRIPTION
With the changes from:

https://github.com/Pylons/pylons_sphinx_theme/pull/3

We can mark the old documentation to warn the users.
