### PR TITLE
Fix broken link to tox in HACKING

### DIFF
--- a/HACKING.txt
+++ b/HACKING.txt
@@ -21,10 +21,10 @@ checkout.
   (alternately, create a writeable fork on GitHub and check that out).
 
 Since pyramid is a framework and not an application, it can be
-convenient to work against a sample application, preferably in its
-own virtualenv. A quick way to achieve this is to (ab-)use ``tox``
-(http://codespeak.net/~hpk/tox/) with a custom configuration file that's part of
-the checkout::
+convenient to work against a sample application, preferably in its own
+virtualenv. A quick way to achieve this is to (ab-)use ``tox``
+(http://tox.readthedocs.org/en/latest/) with a custom configuration
+file that's part of the checkout::
 
   tox -c hacking-tox.ini
 


### PR DESCRIPTION
Note that http://codespeak.net/tox/ is stale - only has v0.9 of tox, current is 1.6.1.
