### PR TITLE
Specified installation instructions for pyramid_chameleon in quick tour docs

### DIFF
--- a/docs/quick_tour.rst
+++ b/docs/quick_tour.rst
@@ -246,6 +246,23 @@ languages. That said, the Pylons Project officially supports bindings for
 Chameleon, Jinja2 and Mako, so in this step, let's use Chameleon as an
 example:
 
+Let's add ``pyramid_chameleon``,
+a Pyramid :term:`add-on` which enables Chameleon as a :term:`renderer` in
+our Pyramid applications:
+
+.. code-block:: bash
+
+    $ easy_install pyramid_chameleon
+
+With the package installed, we can include the template bindings into
+our configuration:
+
+.. code-block:: python
+
+    config.include('pyramid_chameleon')
+    
+Now lets change our views.py file:
+
 .. literalinclude:: quick_tour/templating/views.py
     :start-after: Start View 1
     :end-before: End View 1


### PR DESCRIPTION
I think the pyramid_chameleon instructions should be specified, as it is used before pyramid_jinja2 (for which installation instructions are mentioned)
