### PR TITLE
Strip redundant logging config from tutorial INI files.

### DIFF
--- a/docs/quick_tutorial/authentication/development.ini
+++ b/docs/quick_tutorial/authentication/development.ini
@@ -9,34 +9,3 @@ tutorial.secret = 98zd
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/authorization/development.ini
+++ b/docs/quick_tutorial/authorization/development.ini
@@ -9,34 +9,3 @@ tutorial.secret = 98zd
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/databases/development.ini
+++ b/docs/quick_tutorial/databases/development.ini
@@ -11,39 +11,3 @@ sqlalchemy.url = sqlite:///%(here)s/sqltutorial.sqlite
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial, sqlalchemy
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[logger_sqlalchemy]
-level = INFO
-handlers =
-qualname = sqlalchemy.engine
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/debugtoolbar/development.ini
+++ b/docs/quick_tutorial/debugtoolbar/development.ini
@@ -7,34 +7,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/forms/development.ini
+++ b/docs/quick_tutorial/forms/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/functional_testing/development.ini
+++ b/docs/quick_tutorial/functional_testing/development.ini
@@ -7,34 +7,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/ini/development.ini
+++ b/docs/quick_tutorial/ini/development.ini
@@ -5,34 +5,3 @@ use = egg:tutorial
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/jinja2/development.ini
+++ b/docs/quick_tutorial/jinja2/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/json/development.ini
+++ b/docs/quick_tutorial/json/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/more_view_classes/development.ini
+++ b/docs/quick_tutorial/more_view_classes/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/request_response/development.ini
+++ b/docs/quick_tutorial/request_response/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/retail_forms/development.ini
+++ b/docs/quick_tutorial/retail_forms/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/routing/development.ini
+++ b/docs/quick_tutorial/routing/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/sessions/development.ini
+++ b/docs/quick_tutorial/sessions/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/static_assets/development.ini
+++ b/docs/quick_tutorial/static_assets/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/templating/development.ini
+++ b/docs/quick_tutorial/templating/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/unit_testing/development.ini
+++ b/docs/quick_tutorial/unit_testing/development.ini
@@ -7,34 +7,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/view_classes/development.ini
+++ b/docs/quick_tutorial/view_classes/development.ini
@@ -8,34 +8,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration

--- a/docs/quick_tutorial/views/development.ini
+++ b/docs/quick_tutorial/views/development.ini
@@ -7,34 +7,3 @@ pyramid.includes =
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
-
-# Begin logging configuration
-
-[loggers]
-keys = root, tutorial
-
-[logger_tutorial]
-level = DEBUG
-handlers =
-qualname = tutorial
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = INFO
-handlers = console
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
-
-# End logging configuration


### PR DESCRIPTION
Leave it for the 'logging' and 'scaffolds' sections, where it is germane.
