### PR TITLE
Resources.rst typo fix

### DIFF
--- a/docs/narr/resources.rst
+++ b/docs/narr/resources.rst
@@ -300,7 +300,7 @@ the resource by :meth:`~pyramid.request.Request.resource_url`.
 The ``__resource_url__`` hook is passed two arguments: ``request`` and
 ``info``.  ``request`` is the :term:`request` object passed to
 :meth:`~pyramid.request.Request.resource_url`.  ``info`` is a dictionary with
-two keys:
+the following keys:
 
 ``physical_path``
    A string representing the "physical path" computed for the resource, as


### PR DESCRIPTION
There's 3 keys in the info dict, not two.
