### PR TITLE
force default sessions to set the vary header for cookies

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,16 @@
 Next release
 ============
 
+Security Fixes
+--------------
+
+- When using the ``SignedCookieSessionFactory`` or the
+  ``UnencryptedCookieSessionFactoryConfig`` session factories, the "Vary"
+  header was not being set on the response. This could lead to information
+  disclosure and could be a vector for cache poisoning in certain situations
+  where caches might store the response and serve it for requests attached
+  to different sessions.
+
 Bug Fixes
 ---------
 

--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -373,6 +373,10 @@ def BaseCookieSessionFactory(
                     'Cookie value is too long to store (%s bytes)' %
                     len(cookieval)
                     )
+            if response.vary is None:
+                response.vary = ['Cookie']
+            elif 'cookie' not in set(v.lower() for v in response.vary):
+                response.vary = list(response.vary) + ['Cookie']
             response.set_cookie(
                 self._cookie_name,
                 value=cookieval,

--- a/pyramid/tests/test_session.py
+++ b/pyramid/tests/test_session.py
@@ -117,6 +117,38 @@ class SharedCookieSessionTests(object):
         self.assertEqual(session._set_cookie(response), True)
         self.assertEqual(response.headerlist[-1][0], 'Set-Cookie')
 
+    def test__set_cookie_sets_vary_header(self):
+        import webob
+        request = testing.DummyRequest()
+        session = self._makeOne(request)
+        session['abc'] = 'x'
+        response = webob.Response()
+        self.assertEqual(session._set_cookie(response), True)
+        self.assertEqual(response.headerlist[-1][0], 'Set-Cookie')
+        self.assertEqual(response.headerlist[-2], ('Vary', 'Cookie'))
+
+    def test__set_cookie_extends_vary_header(self):
+        import webob
+        request = testing.DummyRequest()
+        session = self._makeOne(request)
+        session['abc'] = 'x'
+        response = webob.Response()
+        response.vary = ['Accept']
+        self.assertEqual(session._set_cookie(response), True)
+        self.assertEqual(response.headerlist[-1][0], 'Set-Cookie')
+        self.assertEqual(response.headerlist[-2], ('Vary', 'Accept, Cookie'))
+
+    def test__set_cookie_keeps_vary_header(self):
+        import webob
+        request = testing.DummyRequest()
+        session = self._makeOne(request)
+        session['abc'] = 'x'
+        response = webob.Response()
+        response.vary = ['Cookie', 'Accept']
+        self.assertEqual(session._set_cookie(response), True)
+        self.assertEqual(response.headerlist[-1][0], 'Set-Cookie')
+        self.assertEqual(response.headerlist[-2], ('Vary', 'Cookie, Accept'))
+
     def test__set_cookie_options(self):
         from pyramid.response import Response
         request = testing.DummyRequest()
@@ -674,5 +706,6 @@ class DummySessionFactory(dict):
         self._dirty = True
 
 class DummyResponse(object):
+    vary = None
     def __init__(self):
         self.headerlist = []


### PR DESCRIPTION
related https://www.djangoproject.com/weblog/2014/may/14/security-releases-issued/
