### PR TITLE
Remove references to relocated PyCharm tutorial

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,7 +109,6 @@ platforms.
    tutorials/wiki/index.rst
    tutorials/bfg/index.rst
    tutorials/modwsgi/index.rst
-   tutorials/pycharm/index.rst
 
 API Documentation
 =================

--- a/docs/latexindex.rst
+++ b/docs/latexindex.rst
@@ -78,7 +78,6 @@ Tutorials
    tutorials/wiki/index.rst
    tutorials/bfg/index.rst
    tutorials/modwsgi/index.rst
-   tutorials/pycharm/index.rst
 
 .. _api_documentation:
 
@@ -115,7 +114,7 @@ API Documentation
 .. backmatter::
 
 Glossary and Index
-@@@@@@@@@@@@@@@@@@
+==================
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
Also make headings consistent in latexindex.rst
