### PR TITLE
We shouldn't recompute json_body every time it is accessed

### DIFF
--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -379,7 +379,7 @@ class Request(BaseRequest, DeprecatedRequestMethodsMixin, URLMethodsMixin,
             return False
         return adapted is ob
 
-    @property
+    @reify
     def json_body(self):
         return json.loads(text_(self.body, self.charset))
 

--- a/pyramid/tests/test_request.py
+++ b/pyramid/tests/test_request.py
@@ -271,6 +271,18 @@ class TestRequest(unittest.TestCase):
         request.body = b'{"a":1}'
         self.assertEqual(request.json_body, {'a':1})
 
+    def test_json_body_reify(self):
+        request = self._makeOne({'REQUEST_METHOD':'POST'})
+
+        request.body = b'{"a":1}'
+
+        self.assertEqual(request.json_body, {'a':1})
+
+        request.body = b''
+
+        self.assertEqual(request.json_body, {'a':1})
+
+
     def test_json_body_alternate_charset(self):
         import json
         request = self._makeOne({'REQUEST_METHOD':'POST'})


### PR DESCRIPTION
Not sure if there is a good reason for re-computing json_body every time but it seems pretty safe to reify it.
