### PR TITLE
Docs: Hyperlink example of explicitly calling a renderer into renderer n...

### DIFF
--- a/docs/narr/introduction.rst
+++ b/docs/narr/introduction.rst
@@ -309,6 +309,12 @@ can use multiple templating systems, even in the same project.
 
 Example: :ref:`templates_used_directly`.
 
+.. index::
+   single: renderer
+   single: view renderer
+
+.. _rendered_views_can_return_dictionaries:
+
 Rendered views can return dictionaries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/narr/renderers.rst
+++ b/docs/narr/renderers.rst
@@ -56,10 +56,13 @@ serialization techniques.  In practice, renderers obtain application data
 values from Python dictionaries so, in practice, view callables which use
 renderers return Python dictionaries.
 
-View configuration can vary the renderer associated with a view callable via
-the ``renderer`` attribute.  For example, this call to
-:meth:`~pyramid.config.Configurator.add_view` associates the ``json`` renderer
-with a view callable:
+View callables can `explicitly call
+<rendered_views_can_return_dictionaries_>`_ renderers but, typically,
+view configuration declares the renderer used to render a view
+callable's results.  This is done with the ``renderer`` attribute.
+For example, this call to
+:meth:`~pyramid.config.Configurator.add_view` associates the ``json``
+renderer with a view callable:
 
 .. code-block:: python
 


### PR DESCRIPTION
...arrative.  Add index entry.

I knew there was an example somewhere. Couldn't find the damm thing.

This has not been tested.  (Still not making the docs.)  Both the index entry and the link must be tested.
