### PR TITLE
Documentation/accept

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -135,6 +135,7 @@ Docs
   https://github.com/Pylons/pyramid/issues/1391 for a bug report stating
   ``not_`` was failing on ``accept``. Discussion with @mcdonc led to the
   conclusion that it should not be documented as a predicate.
+  See https://github.com/Pylons/pyramid/pull/1487 for this PR
 
 - Removed logging configuration from Quick Tutorial ini files except for
   scaffolding- and logging-related chapters to avoid needing to explain it too

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -131,7 +131,7 @@ Docs
 ----
 
 - Moved the documentation for ``accept`` on ``Configurator.add_view`` to no
-  longer be part of the decorator list. See
+  longer be part of the predicate list. See
   https://github.com/Pylons/pyramid/issues/1391 for a bug report stating
   ``not_`` was failing on ``accept``. Discussion with @mcdonc led to the
   conclusion that it should not be documented as a predicate.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -130,6 +130,12 @@ Deprecations
 Docs
 ----
 
+- Moved the documentation for ``accept`` on ``Configurator.add_view`` to no
+  longer be part of the decorator list. See
+  https://github.com/Pylons/pyramid/issues/1391 for a bug report stating
+  ``not_`` was failing on ``accept``. Discussion with @mcdonc led to the
+  conclusion that it should not be documented as a predicate.
+
 - Removed logging configuration from Quick Tutorial ini files except for
   scaffolding- and logging-related chapters to avoid needing to explain it too
   early.

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -140,16 +140,15 @@ class RoutesConfiguratorMixin(object):
 
         accept
 
-          This value represents a match query for one or more
-          mimetypes in the ``Accept`` HTTP request header.  If this
-          value is specified, it must be in one of the following
-          forms: a mimetype match token in the form ``text/plain``, a
-          wildcard mimetype match token in the form ``text/*`` or a
-          match-all wildcard mimetype match token in the form ``*/*``.
-          If any of the forms matches the ``Accept`` header of the
-          request, or if the ``Accept`` header isn't set at all in the
-          request, this predicate will be true. If this predicate
-          returns ``False``, route matching continues.
+          This value represents a match query for one or more mimetypes in the
+          ``Accept`` HTTP request header.  If this value is specified, it must
+          be in one of the following forms: a mimetype match token in the form
+          ``text/plain``, a wildcard mimetype match token in the form
+          ``text/*`` or a match-all wildcard mimetype match token in the form
+          ``*/*``.  If any of the forms matches the ``Accept`` header of the
+          request, or if the ``Accept`` header isn't set at all in the request,
+          this will match the current route. If this does not match the
+          ``Accept`` header of the request, route matching continues.
 
         Predicate Arguments
 

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -138,6 +138,19 @@ class RoutesConfiguratorMixin(object):
 
           .. versionadded:: 1.1
 
+        accept
+
+          This value represents a match query for one or more
+          mimetypes in the ``Accept`` HTTP request header.  If this
+          value is specified, it must be in one of the following
+          forms: a mimetype match token in the form ``text/plain``, a
+          wildcard mimetype match token in the form ``text/*`` or a
+          match-all wildcard mimetype match token in the form ``*/*``.
+          If any of the forms matches the ``Accept`` header of the
+          request, or if the ``Accept`` header isn't set at all in the
+          request, this predicate will be true. If this predicate
+          returns ``False``, route matching continues.
+
         Predicate Arguments
 
         pattern
@@ -219,19 +232,6 @@ class RoutesConfiguratorMixin(object):
           represents a header name or a header name/value pair, the
           case of the header name is not significant.  If this
           predicate returns ``False``, route matching continues.
-
-        accept
-
-          This value represents a match query for one or more
-          mimetypes in the ``Accept`` HTTP request header.  If this
-          value is specified, it must be in one of the following
-          forms: a mimetype match token in the form ``text/plain``, a
-          wildcard mimetype match token in the form ``text/*`` or a
-          match-all wildcard mimetype match token in the form ``*/*``.
-          If any of the forms matches the ``Accept`` header of the
-          request, or if the ``Accept`` header isn't set at all in the
-          request, this predicate will be true. If this predicate
-          returns ``False``, route matching continues.
 
         effective_principals
 

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -843,14 +843,15 @@ class ViewsConfiguratorMixin(object):
 
         accept
 
-          The value of this argument represents a match query for one
-          or more mimetypes in the ``Accept`` HTTP request header.  If
-          this value is specified, it must be in one of the following
-          forms: a mimetype match token in the form ``text/plain``, a
-          wildcard mimetype match token in the form ``text/*`` or a
-          match-all wildcard mimetype match token in the form ``*/*``.
-          If any of the forms matches the ``Accept`` header of the
-          request, this predicate will be true.
+          This value represents a match query for one or more mimetypes in the
+          ``Accept`` HTTP request header.  If this value is specified, it must
+          be in one of the following forms: a mimetype match token in the form
+          ``text/plain``, a wildcard mimetype match token in the form
+          ``text/*`` or a match-all wildcard mimetype match token in the form
+          ``*/*``.  If any of the forms matches the ``Accept`` header of the
+          request, or if the ``Accept`` header isn't set at all in the request,
+          this will match the current view. If this does not match the
+          ``Accept`` header of the request, view matching continues.
 
         Predicate Arguments
 

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -841,6 +841,17 @@ class ViewsConfiguratorMixin(object):
           very useful for 'civilians' who are just developing stock Pyramid
           applications. Pay no attention to the man behind the curtain.
 
+        accept
+
+          The value of this argument represents a match query for one
+          or more mimetypes in the ``Accept`` HTTP request header.  If
+          this value is specified, it must be in one of the following
+          forms: a mimetype match token in the form ``text/plain``, a
+          wildcard mimetype match token in the form ``text/*`` or a
+          match-all wildcard mimetype match token in the form ``*/*``.
+          If any of the forms matches the ``Accept`` header of the
+          request, this predicate will be true.
+
         Predicate Arguments
 
         name
@@ -940,17 +951,6 @@ class ViewsConfiguratorMixin(object):
           ``XMLHttpRequest`` for this view to be found and called.
           This is useful for detecting AJAX requests issued from
           jQuery, Prototype and other Javascript libraries.
-
-        accept
-
-          The value of this argument represents a match query for one
-          or more mimetypes in the ``Accept`` HTTP request header.  If
-          this value is specified, it must be in one of the following
-          forms: a mimetype match token in the form ``text/plain``, a
-          wildcard mimetype match token in the form ``text/*`` or a
-          match-all wildcard mimetype match token in the form ``*/*``.
-          If any of the forms matches the ``Accept`` header of the
-          request, this predicate will be true.
 
         header
 


### PR DESCRIPTION
As a follow up to: #1391 and #1481 this is a documentation change that moves accept from a predicate to a non-predicate.

This then explicitly documents that `not_` will not work with it since it is not technically a predicate.