### PR TITLE
Additional HTTP Status Codes

### DIFF
--- a/pyramid/httpexceptions.py
+++ b/pyramid/httpexceptions.py
@@ -63,7 +63,6 @@ Exception
         * 504 - HTTPGatewayTimeout
         * 505 - HTTPVersionNotSupported
         * 507 - HTTPInsufficientStorage
-        * 511 - HTTPNetworkAuthenticationRequired
 
 HTTP exceptions are also :term:`response` objects, thus they accept most of
 the same parameters that can be passed to a regular


### PR DESCRIPTION
HTTP Status codes from [RFC 6585](http://tools.ietf.org/html/rfc6585),
Especially _429 - Too Many Requests_ is pretty useful for APIs, I think it is worth including.
I did not implement _511 - Network Authentication Required_ because it is 

> for use by intercepting proxies that are interposed as a means of controlling access to the network.
