### PR TITLE
Fix pserve --reload on Py3 (the simple solution)

### DIFF
--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -811,7 +811,7 @@ class Monitor(object): # pragma: no cover
                 print(
                     "Error calling reloader callback %r:" % file_callback)
                 traceback.print_exc()
-        for module in sys.modules.values():
+        for module in list(sys.modules.values()):
             try:
                 filename = module.__file__
             except (AttributeError, ImportError):


### PR DESCRIPTION
This is the simpler fix for `pserve --reload` (so please pull either https://github.com/Pylons/pyramid/pull/1244 or this).

Basically with some project setups the reloader thread is guaranteed to crash on Python 3 as the main thread is importing modules in the other thread.
