### PR TITLE
pcreate output_dir: base dir name 'pyramid' is forbidden

### DIFF
--- a/pyramid/scaffolds/__init__.py
+++ b/pyramid/scaffolds/__init__.py
@@ -18,10 +18,6 @@ class PyramidTemplate(Template):
         misnamings (such as naming a package "site" or naming a package
         logger "root".
         """
-        if vars['package'] == 'site':
-            raise ValueError('Sorry, you may not name your package "site". '
-                             'The package name "site" has a special meaning in '
-                             'Python.  Please name it anything except "site".')
         vars['random_string'] = native_(binascii.hexlify(os.urandom(20)))
         package_logger = vars['package']
         if package_logger == 'root':

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -74,6 +74,11 @@ class PCreateCommand(object):
         if diff:
             self.out('Unavailable scaffolds: %s' % list(diff))
             return 2
+        output_dir = os.path.abspath(os.path.normpath(self.args[0]))
+        if 'pyramid' == os.path.basename(output_dir):
+            self.out("You must change output_dir. Base dir name 'pyramid' is forbidden.")
+            return 2
+
         return self.render_scaffolds()
 
     def render_scaffolds(self):

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -10,6 +10,10 @@ import re
 import sys
 
 _bad_chars_re = re.compile('[^a-zA-Z0-9_]')
+_package_names_blacklist = ('site', 'pyramid')
+
+class _BadInputError(Exception):
+    """Bad input for PCreateCommand"""
 
 def main(argv=sys.argv, quiet=False):
     command = PCreateCommand(argv, quiet)
@@ -63,20 +67,11 @@ class PCreateCommand(object):
     def run(self):
         if self.options.list:
             return self.show_scaffolds()
-        if not self.options.scaffold_name:
-            self.out('You must provide at least one scaffold name')
-            return 2
-        if not self.args:
-            self.out('You must provide a project name')
-            return 2
-        available = [x.name for x in self.scaffolds]
-        diff = set(self.options.scaffold_name).difference(available)
-        if diff:
-            self.out('Unavailable scaffolds: %s' % list(diff))
-            return 2
-        output_dir = os.path.abspath(os.path.normpath(self.args[0]))
-        if 'pyramid' == os.path.basename(output_dir):
-            self.out("You must change output_dir. Base dir name 'pyramid' is forbidden.")
+
+        try:
+            self._validate_input()
+        except _BadInputError as exception:
+            self.out(str(exception))
             return 2
 
         return self.render_scaffolds()
@@ -149,6 +144,25 @@ class PCreateCommand(object):
     def out(self, msg): # pragma: no cover
         if not self.quiet:
             print(msg)
+
+    def _validate_input(self):
+        if not self.options.scaffold_name:
+            raise _BadInputError('You must provide at least one scaffold name')
+
+        if not self.args:
+            raise _BadInputError('You must provide a project name')
+
+        available = [x.name for x in self.scaffolds]
+        diff = set(self.options.scaffold_name).difference(available)
+        if diff:
+            raise _BadInputError('Unavailable scaffolds: %s' % list(diff))
+
+        output_dir = os.path.abspath(os.path.normpath(self.args[0]))
+        project_name = os.path.basename(os.path.split(output_dir)[1])
+        pkg_name = _bad_chars_re.sub('', project_name.lower())
+        if pkg_name in _package_names_blacklist:
+            raise _BadInputError('Sorry, you may not name your package "%s". Please name it anything except: %s.'
+                                 % (pkg_name, ', '.join(_package_names_blacklist)))
 
 if __name__ == '__main__': # pragma: no cover
     sys.exit(main() or 0)

--- a/pyramid/tests/test_scaffolds/test_init.py
+++ b/pyramid/tests/test_scaffolds/test_init.py
@@ -12,11 +12,6 @@ class TestPyramidTemplate(unittest.TestCase):
         self.assertTrue(vars['random_string'])
         self.assertEqual(vars['package_logger'], 'one')
 
-    def test_pre_site(self):
-        inst = self._makeOne()
-        vars = {'package':'site'}
-        self.assertRaises(ValueError, inst.pre, 'command', 'output dir', vars)
-        
     def test_pre_root(self):
         inst = self._makeOne()
         vars = {'package':'root'}

--- a/pyramid/tests/test_scripts/test_pcreate.py
+++ b/pyramid/tests/test_scripts/test_pcreate.py
@@ -56,17 +56,21 @@ class TestPCreateCommand(unittest.TestCase):
         out = self.out_.getvalue()
         self.assertTrue(out.startswith('Unavailable scaffolds'))
 
-    def test_output_base_dir_name_pyramid_is_forbidden(self):
-        import os
-        path = os.path.abspath('pyramid')
-        cmd = self._makeOne('-s', 'dummy', path)
+    def test_site_package_name_site_is_forbidden(self):
+        self._site_package_name_is_forbidden('site')
+
+    def test_site_package_name_pyramid_is_forbidden(self):
+        self._site_package_name_is_forbidden('pyramid')
+
+    def _site_package_name_is_forbidden(self, forbidden_package_name):
+        cmd = self._makeOne('-s', 'dummy', forbidden_package_name)
         scaffold = DummyScaffold('dummy')
         cmd.scaffolds = [scaffold]
         cmd.pyramid_dist = DummyDist("0.1")
         result = cmd.run()
         self.assertEqual(result, 2)
         out = self.out_.getvalue()
-        self.assertEquals(out, "You must change output_dir. Base dir name 'pyramid' is forbidden.")
+        self.assertTrue(out.startswith('Sorry, you may not name your package "%s".' % forbidden_package_name), out)
 
     def test_known_scaffold_single_rendered(self):
         import os

--- a/pyramid/tests/test_scripts/test_pcreate.py
+++ b/pyramid/tests/test_scripts/test_pcreate.py
@@ -56,6 +56,18 @@ class TestPCreateCommand(unittest.TestCase):
         out = self.out_.getvalue()
         self.assertTrue(out.startswith('Unavailable scaffolds'))
 
+    def test_output_base_dir_name_pyramid_is_forbidden(self):
+        import os
+        path = os.path.abspath('pyramid')
+        cmd = self._makeOne('-s', 'dummy', path)
+        scaffold = DummyScaffold('dummy')
+        cmd.scaffolds = [scaffold]
+        cmd.pyramid_dist = DummyDist("0.1")
+        result = cmd.run()
+        self.assertEqual(result, 2)
+        out = self.out_.getvalue()
+        self.assertEquals(out, "You must change output_dir. Base dir name 'pyramid' is forbidden.")
+
     def test_known_scaffold_single_rendered(self):
         import os
         cmd = self._makeOne('-s', 'dummy', 'Distro')


### PR DESCRIPTION
Solution for issue https://github.com/Pylons/pyramid/issues/1357 where pcreate creates project named pyramid.

New behavior:
```
$ virtualenv pyramid
$ cd pyramid
$ . bin/activate
$ pip install pyramid
$ pcreate -s starter .
You must change output_dir. Base dir name 'pyramid' is forbidden.
```