### PR TITLE
Fixes missing arguments to view_config

### DIFF
--- a/docs/narr/configuration.rst
+++ b/docs/narr/configuration.rst
@@ -109,7 +109,8 @@ in a package and its subpackages.  For example:
    from pyramid.response import Response
    from pyramid.view import view_config
 
-   @view_config()
+
+   @view_config(name='hello', request_method='GET')
    def hello(request):
        return Response('Hello')
 


### PR DESCRIPTION
The documentation following the change mentions the arguments 
to view_config but the code sample doesn't have any.
