### PR TITLE
Update i18n.rst

### DIFF
--- a/docs/narr/i18n.rst
+++ b/docs/narr/i18n.rst
@@ -326,7 +326,7 @@ application.  You run a ``pot-create`` command to extract the messages:
 
    $ cd /place/where/myapplication/setup.py/lives
    $ mkdir -p myapplication/locale
-   $ $VENV/bin/pot-create src > myapplication/locale/myapplication.pot
+   $ $VENV/bin/pot-create -o myapplication/locale/myapplication.pot src
 
 The message catalog ``.pot`` template will end up in:
 


### PR DESCRIPTION
To set output file for pot-create -o flag should be used, not redirect.
