### PR TITLE
Minor edits to Templating With jinja2

### DIFF
--- a/docs/quick_tutorial/jinja2.rst
+++ b/docs/quick_tutorial/jinja2.rst
@@ -20,8 +20,8 @@ Objectives
 Steps
 =====
 
-#. In this step let's start by installing the ``pyramid_jinja2``
-   add-on, the copying the ``view_class`` step's directory:
+#. In this step let's start by copying the ``view_class`` step's 
+   directory, and then installing the ``pyramid_jinja2`` add-on. 
 
    .. code-block:: bash
 
@@ -71,9 +71,6 @@ in the add-on. In this case the setup code told Pyramid to make a new
 Our view code stayed largely the same. We simply changed the file
 extension on the renderer. For the template, the syntax for Chameleon
 and Jinja2's basic variable insertion is very similar.
-
-Our functional tests don't have ``development.ini`` so they needed the
-``pyramid.includes`` to be setup in the test setup.
 
 Extra Credit
 ============


### PR DESCRIPTION
- Fix grammar, order of operations in step 1.
- Remove Analysis section reference to pyramid.includes in functional
  tests, which is no longer accurate.
