### PR TITLE
Avoid re-executing the same view when looking up context base views.

### DIFF
--- a/pyramid/router.py
+++ b/pyramid/router.py
@@ -165,9 +165,13 @@ class Router(object):
                 # look for other views that meet the predicate
                 # criteria
                 for iface in context_iface.__sro__[1:]:
+                    previous_view_callable = view_callable
                     view_callable = adapters.lookup(
                         (IViewClassifier, request.request_iface, iface),
                         IView, name=view_name, default=None)
+                    # intermediate bases may lookup same view_callable
+                    if view_callable is previous_view_callable:
+                        continue
                     if view_callable is not None:
                         try:
                             response = view_callable(context, request)


### PR DESCRIPTION
This is a tweak of #1004.

Really we should be using subscribers here instead of adapters, but
zope.interface doesn't yet suppport named subscribers.
