### PR TITLE
Typo found in second Declarative code block

### DIFF
--- a/docs/narr/configuration.rst
+++ b/docs/narr/configuration.rst
@@ -114,7 +114,6 @@ in a package and its subpackages.  For example:
        return Response('Hello')
 
    if __name__ == '__main__':
-       from pyramid.config import Configurator
        config = Configurator()
        config.scan()
        app = config.make_wsgi_app()


### PR DESCRIPTION
There were two import statements for Configurator.
I removed the second import statement in the "**main**" since most of the
documentation declares all imports on the top of the source.

I verified the sample ran before submitting this really small and silly typo.  
It threw me for a loop so I figured I'd try to fix it.

```
modified:   configuration.rst
```
