### PR TITLE
Preserve order of views using "accept"

### DIFF
--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -552,9 +552,8 @@ class MultiView(object):
             else:
                 subset.append((order, view, phash))
                 subset.sort(key=operator.itemgetter(0))
-            accepts = set(self.accepts)
-            accepts.add(accept)
-            self.accepts = list(accepts) # dedupe
+            if accept not in self.accepts:
+                self.accepts.append(accept)
 
     def get_views(self, request):
         if self.accepts and hasattr(request, 'accept'):


### PR DESCRIPTION
Our code assumes that the first configured `accept` predicate will be picked if the client sends `Accept: */*` or no `Accept` header at all.  However, when multiple views are added with different `accept` values, they may be shuffled around by the current call to `set()` and the one selected by `Accept: */*` is not the first one configured.  This patch ensures the media types are offered in the same order they were configured in.
