### PR TITLE
Allow explicit auth cookie domain setting.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -49,9 +49,13 @@ Features
   ``pyramid.config.Configurator.add_static_view``. This allows
   externally-hosted static URLs to be generated based on the current protocol.
 
-- The ``AuthTktAuthenticationPolicy`` has a new ``parent_domain`` option to
-  set the authentication cookie as a wildcard cookie on the parent domain. This
-  is useful if you have multiple sites sharing the same domain.
+- The ``AuthTktAuthenticationPolicy`` has two new options to configure its
+  domain usage: 
+  * ``parent_domain``: if set the authentication cookie is set on
+    the parent domain. This is useful if you have multiple sites sharing the
+    same domain.
+  * ``domain``: if provided the cookie is always set for this domain, bypassing
+     all usual logic.
 
 - The ``AuthTktAuthenticationPolicy`` now supports IPv6 addresses when using
   the ``include_ip=True`` option. This is possibly incompatible with

--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -528,6 +528,15 @@ class AuthTktAuthenticationPolicy(CallbackAuthenticationPolicy):
 
        This option is available as of :app:`Pyramid` 1.5.
 
+    ``domain``
+
+       Default: ``None``. If provided the auth_tkt cookie will only be
+       set for this domain. This option is not compatible with ``wild_domain``
+       and ``parent_domain``.
+       Optional.
+
+       This option is available as of :app:`Pyramid` 1.5.
+
     ``hashalg``
 
        Default: ``md5`` (the literal string).
@@ -581,6 +590,7 @@ class AuthTktAuthenticationPolicy(CallbackAuthenticationPolicy):
                  debug=False,
                  hashalg=_marker,
                  parent_domain=False,
+                 domain=None,
                  ):
         if hashalg is _marker:
             hashalg = 'md5'
@@ -619,6 +629,7 @@ class AuthTktAuthenticationPolicy(CallbackAuthenticationPolicy):
             wild_domain=wild_domain,
             hashalg=hashalg,
             parent_domain=parent_domain,
+            domain=domain,
             )
         self.callback = callback
         self.debug = debug
@@ -816,7 +827,7 @@ class AuthTktCookieHelper(object):
     def __init__(self, secret, cookie_name='auth_tkt', secure=False,
                  include_ip=False, timeout=None, reissue_time=None,
                  max_age=None, http_only=False, path="/", wild_domain=True,
-                 hashalg='md5', parent_domain=False):
+                 hashalg='md5', parent_domain=False, domain=None):
         self.secret = secret
         self.cookie_name = cookie_name
         self.include_ip = include_ip
@@ -828,6 +839,7 @@ class AuthTktCookieHelper(object):
         self.path = path
         self.wild_domain = wild_domain
         self.parent_domain = parent_domain
+        self.domain = domain
         self.hashalg = hashalg
 
         static_flags = []
@@ -867,13 +879,16 @@ class AuthTktCookieHelper(object):
 
 
         domains = []
-        if self.parent_domain and cur_domain.count('.') > 1:
-            domains.append('.' + cur_domain.split('.', 1)[1])
+        if self.domain:
+            domains.append(self.domain)
         else:
-            domains.append(None)
-            domains.append(cur_domain)
-            if self.wild_domain:
-                domains.append('.' + cur_domain)
+            if self.parent_domain and cur_domain.count('.') > 1:
+                domains.append('.' + cur_domain.split('.', 1)[1])
+            else:
+                domains.append(None)
+                domains.append(cur_domain)
+                if self.wild_domain:
+                    domains.append('.' + cur_domain)
 
         cookies = []
         base_cookie = '%s="%s"; Path=%s%s%s' % (self.cookie_name, value,

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -966,6 +966,26 @@ class TestAuthTktCookieHelper(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0][1].endswith('; Domain=.example.com'))
 
+    def test_remember_explicit_domain(self):
+        helper = self._makeOne('secret', domain='pyramid.bazinga')
+        request = self._makeRequest()
+        request.environ['HTTP_HOST'] = 'www.example.com'
+        result = helper.remember(request, 'other')
+        self.assertEqual(len(result), 1)
+
+        self.assertEqual(result[0][0], 'Set-Cookie')
+        self.assertTrue(result[0][1].endswith('; Path=/; Domain=pyramid.bazinga'))
+        self.assertTrue(result[0][1].startswith('auth_tkt='))
+
+    def test_remember_domain_supercedes_parent_and_wild_domain(self):
+        helper = self._makeOne('secret', domain='pyramid.bazinga',
+                parent_domain=True, wild_domain=True)
+        request = self._makeRequest()
+        request.environ['HTTP_HOST'] = 'www.example.com'
+        result = helper.remember(request, 'other')
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0][1].endswith('; Path=/; Domain=pyramid.bazinga'))
+
     def test_remember_domain_has_port(self):
         helper = self._makeOne('secret', wild_domain=False)
         request = self._makeRequest()


### PR DESCRIPTION
This builds on (and includes) the commit from #1072.

In some situations any standard rules for cookies do not apply and the only alternative is to hardcode the domain used for cookies. This pull request makes that possible by adding a new `domain` option to AuthTktAuthenticationPolicy.
