### PR TITLE
Hand RepozeWho1AuthenticationPolicy.remember kwargs to repoze.who (1.5) #1249

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -336,12 +336,19 @@ class RepozeWho1AuthenticationPolicy(CallbackAuthenticationPolicy):
         return effective_principals
 
     def remember(self, request, principal, **kw):
-        """ Store the ``principal`` as ``repoze.who.userid``."""
+        """ Store the ``principal`` as ``repoze.who.userid``.
+        
+        The identity to authenticated to :mod:`repoze.who`
+        will contain the given principal as ``userid``, and
+        provide all keyword arguments as additional identity
+        keys. Useful keys could be ``max_age`` or ``userdata``.
+        """
         identifier = self._get_identifier(request)
         if identifier is None:
             return []
         environ = request.environ
-        identity = {'repoze.who.userid':principal}
+        identity = kw
+        identity['repoze.who.userid'] = principal
         return identifier.remember(environ, identity)
 
     def forget(self, request):

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -350,6 +350,14 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         self.assertEqual(result[0], request.environ)
         self.assertEqual(result[1], {'repoze.who.userid':'fred'})
 
+    def test_remember_kwargs(self):
+        authtkt = DummyWhoPlugin()
+        request = DummyRequest(
+            {'repoze.who.plugins':{'auth_tkt':authtkt}})
+        policy = self._makeOne()
+        result = policy.remember(request, 'fred', max_age=23)
+        self.assertEqual(result[1], {'repoze.who.userid':'fred', 'max_age': 23})
+
     def test_forget_no_plugins(self):
         request = DummyRequest({})
         policy = self._makeOne()


### PR DESCRIPTION
Documentation for pyramid.security.remember supports keyword arguments
to hand over to the authentication policy. However, when using
RepozeWho1AuthenticationPolicy, all of the kw were dropped in remember.

It is my understanding that with repoze.who, additional configuration
parameters shall be stored in the identity dictionary. In our case,
setting the max_age parameter to the authtkt identifier, would be done
using an identity {'repoze.who.userid':principal, 'max_age': 23}.

It seems sensible just to hand over kw through the identity dictionary
and all users to specify max_age or other parameters such as userdata.
