### PR TITLE
fix debug toolbar errors with pyramid_mako

### DIFF
--- a/pyramid/scaffolds/alchemy/development.ini_tmpl
+++ b/pyramid/scaffolds/alchemy/development.ini_tmpl
@@ -14,6 +14,7 @@ pyramid.default_locale_name = en
 pyramid.includes =
     pyramid_debugtoolbar
     pyramid_tm
+    pyramid_mako
 
 sqlalchemy.url = sqlite:///%(here)s/{{project}}.sqlite
 


### PR DESCRIPTION
Currently, clicking on the debug toolbar button on a fresh, unedited alchemy scaffold throws a series of Mako templating errors. Adding "pyramid_mako" to the list of includes in development.ini ensures that the toolbar functions as expected.
