### PR TITLE
Note for debian & Ubuntu users for setuptools

### DIFF
--- a/docs/quick_tutorial/requirements.rst
+++ b/docs/quick_tutorial/requirements.rst
@@ -172,11 +172,18 @@ we just specified in the environment variable.
    package,
    :ref:`Installing Pyramid on a Windows System <installing_windows>`
 
-
 .. _install-setuptools-(python-packaging-tools):
 
 Install ``setuptools`` (Python packaging tools)
 -----------------------------------------------
+
+.. note::
+
+    For all debian & Ubuntu users: 
+    There is a bug (see http://bugs.python.org/issue16480) that will install the setuptools in
+    $VENV/local/bin instead of $VENV/bin. A possible workaround is to activate this new environment 
+    with the following command:
+    source $VENV/bin/activate
 
 The following command will download a script to install ``setuptools``, then
 pipe it to your environment's version of Python.


### PR DESCRIPTION
On debian and Ubuntu environments the setuptools are installed in $VENV/local/bin instead of $VENV/bin

This hint should give those users a workaround, so they are still able to use the commands in the tutorial without modifying each.

see https://github.com/diablorosso/pyramid/commit/71eb5871ef67c0657d7124d65b9a528d3bec5585 for details
