### PR TITLE
Add a parent_domain option for auth_tkt policy

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,10 @@ Features
   ``pyramid.config.Configurator.add_static_view``. This allows
   externally-hosted static URLs to be generated based on the current protocol.
 
+- The ``AuthTktAuthenticationPolicy`` has a new ``parent_domain`` option to
+  set the authentication cookie as a wildcard cookie on the parent domain. This
+  is useful if you have multiple sites sharing the same domain.
+
 - The ``AuthTktAuthenticationPolicy`` now supports IPv6 addresses when using
   the ``include_ip=True`` option. This is possibly incompatible with
   alternative ``auth_tkt`` implementations, as the specification does not

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -947,6 +947,30 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         self.assertTrue(result[1][1].endswith('; Path=/; Domain=localhost'))
         self.assertTrue(result[1][1].startswith('auth_tkt='))
 
+    def test_remember_parent_domain(self):
+        helper = self._makeOne('secret', parent_domain=True)
+        request = self._makeRequest()
+        request.environ['HTTP_HOST'] = 'www.example.com'
+        result = helper.remember(request, 'other')
+        self.assertEqual(len(result), 2)
+
+        self.assertEqual(result[0][0], 'Set-Cookie')
+        self.assertTrue(result[0][1].endswith('; Path=/'))
+        self.assertTrue(result[0][1].startswith('auth_tkt='))
+
+        self.assertEqual(result[1][0], 'Set-Cookie')
+        self.assertTrue(result[1][1].endswith('; Path=/; Domain=.example.com'))
+        self.assertTrue(result[1][1].startswith('auth_tkt='))
+
+    def test_remember_parent_domain_supercedes_wild_domain(self):
+        helper = self._makeOne('secret', parent_domain=True, wild_domain=True)
+        request = self._makeRequest()
+        request.environ['HTTP_HOST'] = 'www.example.com'
+        result = helper.remember(request, 'other')
+        self.assertEqual(len(result), 2)
+        self.assertTrue(result[0][1].endswith('; Path=/'))
+        self.assertTrue(result[1][1].endswith('; Path=/; Domain=.example.com'))
+
     def test_remember_domain_has_port(self):
         helper = self._makeOne('secret', wild_domain=False)
         request = self._makeRequest()


### PR DESCRIPTION
This change adds a new `parent_domain` option to `AuthTktAuthenticationPolicy` which sets the authentication cookie as a wildcard cookie on the parent domain. This is useful if you have multiple sites sharing the same domain.
