### PR TITLE
Update documentation for HTTP exceptions (Remove WebDAV only)

### DIFF
--- a/pyramid/httpexceptions.py
+++ b/pyramid/httpexceptions.py
@@ -868,7 +868,12 @@ class HTTPUnprocessableEntity(HTTPClientError):
     subclass of :class:`~HTTPClientError`
 
     This indicates that the server is unable to process the contained
-    instructions. Only for WebDAV.
+    instructions. 
+
+    May be used to notify the client that their JSON/XML is well formed, but
+    not correct for the current request.
+
+    See RFC4918 section 11 for more information.
     
     code: 422, title: Unprocessable Entity
     """
@@ -881,7 +886,7 @@ class HTTPLocked(HTTPClientError):
     """
     subclass of :class:`~HTTPClientError`
 
-    This indicates that the resource is locked. Only for WebDAV
+    This indicates that the resource is locked.
     
     code: 423, title: Locked
     """
@@ -896,7 +901,6 @@ class HTTPFailedDependency(HTTPClientError):
 
     This indicates that the method could not be performed because the
     requested action depended on another action and that action failed.
-    Only for WebDAV.
     
     code: 424, title: Failed Dependency
     """


### PR DESCRIPTION
This was brought up by https://github.com/Pylons/webob/issues/169 but is something I was thinking earlier this week as well while building my latest app.

There is no reason why these HTTP Exceptions should be labeled WebDAV only, especially since browsers treat them correctly even if it is not WebDAV. This also makes sense for REST API's where having at least 422 (Unprocessable Entity) be available makes a lot of sense because it gives a better signal back to the client than 400 (Bad Request).
