### PR TITLE
Add integration tests for Unicode in URL

### DIFF
--- a/pyramid/tests/test_integration.py
+++ b/pyramid/tests/test_integration.py
@@ -659,6 +659,10 @@ class UnicodeInURLTest(unittest.TestCase):
         testapp = self._makeTestApp(config)
 
         res = testapp.get(request_path, status=404)
+
+        # Pyramid default 404 handler outputs:
+        # u'404 Not Found\n\nThe resource could not be found.\n\n\n'
+        # u'/avalia\xe7\xe3o_participante\n\n'
         self.assertTrue(request_path_unicode in res.text)
 
     def test_unicode_in_url_200(self):


### PR DESCRIPTION
Apologies if there are already tests for these cases, but I didn't see them.

These test a few cases where a URL contains Unicode characters in it -- a 404 and a 200. Both work fine.

The only thing that doesn't work is that if one calls `str(context)` in the `NotFound` handler, then you get a `UnicodeDecodeError`, but I guess this is reasonable; one should call `unicode(context)` instead I suppose.
