### PR TITLE
Correct handler name for logger_wsgi

### DIFF
--- a/docs/narr/logging.rst
+++ b/docs/narr/logging.rst
@@ -377,7 +377,7 @@ FileHandler to the list of handlers (named ``accesslog``), and ensure that the
 
     [logger_wsgi] 
     level = INFO 
-    handlers = handler_accesslog
+    handlers = accesslog
     qualname = wsgi 
     propagate = 0 
 


### PR DESCRIPTION
Encounter startup error if not correct config
