### PR TITLE
Reloader crashes on Python 3 occasionally...

### DIFF
--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -811,7 +811,12 @@ class Monitor(object): # pragma: no cover
                 print(
                     "Error calling reloader callback %r:" % file_callback)
                 traceback.print_exc()
-        for module in sys.modules.values():
+        
+        modules = sys.modules.values()
+        if PY3:
+            modules = list(modules)
+            
+        for module in modules:
             try:
                 filename = module.__file__
             except (AttributeError, ImportError):


### PR DESCRIPTION
... because dict.values() return a view that throws `RuntimeError: dictionary changed size during iteration` if the backed collection is changed during iteration.
