### PR TITLE
tox.ini: Add py34

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-    py26,py27,py32,py33,pypy,cover
+    py26,py27,py32,py33,py34,pypy,cover
 
 [testenv]
 commands = 


### PR DESCRIPTION
Useful for testing with the new Python 3.4 alpha versions.
