### PR TITLE
Missing view_defaults import, causes error on use.

### DIFF
--- a/docs/narr/viewconfig.rst
+++ b/docs/narr/viewconfig.rst
@@ -834,6 +834,7 @@ decorator on the RESTView class:
 .. code-block:: python
    :linenos:
 
+   from pyramid.view import view_defaults
    from pyramid.view import view_config
    from pyramid.response import Response
    from pyramid.config import Configurator


### PR DESCRIPTION
Example missing view_defaults import.
