### PR TITLE
No cookies on other domain when using parent_domain

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -865,22 +865,22 @@ class AuthTktCookieHelper(object):
         if ':' in cur_domain:
             cur_domain = cur_domain.split(':', 1)[0]
 
-        cookies = [
-            ('Set-Cookie', '%s="%s"; Path=%s%s%s' % (
-            self.cookie_name, value, self.path, max_age, self.static_flags))
-            ]
 
         domains = []
         if self.parent_domain and cur_domain.count('.') > 1:
             domains.append('.' + cur_domain.split('.', 1)[1])
         else:
+            domains.append(None)
             domains.append(cur_domain)
             if self.wild_domain:
                 domains.append('.' + cur_domain)
+
+        cookies = []
+        base_cookie = '%s="%s"; Path=%s%s%s' % (self.cookie_name, value,
+                self.path, max_age, self.static_flags)
         for domain in domains:
-            cookies.append(('Set-Cookie', '%s="%s"; Path=%s; Domain=%s%s%s' % (
-                self.cookie_name, value, self.path, domain, max_age,
-                self.static_flags)))
+            domain = '; Domain=%s' % domain if domain is not None else ''
+            cookies.append(('Set-Cookie', '%s%s' % (base_cookie, domain)))
 
         return cookies
 

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -908,11 +908,11 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         self.assertTrue(result[0][1].startswith('auth_tkt='))
 
         self.assertEqual(result[1][0], 'Set-Cookie')
-        self.assertTrue(result[1][1].endswith('; HttpOnly'))
+        self.assertTrue('; HttpOnly' in result[1][1])
         self.assertTrue(result[1][1].startswith('auth_tkt='))
 
         self.assertEqual(result[2][0], 'Set-Cookie')
-        self.assertTrue(result[2][1].endswith('; HttpOnly'))
+        self.assertTrue('; HttpOnly' in result[2][1])
         self.assertTrue(result[2][1].startswith('auth_tkt='))
 
     def test_remember_secure(self):
@@ -952,24 +952,19 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         request = self._makeRequest()
         request.environ['HTTP_HOST'] = 'www.example.com'
         result = helper.remember(request, 'other')
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 1)
 
         self.assertEqual(result[0][0], 'Set-Cookie')
-        self.assertTrue(result[0][1].endswith('; Path=/'))
+        self.assertTrue(result[0][1].endswith('; Path=/; Domain=.example.com'))
         self.assertTrue(result[0][1].startswith('auth_tkt='))
-
-        self.assertEqual(result[1][0], 'Set-Cookie')
-        self.assertTrue(result[1][1].endswith('; Path=/; Domain=.example.com'))
-        self.assertTrue(result[1][1].startswith('auth_tkt='))
 
     def test_remember_parent_domain_supercedes_wild_domain(self):
         helper = self._makeOne('secret', parent_domain=True, wild_domain=True)
         request = self._makeRequest()
         request.environ['HTTP_HOST'] = 'www.example.com'
         result = helper.remember(request, 'other')
-        self.assertEqual(len(result), 2)
-        self.assertTrue(result[0][1].endswith('; Path=/'))
-        self.assertTrue(result[1][1].endswith('; Path=/; Domain=.example.com'))
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0][1].endswith('; Domain=.example.com'))
 
     def test_remember_domain_has_port(self):
         helper = self._makeOne('secret', wild_domain=False)
@@ -1102,13 +1097,13 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         name, value = headers[1]
         self.assertEqual(name, 'Set-Cookie')
         self.assertEqual(value,
-                         'auth_tkt=""; Path=/; Domain=localhost; Max-Age=0; '
-                         'Expires=Wed, 31-Dec-97 23:59:59 GMT')
+                         'auth_tkt=""; Path=/; Max-Age=0; '
+                         'Expires=Wed, 31-Dec-97 23:59:59 GMT; Domain=localhost')
         name, value = headers[2]
         self.assertEqual(name, 'Set-Cookie')
         self.assertEqual(value,
-                         'auth_tkt=""; Path=/; Domain=.localhost; Max-Age=0; '
-                         'Expires=Wed, 31-Dec-97 23:59:59 GMT')
+                         'auth_tkt=""; Path=/; Max-Age=0; '
+                         'Expires=Wed, 31-Dec-97 23:59:59 GMT; Domain=.localhost')
 
 class TestAuthTicket(unittest.TestCase):
     def _makeOne(self, *arg, **kw):


### PR DESCRIPTION
This address a [comment from @enmand](https://github.com/Pylons/pyramid/pull/1028#issuecomment-21523972) on Pylons/pyramid#1028: when using parent_domain you should never set a cookie on the current domain, or you risk getting invalid behaviour when logging in on one domain and doing logout on another domain.
