### PR TITLE
Query string arg names starting with equal sign

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -232,3 +232,5 @@ Contributors
 - Amit Mane, 2014/01/23
 
 - Fenton Travers, 2014/05/06
+
+- Timur Izhbulatov, 2015/04/14

--- a/pyramid/config/predicates.py
+++ b/pyramid/config/predicates.py
@@ -70,7 +70,7 @@ class RequestParamPredicate(object):
         for p in val:
             k = p
             v = None
-            if '=' in p and not (p.startswith('=') or p.endswith('=')):
+            if '=' in p and not p.startswith('='):
                 k, v = p.split('=', 1)
                 k, v = k.strip(), v.strip()
             reqs.append((k, v))

--- a/pyramid/config/predicates.py
+++ b/pyramid/config/predicates.py
@@ -70,7 +70,7 @@ class RequestParamPredicate(object):
         for p in val:
             k = p
             v = None
-            if '=' in p:
+            if '=' in p and not (p.startswith('=') or p.endswith('=')):
                 k, v = p.split('=', 1)
                 k, v = k.strip(), v.strip()
             reqs.append((k, v))

--- a/pyramid/config/predicates.py
+++ b/pyramid/config/predicates.py
@@ -70,8 +70,11 @@ class RequestParamPredicate(object):
         for p in val:
             k = p
             v = None
-            if '=' in p and not p.startswith('='):
-                k, v = p.split('=', 1)
+            if '=' in p:
+                if p.startswith('='):
+                    k, v = p.rsplit('=', 1)
+                else:
+                    k, v = p.split('=', 1)
                 k, v = k.strip(), v.strip()
             reqs.append((k, v))
         self.val = val

--- a/pyramid/tests/test_config/test_predicates.py
+++ b/pyramid/tests/test_config/test_predicates.py
@@ -157,8 +157,8 @@ class TestRequestParamPredicate(unittest.TestCase):
         self.assertEqual(inst.text(), 'request_param abc=1,def')
 
     def test_text_multi_equal_sign(self):
-        inst = self._makeOne(('abc=  1', '=def'))
-        self.assertEqual(inst.text(), 'request_param =def,abc=1')
+        inst = self._makeOne(('abc=  1', '=def= 2'))
+        self.assertEqual(inst.text(), 'request_param =def=2,abc=1')
 
     def test_phash_exists(self):
         inst = self._makeOne('abc')

--- a/pyramid/tests/test_config/test_predicates.py
+++ b/pyramid/tests/test_config/test_predicates.py
@@ -144,6 +144,10 @@ class TestRequestParamPredicate(unittest.TestCase):
         inst = self._makeOne('abc')
         self.assertEqual(inst.text(), 'request_param abc')
 
+    def test_text_exists_equal_sign(self):
+        inst = self._makeOne('=abc')
+        self.assertEqual(inst.text(), 'request_param =abc')
+
     def test_text_withval(self):
         inst = self._makeOne('abc=  1')
         self.assertEqual(inst.text(), 'request_param abc=1')
@@ -152,9 +156,17 @@ class TestRequestParamPredicate(unittest.TestCase):
         inst = self._makeOne(('abc=  1', 'def'))
         self.assertEqual(inst.text(), 'request_param abc=1,def')
 
+    def test_text_multi_equal_sign(self):
+        inst = self._makeOne(('abc=  1', '=def'))
+        self.assertEqual(inst.text(), 'request_param =def,abc=1')
+
     def test_phash_exists(self):
         inst = self._makeOne('abc')
         self.assertEqual(inst.phash(), 'request_param abc')
+
+    def test_phash_exists_equal_sign(self):
+        inst = self._makeOne('=abc')
+        self.assertEqual(inst.phash(), 'request_param =abc')
 
     def test_phash_withval(self):
         inst = self._makeOne('abc=   1')


### PR DESCRIPTION
I use %3D (URL encoded equal sign) prefix in argument name for filter parametrization:

    GET /users?%3Dphone_number=1234567

Since request_param supports matching specific values with equal sign syntax, this doesn't work when route registered with explicit filter args names in request_param.