### PR TITLE
Fix: #1299 - Add PYTHONSTARTUP support to pshell

### DIFF
--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -2,6 +2,7 @@ from code import interact
 import optparse
 import sys
 import textwrap
+import os
 
 from pyramid.compat import configparser
 from pyramid.util import DottedNameResolver
@@ -173,6 +174,9 @@ class PShellCommand(object):
             cprt = 'Type "help" for more information.'
             banner = "Python %s on %s\n%s" % (sys.version, sys.platform, cprt)
             banner += '\n\n' + help + '\n'
+            pystartup = os.environ.get('PYTHONSTARTUP')
+            if pystartup and os.path.isfile(pystartup):
+                execfile(pystartup, env)
             interact(banner, local=env)
         return shell
 


### PR DESCRIPTION
This will load the `PYTHONSTARTUP` file.  It also handles injecting the globals in the `PYTHONSTARTUP` file into the interpreter.

There is at least one caveat wrt readline / tabbed completion.  In order to get tabbed completion working on modules that were imported once inside pshell, I had to add the following line to my `PYTHONSTARTUP` file:

``` python
readline.set_completer(rlcompleter.Completer(locals()).complete)
```

I am not sure why, but the normal python shell doesn't require that line to have tabbed completion work properly.
