### PR TITLE
Update package_name() to work with namespace pkgs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+Next Release
+============
+
+Bug Fixes
+---------
+
+- Fix an exception in ``package_name()`` when resolving the package
+  name for namespace packages.
+
 1.4.5 (2013-08-30)
 ==================
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -194,3 +194,5 @@ Contributors
 - John Anderson, 2012/11/14
 
 - Jason McKellar, 2013/03/28
+
+- Doug Hellmann, 2013/09/06

--- a/pyramid/path.py
+++ b/pyramid/path.py
@@ -33,8 +33,12 @@ def package_name(pkg_or_module):
     name of the package itself."""
     if pkg_or_module is None or pkg_or_module.__name__ == '__main__':
         return '__main__'
-    pkg_filename = pkg_or_module.__file__
     pkg_name = pkg_or_module.__name__
+    pkg_filename = getattr(pkg_or_module, '__file__', None)
+    if pkg_filename is None:
+        # Namespace packages do not have __init__.py* files,
+        # and so have no __file__ attribute
+        return pkg_name
     splitted = os.path.split(pkg_filename)
     if splitted[-1] in init_names:
         # it's a package

--- a/pyramid/tests/test_path.py
+++ b/pyramid/tests/test_path.py
@@ -154,6 +154,12 @@ class TestPackageName(unittest.TestCase):
         package = DummyPackageOrModule(tests)
         result = self._callFUT(package)
         self.assertEqual(result, 'pyramid.tests')
+
+    def test_it_namespace_package(self):
+        from pyramid import tests
+        package = DummyNamespacePackage(tests)
+        result = self._callFUT(package)
+        self.assertEqual(result, 'pyramid.tests')
         
     def test_it_module(self):
         from pyramid.tests import test_path
@@ -558,3 +564,13 @@ class DummyPackageOrModule:
         if self.raise_exc is not None:
             raise self.raise_exc
         self.__dict__[key] = val
+
+class DummyNamespacePackage:
+    """Has no __file__ attribute.
+    """
+    
+    def __init__(self, real_package_or_module):
+        self.__name__ = real_package_or_module.__name__
+        import os
+        self.package_path = os.path.dirname(
+            os.path.abspath(real_package_or_module.__file__))


### PR DESCRIPTION
The logic in pyramid.path.package_name() should take into
account the fact that namespace packages created by
setuptools do not have **init**.py[c] files, and so they
have no **file** attribute.

This resolves an issue with WSME
(https://bugs.launchpad.net/wsme/+bug/1221201)

Change-Id: I39bc32a9c38fa11c4cef22a041077ed9001091be
(cherry picked from commit c062d5ace6adedcf0f6434cffc07fb24cc608733)
