### PR TITLE
Fix JSONP syntax error

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -51,6 +51,9 @@ Features
 Bug Fixes
 ---------
 
+- Add a trailing semicolon to the JSONP response. This fixes JavaScript syntax
+  errors for old IE versions.
+
 - Fix the ``pcreate`` script so that when the target directory name ends with a 
   slash it does not produce a non-working project directory structure.  
   Previously saying ``pcreate -s starter /foo/bar/`` produced different output 

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -363,7 +363,7 @@ class JSONP(JSON):
                 body = val
             else:
                 ct = 'application/javascript'
-                body = '%s(%s)' % (callback, val)
+                body = '%s(%s);' % (callback, val)
             response = request.response
             if response.content_type == response.default_content_type:
                 response.content_type = ct

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -567,7 +567,7 @@ class TestJSONP(unittest.TestCase):
         request = testing.DummyRequest()
         request.GET['callback'] = 'callback'
         result = renderer({'a':'1'}, {'request':request})
-        self.assertEqual(result, 'callback({"a": "1"})')
+        self.assertEqual(result, 'callback({"a": "1"});')
         self.assertEqual(request.response.content_type,
                          'application/javascript')
 


### PR DESCRIPTION
Javascript requires a semicolon to terminate a statement. This should also be done in JSONP responses (see the example on the [JSONP wikipedia page](http://en.wikipedia.org/wiki/JSONP) to prevent errors in older IE versions.
