### PR TITLE
Support returning app_iter from renderer.

### DIFF
--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -456,6 +456,10 @@ class RendererHelper(object):
         if result is not None:
             if isinstance(result, text_type):
                 response.text = result
+            elif isinstance(result, bytes):
+                response.body = result
+            elif hasattr(result, '__iter__'):
+                response.app_iter = result
             else:
                 response.body = result
 

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -191,8 +191,8 @@ class TestRendererHelper(unittest.TestCase):
         helper = self._makeOne('loo.foo')
         response = helper.render_to_response('values', {},
                                              request=request)
-        self.assertEqual(response.body[0], 'values')
-        self.assertEqual(response.body[1], {})
+        self.assertEqual(response.app_iter[0], 'values')
+        self.assertEqual(response.app_iter[1], {})
 
     def test_get_renderer(self):
         factory = self._registerRendererFactory()
@@ -209,8 +209,8 @@ class TestRendererHelper(unittest.TestCase):
         request = testing.DummyRequest()
         response = 'response'
         response = helper.render_view(request, response, view, context)
-        self.assertEqual(response.body[0], 'response')
-        self.assertEqual(response.body[1],
+        self.assertEqual(response.app_iter[0], 'response')
+        self.assertEqual(response.app_iter[1],
                           {'renderer_info': helper,
                            'renderer_name': 'loo.foo',
                            'request': request,
@@ -286,6 +286,23 @@ class TestRendererHelper(unittest.TestCase):
         la = text_('/La Pe\xc3\xb1a', 'utf-8')
         response = helper._make_response(la.encode('utf-8'), request)
         self.assertEqual(response.body, la.encode('utf-8'))
+
+    def test__make_response_result_is_iterable(self):
+        from pyramid.response import Response
+        request = testing.DummyRequest()
+        request.response = Response()
+        helper = self._makeOne('loo.foo')
+        la = text_('/La Pe\xc3\xb1a', 'utf-8')
+        response = helper._make_response([la.encode('utf-8')], request)
+        self.assertEqual(response.body, la.encode('utf-8'))
+
+    def test__make_response_result_is_other(self):
+        self._registerResponseFactory()
+        request = None
+        helper = self._makeOne('loo.foo')
+        result = object()
+        response = helper._make_response(result, request)
+        self.assertEqual(response.body, result)
 
     def test__make_response_result_is_None_no_body(self):
         from pyramid.response import Response


### PR DESCRIPTION
Sets `response.app_iter = result` for renderer results which are not text, bytes or None.

My motivating case here is that rendering very large json responses can lead to 'memory leaks' where python is unable to release the space required for the large string back to the OS. This causes process size to increase as it allocates first 100MB for a large json response, then later for a slightly larger json response, it allocates say 105MB, then 115MB... (These allocations are visible in /proc/<pid>/smaps.)

My hope is that by using using json serializer that returns an iterable these large string allocations will not be required:

```
class JSONResult(object):
    def __init__(self):
        self.app_iter = []
        self.write = self.app_iter.append

    @classmethod
    def serializer(cls, value, **kw):
        fp = cls()
        json.dump(value, fp, **kw)
        return fp.app_iter


json_renderer = pyramid.renderers.JSON(serializer=JSONResult.serializer)
```