### PR TITLE
Update request_method predicate documentation

### DIFF
--- a/docs/narr/viewconfig.rst
+++ b/docs/narr/viewconfig.rst
@@ -295,14 +295,17 @@ configured view.
   *This is an advanced feature, not often used by "civilians"*.
 
 ``request_method``
-  This value can be a string (typically ``"GET"``, ``"POST"``, ``"PUT"``,
-  ``"DELETE"``, or ``"HEAD"``) representing an HTTP ``REQUEST_METHOD``.  A view
-  declaration with this argument ensures that the view will only be called
-  when the request's ``method`` attribute (aka the ``REQUEST_METHOD`` of the
-  WSGI environment) string matches the supplied value.
+  This value can be one of the strings ``GET``, ``POST``, ``PUT``, ``DELETE``,
+  or ``HEAD`` representing an HTTP ``REQUEST_METHOD``, or a tuple containing
+  one or more of these strings.  A view declaration with this argument ensures
+  that the view will only be called when the request's ``method`` attribute
+  (aka the ``REQUEST_METHOD`` of the WSGI environment) string matches a
+  supplied value.  Note that use of ``GET`` also implies that the view will
+  respond to ``HEAD`` as of Pyramid 1.4.
 
-  If ``request_method`` is not supplied, the view will be invoked regardless
-  of the ``REQUEST_METHOD`` of the :term:`WSGI` environment.
+  .. versionchanged:: 1.2
+     The ability to pass a tuple of items as ``request_method``.  Previous
+     versions allowed only a string.
 
 ``request_param``
   This value can be any string or a sequence of strings.  A view declaration


### PR DESCRIPTION
I don't know if this is the best way to approach this situation, or if there is a better way to clean up this part of the docs, but this is something I just ran into.

I was looking for the `request_method` predicate and was sent to http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html

I remembered that it should be possible to pass a tuple, and was trying to verify that using `GET` would also automatically include `HEAD`, well that documentation is available at: http://docs.pylonsproject.org/projects/pyramid/en/latest/api/config.html#pyramid.config.Configurator.add_view

It seems the documentation has drifted apart, is there a way to simply pull the documentation from the source code and place it into that `viewconfig` narrative document? Is there a reason why that is duplicated?

I didn't verify any of the other predicates for inaccuracies, but I have a feeling that there is a bunch of gardening to be done here.

Cheers!
