### PR TITLE
Docs: project.rst: Printf()s can be used for debugging.  Output goes to ...

### DIFF
--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -894,7 +894,7 @@ returns the HTML in a :term:`response`.
    <MyProject_ini_logging>` to aid debugging.  Should an exception be raised,
    uncaught tracebacks are displayed, after the startup messages, on :ref:`the
    console running the server <running_the_project_application>`.
-   Conveniently, ``printf()``\s inserted into the application for debugging
+   Conveniently, ``print()``\s inserted into the application for debugging
    also send output to this console.
 
 .. note:: ``development.ini`` has a setting that controls how templates are


### PR DESCRIPTION
...the server console.

The main point of the second sentence is to setup the reader with
mental context for the 3rd sentence, so that the 3rd sentence sinks
in.  Likewise, the parenthetical in the second sentence about server
startup messages gives the reader some clue as to what the rest of the
sentence it talking about.  I suspect that some readers won't know
what a console is, and the rest will be confused by a server run on a
console.
