### PR TITLE
Implement PEP302 API in PackageOverrides as '__loader__'.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ next release
 Features
 --------
 
+- Make the ``pyramid.config.assets.PackageOverrides`` object implement the
+  API for ``__loader__`` objects specified in PEP 302.  Proxies to the
+  ``__loader__`` set by the importer, if present;  otherwise, raises
+  ``NotImplementedError``.
+
 - ``ACLAuthorizationPolicy`` supports ``__acl__`` as a callable. This
   removes the ambiguity between the potential ``AttributeError`` that would
   be raised on the ``context`` when the property was not defined and the

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -793,7 +793,49 @@ deprecated(
     'See the "What\'s new In Pyramid 1.3" document for more details.'
     )
 
-class IPackageOverrides(Interface):
+class IPEP302Loader(Interface):
+    """ See http://www.python.org/dev/peps/pep-0302/#id30.
+    """
+    def get_data(path):
+        """ Retrieve data for and arbitrary "files" from storage backend.
+
+        Raise IOError for not found.
+
+        Data is returned as bytes.
+        """
+
+    def is_package(fullname):
+        """ Return True if the module specified by 'fullname' is a package.
+        """
+
+    def get_code(fullname):
+        """ Return the code object for the module identified by 'fullname'.
+        
+        Return 'None' if it's a built-in or extension module.
+        
+        If the loader doesn't have the code object but it does have the source
+        code, return the compiled source code.
+
+        Raise ImportError if the module can't be found by the importer at all.
+        """
+
+    def get_source(fullname):
+        """ Return the source code for the module identified by 'fullname'.
+        
+        Return a string, using newline characters for line endings, or None
+        if the source is not available.
+            
+        Raise ImportError if the module can't be found by the importer at all.
+        """
+
+    def get_filename(fullname):
+        """ Return the value of '__file__' if the named module was loaded.
+        
+        If the module is not found, raise ImportError.
+        """
+
+
+class IPackageOverrides(IPEP302Loader):
     """ Utility for pkg_resources overrides """
 
 # VH_ROOT_KEY is an interface; its imported from other packages (e.g.


### PR DESCRIPTION
Proxy to the '**loader**' set by the importer, if present.  Otherwise,
raise NotImplementedError.

We cannot raise in the presence of an existing '**loader**', because Python 3.3.x sets one for any module.  So, we need to pretend to be one by proxy.
