### PR TITLE
fix 'test_it' test of the class 'ViewPageTests'

### DIFF
--- a/docs/tutorials/wiki/src/tests/tutorial/tests.py
+++ b/docs/tutorials/wiki/src/tests/tutorial/tests.py
@@ -66,7 +66,9 @@ class ViewPageTests(unittest.TestCase):
         self.assertEqual(
             info['content'],
             '<div class="document">\n'
-            '<p>Hello <a href="http://example.com/add_page/CruelWorld">'
+            '<p><a href="http://example.com/add_page/Hello">'
+            'Hello</a> '
+            '<a href="http://example.com/add_page/CruelWorld">'
             'CruelWorld</a> '
             '<a href="http://example.com/IDoExist/">'
             'IDoExist</a>'


### PR DESCRIPTION
the variable 'context' has a DummyResource with the 'data' param ('data' has as value 'Hello CruelWorld IDoExist'). It return three <a> HTML tag (for Hello, CruelWorld and IDoexist). In the second assertEqual is missing the <a> HTML tag to 'Hello'.
