### PR TITLE
to demo i18n improvements

### DIFF
--- a/pyramid/i18n.py
+++ b/pyramid/i18n.py
@@ -141,7 +141,8 @@ def default_locale_negotiator(request):
             i.split(None, maxsplit=1)
             for i in aslist(
                 request.registry.settings.get(
-                    'pyramid.available_languages'
+                    'pyramid.available_languages',
+                    []
                 ),
                 flatten=False
             )

--- a/pyramid/i18n.py
+++ b/pyramid/i18n.py
@@ -21,6 +21,7 @@ from pyramid.interfaces import (
     )
 
 from pyramid.threadlocal import get_current_registry
+from pyramid.settings import aslist
 
 class Localizer(object):
     """

--- a/pyramid/i18n.py
+++ b/pyramid/i18n.py
@@ -136,11 +136,16 @@ def default_locale_negotiator(request):
     name = '_LOCALE_'
 
     # TODO: this needs to be moved to Configurator
+    try:
+        registry = request.registry
+    except AttributeError:
+        registry = get_current_registry()
+        
     available_languages = dict(
         [
             i.split(None, maxsplit=1)
             for i in aslist(
-                request.registry.settings.get(
+                registry.settings.get(
                     'pyramid.available_languages',
                     []
                 ),
@@ -160,9 +165,12 @@ def default_locale_negotiator(request):
 
     # try matching HTTP Accept-Language request header
     if locale_name is None:
-        locale_name = request.accept_language.best_match(
-            available_languages
-        )
+        try:
+            locale_name = request.accept_language.best_match(
+                available_languages
+            )
+        except AttributeError:
+            pass
 
     return locale_name
 

--- a/pyramid/i18n.py
+++ b/pyramid/i18n.py
@@ -133,11 +133,35 @@ def default_locale_negotiator(request):
       :term:`default locale name` should be used.)
     """
     name = '_LOCALE_'
+
+    # TODO: this needs to be moved to Configurator
+    available_languages = dict(
+        [
+            i.split(None, maxsplit=1)
+            for i in aslist(
+                request.registry.settings.get(
+                    'pyramid.available_languages'
+                ),
+                flatten=False
+            )
+        ]
+    )
+
     locale_name = getattr(request, name, None)
     if locale_name is None:
         locale_name = request.params.get(name)
         if locale_name is None:
             locale_name = request.cookies.get(name)
+
+    if len(available_languages) > 0 and locale_name not in available_languages:
+        locale_name = None
+
+    # try matching HTTP Accept-Language request header
+    if locale_name is None:
+        locale_name = request.accept_language.best_match(
+            available_languages
+        )
+
     return locale_name
 
 def negotiate_locale_name(request):


### PR DESCRIPTION
I don't seem to be getting my point across very well in #1398
so I'm throwing together this PR to demonstrate what I'm saying.

The default_locale_negotiator now looks at a
`pyramid.available_languages` value to know what possible languages
values are acceptable.  Also, it will now use that value to match
against `Accept-Language` http request headers if no `_LOCALE_` value
is found.

Backwards compatibility:  If no `pyramid.available_languages` is set
then the `_LOCALE_` value is returned as before or `None`.
(The `Accept-Language` is ignored as there's nothing to match
against)

Obviously this needs some work, docs, and tests...  I thought it'd
be easier to see what I was talking about with a solid example.

The `pyramid.available_languages` is in this form:

```
pyramid.available_languages = 
    en English
    en-US English (United States)
    fr French
    pr-BR Portuguese (Brazil)
```
