### PR TITLE
Add __bool__ for python 3

### DIFF
--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -219,6 +219,9 @@ class DummyResource:
 
     __iter__ = keys
 
+    def __bool__(self):
+        return True
+
     def __nonzero__(self):
         return True
 


### PR DESCRIPTION
Python 3 checks __bool__ instead of __nonzero__ when testing the "truthiness" of an object. This was causing some code to use __len__ instead of __nonzero__, and it was returning 0, which was causing an instance of DummyResource to be "falsy" instead.
