### PR TITLE
Modified the way anonymous commiters configure the remote, the older

### DIFF
--- a/HACKING.txt
+++ b/HACKING.txt
@@ -31,7 +31,7 @@ By Hand
    $ cd hack-on-pyramid
    # Configure remotes such that you can pull changes from the Pyramid
    # repository into your local repository.
-   $ git remote add upstream git@github.com:Pylons/pyramid.git
+   $ git remote add upstream https://github.com:Pylons/pyramid.git
    # fetch and merge changes from upstream into master
    $ git fetch upstream
    $ git merge upstream/master


### PR DESCRIPTION
version only worked for users with access to the repository as
commiters was modified to work with anonymous commiters.
