### PR TITLE
Added MANIFEST.in file for including 3 scaffold folders

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -228,3 +228,5 @@ Contributors
 - Matthew Russell, 2013/10/14
 
 - Antti Haapala, 2013/11/15
+
+- Rob van der Linde, 2013/12/20

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include pyramid/scaffolds/alchemy *
+recursive-include pyramid/scaffolds/starter *
+recursive-include pyramid/scaffolds/zodb *


### PR DESCRIPTION
Listing the 3 folders containing the scaffolds included with Pyramid
also helps making Debian packaging a bit easier, since dh_autoinstall
reads the MANIFEST.in file for Python projects.
