### PR TITLE
Format proutes output and include module instead of repr of view

### DIFF
--- a/pyramid/tests/test_scripts/test_proutes.py
+++ b/pyramid/tests/test_scripts/test_proutes.py
@@ -123,8 +123,11 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
         compare_to = L[-1].split()[:3]
-        self.assertEqual(compare_to, ['a', '/a', '<function'])
-        
+        self.assertEqual(
+            compare_to,
+            ['a', '/a', 'pyramid.tests.test_scripts.test_proutes.view']
+        )
+
     def test_single_route_one_view_registered_with_factory(self):
         from zope.interface import Interface
         from pyramid.registry import Registry
@@ -161,7 +164,7 @@ class TestPRoutesCommand(unittest.TestCase):
         registry = Registry()
         result = command._get_mapper(registry)
         self.assertEqual(result.__class__, RoutesMapper)
-        
+
 class Test_main(unittest.TestCase):
     def _callFUT(self, argv):
         from pyramid.scripts.proutes import main
@@ -170,4 +173,3 @@ class Test_main(unittest.TestCase):
     def test_it(self):
         result = self._callFUT(['proutes'])
         self.assertEqual(result, 2)
-


### PR DESCRIPTION
his is a rework of #1431 without the request method.

Before:

```
Name            Pattern                        View                     
----            -------                        ----                     
debugtoolbar    /_debug_toolbar/*subpath       <function decorator at 0x7fda645bc848>
response-rollups /v1/responses/rollup           <pyramid.config.views.MultiView object at 0x7fda645c84d0>
respondents     /v1/respondents                <function get_respondents at 0x7fda645bced8>
```

After:

```
Name                Pattern                     View                                               
----                -------                     ----                                               
debugtoolbar        /_debug_toolbar/*subpath    pyramid.router.decorator                           
response-rollups    /v1/responses/rollup        sonteksvc.v1.views.responses.get_response_rollup   
respondents         /v1/respondents             sonteksvc.v1.views.responses.get_respondents    
```
