### PR TITLE
Change helloworld to myapp

### DIFF
--- a/docs/narr/logging.rst
+++ b/docs/narr/logging.rst
@@ -242,7 +242,7 @@ level is set to ``INFO``, whereas the application's log level is set to
     [logger_myapp] 
     level = DEBUG 
     handlers = 
-    qualname = helloworld 
+    qualname = myapp 
 
 All of the child loggers of the ``myapp`` logger will inherit the ``DEBUG``
 level unless they're explicitly set differently. Meaning the ``myapp.views``,


### PR DESCRIPTION
Fix a typo in the documentation.

Closes #1408
