### PR TITLE
Update i18n.rst

### DIFF
--- a/docs/narr/i18n.rst
+++ b/docs/narr/i18n.rst
@@ -402,11 +402,11 @@ command from Gettext:
 .. code-block:: text
 
    $ cd /place/where/myapplication/setup.py/lives
-   $ msgfmt myapplication/locale/*/LC_MESSAGES/*.po
+   $ msgfmt -o myapplication/locale/es/LC_MESSAGES/myapplication.mo myapplication/locale/es/LC_MESSAGES/myapplication.po
 
 This will create a ``.mo`` file for each ``.po`` file in your
 application.  As long as the :term:`translation directory` in which
-the ``.mo`` file ends up in is configured into your application, these
+the ``.mo`` file ends up in is configured into your application (see :ref:`adding_a_translation_directory`), these
 translations will be available to :app:`Pyramid`.
 
 .. index::


### PR DESCRIPTION
msgfmt produces 'messages.mo' file in current dir by default, it needs -o to specify destination. Also, added ref to adding a translation directory.
