### PR TITLE
Update python installation instructions for Mac OSX

### DIFF
--- a/docs/narr/install.rst
+++ b/docs/narr/install.rst
@@ -43,7 +43,10 @@ Alternatively, you can use the `homebrew <http://brew.sh/>`_ package manager.
 
 .. code-block:: text
 
+   # for python 2.7
    $ brew install python
+
+   # for python 3.4
    $ brew install python3
 
 If you use an installer for your Python, then you can skip to the section


### PR DESCRIPTION
The updated suggestion is to install via homebrew rather than compile from source.
