### PR TITLE
More explicit example of set_property

### DIFF
--- a/docs/api/request.rst
+++ b/docs/api/request.rst
@@ -319,7 +319,13 @@
 
           def _connect(request):
               conn = request.registry.dbsession()
-              def cleanup(_):
+              def cleanup(request):
+                  # since version 1.5 request.exception is not more
+                  # eagerly cleared
+                  if request.exception is not None:
+                      conn.rollback()
+                  else:
+                      conn.commit()
                   conn.close()
               request.add_finished_callback(cleanup)
               return conn


### PR DESCRIPTION
cleanup callback has a "request" parameter (and not "_")
cleanup callback know (since 1.5) if an exception occurred or not (to commit or rollback)
