### PR TITLE
Drop setup.cfg from scaffolds

### DIFF
--- a/docs/narr/MyProject/setup.cfg
+++ b/docs/narr/MyProject/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match = ^test
-nocapture = 1
-cover-package = myproject
-with-coverage = 1
-cover-erase = 1

--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -492,7 +492,6 @@ structure:
   │   ├── tests.py
   │   └── views.py
   ├── production.ini
-  ├── setup.cfg
   └── setup.py
 
 The ``MyProject`` :term:`Project`
@@ -514,9 +513,6 @@ describe, run, and test your application.
 
 #. ``production.ini`` is a :term:`PasteDeploy` configuration file that can
    be used to execute your application in a production configuration.
-
-#. ``setup.cfg`` is a :term:`setuptools` configuration file used by
-   ``setup.py``.
 
 #. ``MANIFEST.in`` is a :term:`distutils` "manifest" file, naming which files
    should be included in a source distribution of the package when ``python
@@ -744,24 +740,6 @@ For fun, you can try this command now:
 This will create a tarball of your application in a ``dist`` subdirectory
 named ``MyProject-0.1.tar.gz``.  You can send this tarball to other people
 who want to install and use your application.
-
-.. index::
-   single: setup.cfg
-
-``setup.cfg``
-~~~~~~~~~~~~~
-
-The ``setup.cfg`` file is a :term:`setuptools` configuration file.  It
-contains various settings related to testing and internationalization:
-
-Our generated ``setup.cfg`` looks like this:
-
-.. literalinclude:: MyProject/setup.cfg
-   :language: guess
-   :linenos:
-
-The values in the default setup file make the testing commands to work more
-smoothly.
 
 .. index::
    single: package

--- a/docs/quick_tour/awesome/setup.cfg
+++ b/docs/quick_tour/awesome/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match = ^test
-nocapture = 1
-cover-package = awesome
-with-coverage = 1
-cover-erase = 1

--- a/docs/quick_tour/package/setup.cfg
+++ b/docs/quick_tour/package/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match = ^test
-nocapture = 1
-cover-package = hello_world
-with-coverage = 1
-cover-erase = 1

--- a/docs/quick_tour/sqla_demo/setup.cfg
+++ b/docs/quick_tour/sqla_demo/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=sqla_demo
-with-coverage=1
-cover-erase=1

--- a/docs/quick_tutorial/scaffolds/setup.cfg
+++ b/docs/quick_tutorial/scaffolds/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match = ^test
-nocapture = 1
-cover-package = scaffolds
-with-coverage = 1
-cover-erase = 1

--- a/docs/tutorials/wiki/src/authorization/setup.cfg
+++ b/docs/tutorials/wiki/src/authorization/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki/src/basiclayout/setup.cfg
+++ b/docs/tutorials/wiki/src/basiclayout/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki/src/models/setup.cfg
+++ b/docs/tutorials/wiki/src/models/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki/src/tests/setup.cfg
+++ b/docs/tutorials/wiki/src/tests/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki/src/views/setup.cfg
+++ b/docs/tutorials/wiki/src/views/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki2/src/authorization/setup.cfg
+++ b/docs/tutorials/wiki2/src/authorization/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki2/src/basiclayout/setup.cfg
+++ b/docs/tutorials/wiki2/src/basiclayout/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki2/src/models/setup.cfg
+++ b/docs/tutorials/wiki2/src/models/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki2/src/tests/setup.cfg
+++ b/docs/tutorials/wiki2/src/tests/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/docs/tutorials/wiki2/src/views/setup.cfg
+++ b/docs/tutorials/wiki2/src/views/setup.cfg
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package=tutorial
-with-coverage=1
-cover-erase=1

--- a/pyramid/scaffolds/alchemy/setup.cfg_tmpl
+++ b/pyramid/scaffolds/alchemy/setup.cfg_tmpl
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package={{package}}
-with-coverage=1
-cover-erase=1

--- a/pyramid/scaffolds/starter/setup.cfg_tmpl
+++ b/pyramid/scaffolds/starter/setup.cfg_tmpl
@@ -1,6 +1,0 @@
-[nosetests]
-match = ^test
-nocapture = 1
-cover-package = {{package}}
-with-coverage = 1
-cover-erase = 1

--- a/pyramid/scaffolds/zodb/setup.cfg_tmpl
+++ b/pyramid/scaffolds/zodb/setup.cfg_tmpl
@@ -1,6 +1,0 @@
-[nosetests]
-match=^test
-nocapture=1
-cover-package={{package}}
-with-coverage=1
-cover-erase=1

--- a/pyramid/tests/test_scaffolds/fixture_scaffold/setup.cfg_tmpl
+++ b/pyramid/tests/test_scaffolds/fixture_scaffold/setup.cfg_tmpl
@@ -1,6 +1,0 @@
-[nosetests]
-match = ^test
-nocapture = 1
-cover-package = {{package}}
-with-coverage = 1
-cover-erase = 1


### PR DESCRIPTION
Since setup.cfg is no longer needed for Babel now that #1285 is merged and no scaffold or documentation references nose there is no need to keep them.
