### PR TITLE
Fix documentation for add_notfound_view()

### DIFF
--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -1621,7 +1621,7 @@ class ViewsConfiguratorMixin(object):
         ):
         """ Add a default notfound view to the current configuration state.
         The view will be called when Pyramid or application code raises an
-        :exc:`pyramid.httpexceptions.HTTPForbidden` exception (e.g. when a
+        :exc:`pyramid.httpexceptions.HTTPNotFound` exception (e.g. when a
         view cannot be found for the request).  The simplest example is:
 
           .. code-block:: python


### PR DESCRIPTION
It referred to HTTPForbidden as the exception instead of HTTPNotFound.
