### PR TITLE
Additional HTTP Status Codes

### DIFF
--- a/docs/api/httpexceptions.rst
+++ b/docs/api/httpexceptions.rst
@@ -99,6 +99,8 @@
 
   .. autoclass:: HTTPRequestHeaderFieldsTooLarge
 
+  .. autoclass:: HTTPUnavailableForLegalReasons
+
   .. autoclass:: HTTPInternalServerError
 
   .. autoclass:: HTTPNotImplemented

--- a/pyramid/httpexceptions.py
+++ b/pyramid/httpexceptions.py
@@ -55,6 +55,7 @@ Exception
         * 428 - HTTPPreconditionRequired
         * 429 - HTTPTooManyRequests
         * 431 - HTTPRequestHeaderFieldsTooLarge
+        * 451 - HTTPUnavailableForLegalReasons
       HTTPServerError
         * 500 - HTTPInternalServerError
         * 501 - HTTPNotImplemented
@@ -956,6 +957,25 @@ class HTTPRequestHeaderFieldsTooLarge(HTTPClientError):
     title = 'Request Header Fields Too Large'
     explanation = (
         'The request header fields were too large')
+
+class HTTPUnavailableForLegalReasons(HTTPClientError):
+    """
+    subclass of :class:`~HTTPClientError`
+
+    This indicates that the server is unable to process the request
+    because of legal reasons, e.g. censorship or government-mandated
+    blocked access.
+
+    From the draft "A New HTTP Status Code for Legally-restricted Resources"
+    by Tim Bray:
+
+    http://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-00
+
+    code: 451, title: Unavailable For Legal Reasons
+    """
+    code = 451
+    title = 'Unavailable For Legal Reasons'
+    explanation = ('The resource is not available due to legal reasons.')
 
 ############################################################
 ## 5xx Server Error


### PR DESCRIPTION
This pull request adds HTTP status codes 428 Precondition Required, 429 Too Many Requests, 431 Request Header Fields Too Large, and 511 Network Authentication Required from [Additional HTTP Status Code (RFC 6585)](http://tools.ietf.org/html/rfc6585) and 451 Unavailable For Legal Reasons from [An HTTP Status Code to Report Legal Obstacles Draft](http://tools.ietf.org/html/draft-tbray-http-legally-restricted-status-04).

The 451 status code is in separate commit since I'm not quite sure this status code should really be there, given the nature of the status code and the draft status of its specification. Let me know if you want a separate pull request without 451.

Codes taken from WebOb.
