### PR TITLE
Predicate error with custom HTTP Error

### DIFF
--- a/pyramid/config/predicates.py
+++ b/pyramid/config/predicates.py
@@ -1,6 +1,9 @@
 import re
 
-from pyramid.exceptions import ConfigurationError
+from pyramid.exceptions import (
+    ConfigurationError,
+    PredicateMismatchMethodNotAllowed
+    )
 
 from pyramid.compat import is_nonstr_iter
 
@@ -17,6 +20,7 @@ from pyramid.session import check_csrf_token
 from .util import as_sorted_tuple
 
 _marker = object()
+
 
 class XHRPredicate(object):
     def __init__(self, val, config):
@@ -44,7 +48,10 @@ class RequestMethodPredicate(object):
     phash = text
 
     def __call__(self, context, request):
-        return request.method in self.val
+        if request.method in self.val:
+            return True
+        else:
+            raise PredicateMismatchMethodNotAllowed()
 
 class PathInfoPredicate(object):
     def __init__(self, val, config):

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -614,7 +614,9 @@ class MultiView(object):
                 continue
 
         if errors:
-            errors.sort(key=lambda e: e.__predicates_passed__, reverse=True)
+            errors.sort(
+                key=lambda e: getattr(e, '__predicates_passed__', 0),
+                reverse=True)
             raise errors[0]
         else:
             raise PredicateMismatch(self.name)

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -299,7 +299,8 @@ class ViewDeriver(object):
             for predicate in preds:
                 try:
                     predicate_result = predicate(context, request)
-                except PredicateMismatch as error:
+                except PredicateMismatch as predicate_error:
+                    error = predicate_error  # python 3.4
                     break
                 else:
                     if not predicate_result:

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -292,14 +292,31 @@ class ViewDeriver(object):
         preds = self.kw.get('predicates', ())
         if not preds:
             return view
+
         def predicate_wrapper(context, request):
+            error = None
+            predicates_passed = 0
             for predicate in preds:
-                if not predicate(context, request):
-                    view_name = getattr(view, '__name__', view)
-                    raise PredicateMismatch(
-                         'predicate mismatch for view %s (%s)' % (
-                         view_name, predicate.text()))
-            return view(context, request)
+                try:
+                    predicate_result = predicate(context, request)
+                except PredicateMismatch as error:
+                    break
+                else:
+                    if not predicate_result:
+                        view_name = getattr(view, '__name__', view)
+                        error = PredicateMismatch(
+                             'predicate mismatch for view %s (%s)' % (
+                             view_name, predicate.text()))
+                        break
+                    else:
+                        predicates_passed += 1
+
+            if error:
+                error.__predicates_passed__ = predicates_passed
+                raise error
+            else:
+                return view(context, request)
+
         def checker(context, request):
             return all((predicate(context, request) for predicate in
                         preds))
@@ -588,12 +605,19 @@ class MultiView(object):
         return view(context, request)
 
     def __call__(self, context, request):
+        errors = []
         for order, view, phash in self.get_views(request):
             try:
                 return view(context, request)
-            except PredicateMismatch:
+            except PredicateMismatch as predicate_error:
+                errors.append(predicate_error)
                 continue
-        raise PredicateMismatch(self.name)
+
+        if errors:
+            errors.sort(key=lambda e: e.__predicates_passed__, reverse=True)
+            raise errors[0]
+        else:
+            raise PredicateMismatch(self.name)
 
 class ViewsConfiguratorMixin(object):
     @viewdefaults

--- a/pyramid/exceptions.py
+++ b/pyramid/exceptions.py
@@ -1,5 +1,6 @@
 from pyramid.httpexceptions import (
     HTTPBadRequest,
+    HTTPMethodNotAllowed,
     HTTPNotFound,
     HTTPForbidden,
     )
@@ -49,6 +50,11 @@ class PredicateMismatch(HTTPNotFound):
     The same applies to any type of exception being handled by an
     exception view.
     """
+
+class PredicateMismatchMethodNotAllowed(
+        HTTPMethodNotAllowed,
+        PredicateMismatch):
+    pass
 
 class URLDecodeError(UnicodeDecodeError):
     """

--- a/pyramid/tests/test_config/test_predicates.py
+++ b/pyramid/tests/test_config/test_predicates.py
@@ -58,8 +58,10 @@ class TestRequestMethodPredicate(unittest.TestCase):
         inst = self._makeOne(('GET','HEAD'))
         request = Dummy()
         request.method = 'POST'
-        result = inst(None, request)
-        self.assertFalse(result)
+        from pyramid.exceptions import PredicateMismatchMethodNotAllowed
+        self.assertRaises(
+            PredicateMismatchMethodNotAllowed,
+            inst, None, request)
 
     def test_text(self):
         inst = self._makeOne(('HEAD','GET'))

--- a/pyramid/tests/test_config/test_routes.py
+++ b/pyramid/tests/test_config/test_routes.py
@@ -99,8 +99,12 @@ class RoutesConfiguratorMixinTests(unittest.TestCase):
         request.method = 'GET'
         self.assertEqual(predicate(None, request), True)
         request = self._makeRequest(config)
+
         request.method = 'POST'
-        self.assertEqual(predicate(None, request), False)
+        from pyramid.exceptions import PredicateMismatchMethodNotAllowed
+        self.assertRaises(
+            PredicateMismatchMethodNotAllowed,
+            predicate, None, request)
 
     def test_add_route_with_path_info(self):
         config = self._makeOne(autocommit=True)

--- a/pyramid/tests/test_config/test_util.py
+++ b/pyramid/tests/test_config/test_util.py
@@ -350,8 +350,12 @@ class TestPredicateList(unittest.TestCase):
         self.assertTrue(predicates[0](Dummy(), request))
         request.method = 'GET'
         self.assertTrue(predicates[0](Dummy(), request))
+
         request.method = 'POST'
-        self.assertFalse(predicates[0](Dummy(), request))
+        from pyramid.exceptions import PredicateMismatchMethodNotAllowed
+        self.assertRaises(
+            PredicateMismatchMethodNotAllowed,
+            predicates[0], Dummy(), request)
 
     def test_request_method_ordering_hashes_same(self):
         hash1, _, __= self._callFUT(request_method=('GET', 'HEAD'))
@@ -378,7 +382,12 @@ class TestPredicateList(unittest.TestCase):
         self.assertEqual(predicates[1].text(),
                          "!request_method = POST")
         self.assertEqual(predicates[2].text(), '!header header')
-        self.assertEqual(predicates[1](None, request), True)
+
+        from pyramid.exceptions import PredicateMismatchMethodNotAllowed
+        self.assertRaises(
+            PredicateMismatchMethodNotAllowed,
+            predicates[1], Dummy(), request)
+
         self.assertEqual(predicates[2](None, request), True)
 
 

--- a/pyramid/tests/test_config/test_views.py
+++ b/pyramid/tests/test_config/test_views.py
@@ -2269,6 +2269,17 @@ class TestMultiView(unittest.TestCase):
         response = mv(context, request)
         self.assertEqual(response, expected_response)
 
+    def test___call__predicate_mismatch(self):
+        from pyramid.exceptions import PredicateMismatch
+        mv = self._makeOne()
+        context = DummyContext()
+        request = DummyRequest()
+        request.view_name = ''
+        def view1(context, request):
+            raise PredicateMismatch
+        mv.views = [(100, view1, None)]
+        self.assertRaises(PredicateMismatch, mv, context, request)
+
     def test___call__raise_not_found_isnt_interpreted_as_pred_mismatch(self):
         from pyramid.httpexceptions import HTTPNotFound
         mv = self._makeOne()

--- a/pyramid/tests/test_exceptions.py
+++ b/pyramid/tests/test_exceptions.py
@@ -91,4 +91,34 @@ class TestCyclicDependencyError(unittest.TestCase):
         self.assertTrue("'a' sorts before ['c', 'd']" in result)
         self.assertTrue("'c' sorts before ['a']" in result)
 
+class TestPredicateMismatch(unittest.TestCase):
+    def _makeOne(self, message):
+        from pyramid.exceptions import PredicateMismatch
+        return PredicateMismatch(message)
 
+    def test_it(self):
+        from pyramid.interfaces import IExceptionResponse
+        e = self._makeOne('predicate mismatch')
+        self.assertTrue(IExceptionResponse.providedBy(e))
+        self.assertEqual(e.status, '404 Not Found')
+        self.assertEqual(e.message, 'predicate mismatch')
+
+        from pyramid.httpexceptions import HTTPNotFound
+        self.assertTrue(isinstance(e, HTTPNotFound))
+
+class TestPredicateMismatchMethodNotAllowed(unittest.TestCase):
+    def _makeOne(self, message):
+        from pyramid.exceptions import PredicateMismatchMethodNotAllowed
+        return PredicateMismatchMethodNotAllowed(message)
+
+    def test_it(self):
+        from pyramid.interfaces import IExceptionResponse
+        e = self._makeOne('predicate mismatch')
+        self.assertTrue(IExceptionResponse.providedBy(e))
+        self.assertEqual(e.status, '405 Method Not Allowed')
+        self.assertEqual(e.message, 'predicate mismatch')
+
+        from pyramid.exceptions import PredicateMismatch
+        self.assertTrue(isinstance(e, PredicateMismatch))
+        from pyramid.httpexceptions import HTTPMethodNotAllowed
+        self.assertTrue(isinstance(e, HTTPMethodNotAllowed))


### PR DESCRIPTION
The reason for this change happen when i wanted to customize my errors messages, layout and http status codes on a REST JSON application.
I looked for a way to do this without changing the pyramid code, but i can't find it, but if it is please tell me :)

Here's a example of what i'm trying to do.

```
@view_defaults(route_name='test', renderer='json')
class Test(object):
    def __init__(self, request):
        self.request = request

    @view_config(request_method='POST')
    def post(self):
        return 'POST'

    @view_config(request_method='GET')
    def get(self):
        return 'GET'
```

If we call this view with `PUT` method for example, we get 404, and that is not technically true, i think the 405 it's the correct one.

To change this i make the predicates validations a little more flexible.
Instead of validating if is the predicate is `True` or `False` and raise 404, we validate if is `True` or `False` and if is a `PredicateMismatch` exception. If we get a exception we raise that exception, if `False` we give the default, 404.

Now we have another problem.

```
class PredicateMismatchForbidden(HTTPForbidden, PredicateMismatch):
    pass

class IPAddressPredicate(object):
    def __init__(self, val, config):
        self.val = val
    def text(self):
        return "ip_address = %s" % self.val
    phash = text
    def __call__(self, context, request):
        if request.remote_addr == self.val:
            return True
        else:
            raise PredicateMismatchForbidden()

@view_defaults(route_name='test', renderer='json')
class Test(object):
    def __init__(self, request):
        self.request = request

    @view_config(request_method='POST')
    def post(self):
        return 'POST'

    @view_config(request_method='GET', ip_address='1.1.1.1')
    def get(self):
        return 'GET'
```

If we call this view with `GET` method and with IP '9.9.9.9', we get 405, but we want a 403 raised by invalid IP, because we sent `GET` and that match with the method `Test.get`.
So the solution has to define the valide predicates on the error to create some kind of priority.

This is a small sugestion. I think this need more changes, like defining `PredicateMismatch` as `HTTPError` and create all HTTPErrors for `PredicateMismatch`.
I tried to change only the necessary to keep the code work the same way, and if you agree we can make a better change on this.

Thanks and sorry for my english :)
