### PR TITLE
- Correct 80-column lines specification to 79 to be compliant with PEP8 ...

### DIFF
--- a/HACKING.txt
+++ b/HACKING.txt
@@ -149,7 +149,7 @@ Coding Style
 ------------
 
 - PEP8 compliance.  Whitespace rules are relaxed: not necessary to put
-  2 newlines between classes.  But 80-column lines, in particular, are
+  2 newlines between classes.  But 79-column lines, in particular, are
   mandatory.  See
   http://docs.pylonsproject.org/en/latest/community/codestyle.html for more
   information.


### PR DESCRIPTION
...and consistent with doc to which this line refers.
