### PR TITLE
Exceptions with Accept-Type application/json will return JSON type error.

### DIFF
--- a/pyramid/tests/test_httpexceptions.py
+++ b/pyramid/tests/test_httpexceptions.py
@@ -187,6 +187,37 @@ class TestHTTPException(unittest.TestCase):
         self.assertTrue(start_response.headerlist)
         self.assertEqual(start_response.status, '200 OK')
 
+    def test_call_with_accept_json_returns_json(self):
+        # optimization
+        cls = self._getTargetSubclass()
+        exc = cls(detail={'test': 'test2'})
+        environ = _makeEnviron()
+        environ['HTTP_ACCEPT'] = 'application/json'
+        start_response = DummyStartResponse()
+        app_iter = exc(environ, start_response)
+        self.assertTrue(('Content-Type', 'application/json; charset=UTF-8' ) in start_response.headerlist)
+        self.assertEqual(app_iter[0], exc.body)
+
+    def test_call_with_accept_json_returns_string(self):
+        cls = self._getTargetSubclass()
+        exc = cls(detail='test')
+        environ = _makeEnviron()
+        environ['HTTP_ACCEPT'] = 'application/json'
+        start_response = DummyStartResponse()
+        app_iter = exc(environ, start_response)
+        self.assertTrue(('Content-Type', 'application/json; charset=UTF-8' ) in start_response.headerlist)
+        self.assertEqual(app_iter[0], exc.body)
+
+    def test_call_with_accept_html_returns_html(self):
+        # optimization
+        cls = self._getTargetSubclass()
+        exc = cls()
+        environ = _makeEnviron()
+        environ['HTTP_ACCEPT'] = 'text/html'
+        start_response = DummyStartResponse()
+        app_iter = exc(environ, start_response)
+        self.assertTrue(('Content-Type', 'text/html; charset=UTF-8' ) in start_response.headerlist)
+
     def test_call_returns_same_body_called_twice(self):
         # optimization
         cls = self._getTargetSubclass()
@@ -366,4 +397,5 @@ def _makeEnviron(**kw):
                'SERVER_PORT':'80'}
     environ.update(kw)
     return environ
+
 


### PR DESCRIPTION
* had to implement the server_quality because of failing tests. text/html is preferred. (test test__default_app_iter_with_comment_html)
* because of the server_quality I had to check if the match was in the range of html_types or json_types (using the tuple)
* the json is returning immediately, because no use of "templated" arguments and adding comments is invalid to json spec
* the check for accept at html_types is because of compatibility (with tests), when no accept exists, plain will be default.
* moved the import json to above the pyramid imports
* some fixes becaus of python3 compatibility