### PR TITLE
preserve response objects when using the render() api

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,15 @@
+Next Release
+============
+
+Backwards Incompatibilities
+---------------------------
+
+- Almost all renderers affect properties on the ``request.response`` response
+  object. For example, setting the content-type in the JSON renderer to
+  'application/json'. These mutations will no longer affect
+  ``request.response`` when using the ``pyramid.renderers.render()`` API as
+  its only expected output is a rendered string object.
+
 1.5a1 (2013-08-30)
 ==================
 

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -85,7 +85,23 @@ def render(renderer_name, value, request=None, package=None):
         package = caller_package()
     helper = RendererHelper(name=renderer_name, package=package,
                             registry=registry)
-    return helper.render(value, None, request=request)
+
+    saved_response = None
+    # save the current response, preventing the renderer from affecting it
+    attrs = request.__dict__ if request is not None else {}
+    if 'response' in attrs:
+        saved_response = attrs['response']
+        del attrs['response']
+
+    result = helper.render(value, None, request=request)
+
+    # restore the original response, overwriting any changes
+    if saved_response is not None:
+        attrs['response'] = saved_response
+    elif 'response' in attrs:
+        del attrs['response']
+
+    return result
 
 def render_to_response(renderer_name, value, request=None, package=None):
     """ Using the renderer ``renderer_name`` (a template

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -897,6 +897,14 @@ class Test_render(unittest.TestCase):
         renderer.assert_(a=1)
         renderer.assert_(request=request)
 
+    def test_it_preserves_response(self):
+        request = testing.DummyRequest()
+        response = object() # should error if mutated
+        request.response = response
+        result = self._callFUT('json', dict(a=1), request=request)
+        self.assertEqual(result, '{"a": 1}')
+        self.assertEqual(request.response, response)
+
 class Test_render_to_response(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp()


### PR DESCRIPTION
- `p.renderers.render()` used to affect `request.response` which was unexpected.
- removed deprecated `request.response_*` attributes
