### PR TITLE
Added verbosity option -v --verbose to pserve.py 

### DIFF
--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -45,8 +45,8 @@ if WIN and not hasattr(os, 'kill'): # pragma: no cover
 else:
     kill = os.kill
 
-def main(argv=sys.argv):
-    command = PServeCommand(argv)
+def main(argv=sys.argv, quiet=False):
+    command = PServeCommand(argv, quiet=quiet)
     return command.run()
 
 class DaemonizeException(Exception):
@@ -165,11 +165,14 @@ class PServeCommand(object):
 
     possible_subcommands = ('start', 'stop', 'restart', 'status')
 
-    def __init__(self, argv):
+    def __init__(self, argv, quiet=False):
         self.options, self.args = self.parser.parse_args(argv[1:])
+        if quiet:
+            self.options.verbose = 0
 
     def out(self, msg): # pragma: no cover
-        print(msg)
+        if self.options.verbose > 0:
+            print(msg)
 
     def get_options(self):
         if (len(self.args) > 1

--- a/pyramid/tests/test_scripts/test_pserve.py
+++ b/pyramid/tests/test_scripts/test_pserve.py
@@ -259,7 +259,7 @@ class Test_read_pidfile(unittest.TestCase):
 class Test_main(unittest.TestCase):
     def _callFUT(self, argv):
         from pyramid.scripts.pserve import main
-        return main(argv)
+        return main(argv, quiet=True)
 
     def test_it(self):
         result = self._callFUT(['pserve'])


### PR DESCRIPTION
default_verbosity seemed idle, so it was put to use. self.verbose is referred to quite a bit.
self.verbose is removed as a class attr and replaced with self.options.verbose and test_pserve.py updated.
default_verbosity remains as a class attr and declared earlier.
