### PR TITLE
Update hooks.rst

### DIFF
--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -1023,7 +1023,7 @@ method:
     :linenos:
 
     class simple_tween_factory(object):
-        def __init__(handler, registry):
+        def __init__(self, handler, registry):
             self.handler = handler
             self.registry = registry
 


### PR DESCRIPTION
'self' param was omitted in the constructor of simple_tween_factory class

(Forward port #1340 to master)
