### PR TITLE
remove unnecessary use of `get_current_registry()`

### DIFF
--- a/docs/narr/i18n.rst
+++ b/docs/narr/i18n.rst
@@ -792,9 +792,11 @@ Then as a part of the code of a custom :term:`locale negotiator`:
 .. code-block:: python
    :linenos:
 
-   from pyramid.threadlocal import get_current_registry
-   settings = get_current_registry().settings
-   languages = settings['available_languages'].split()
+   from pyramid.settings import aslist
+
+   def my_locale_negotiator(request):
+       languages = aslist(request.registry.settings['available_languages'])
+       # ...
 
 This is only a suggestion.  You can create your own "available
 languages" configuration scheme as necessary.


### PR DESCRIPTION
- We have a request object, so get the current registry
  properly through it.
- make use of the built-in `aslist` function for parsing the result
