### PR TITLE
backport #1438 from master to 1.5-branch

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -749,8 +749,15 @@ Glossary
      made.  For example the word "java" might be translated
      differently if the translation domain is "programming-languages"
      than would be if the translation domain was "coffee".  A
-     translation domain is represnted by a collection of ``.mo`` files
+     translation domain is represented by a collection of ``.mo`` files
      within one or more :term:`translation directory` directories.
+
+   Translation Context
+     A string representing the "context" in which a translation was
+     made within a given :term:`translation domain`. See the gettext
+     documentation, `11.2.5 Using contexts for solving ambiguities
+     <https://www.gnu.org/software/gettext/manual/gettext.html#Contexts>`_
+     for more information.
 
    Translator
      A callable which receives a :term:`translation string` and returns a


### PR DESCRIPTION
- add Translation Context term to Glossary to allow Sphinx to build docs, in reference to a recent update in the docstrings to the package translationstring https://github.com/Pylons/translationstring/blame/master/translationstring/__init__.py#L50
