### PR TITLE
Expose response class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -59,6 +59,11 @@ Features
   via ``request.static_url('myapp:static/foo.png')``.
   See https://github.com/Pylons/pyramid/issues/1252
 
+- Added ``pyramid.config.Configurator.set_response_factory`` and the
+  ``response_factory`` keyword argument to the ``Configurator`` for defining
+  a factory that will return a custom ``Response`` class.
+  See https://github.com/Pylons/pyramid/pull/1499
+
 Bug Fixes
 ---------
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -17,7 +17,8 @@ Glossary
      positional argument, returns a Pyramid-compatible request.
 
    response factory
-     An object which returns a Pyramid-compatible response.
+     An object which, provied a :term:`request` as a single positional
+     argument, returns a Pyramid-compatible response.
 
    response
      An object returned by a :term:`view callable` that represents response

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -16,6 +16,9 @@ Glossary
      An object which, provided a :term:`WSGI` environment as a single
      positional argument, returns a Pyramid-compatible request.
 
+   response factory
+     An object which returns a Pyramid-compatible response.
+
    response
      An object returned by a :term:`view callable` that represents response
      data returned to the requesting user agent.  It must implement the

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -17,7 +17,7 @@ Glossary
      positional argument, returns a Pyramid-compatible request.
 
    response factory
-     An object which, provied a :term:`request` as a single positional
+     An object which, provided a :term:`request` as a single positional
      argument, returns a Pyramid-compatible response.
 
    response

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -354,6 +354,68 @@ We attach and cache an object named ``extra`` to the ``request`` object.
 
 .. _beforerender_event:
 
+.. index::
+   single: response factory
+
+.. _changing_the_response_factory:
+
+Changing the Response Factory
+----------------------------
+
+Whenever :app:`Pyramid` returns a response from a view it creates a
+:term:`response` object.  By default, an instance of the
+:class:`pyramid.response.Response` class is created to represent the response
+object.
+
+The class (aka "factory") that :app:`Pyramid` uses to create a response object
+instance can be changed by passing a ``response_factory`` argument to the
+constructor of the :term:`configurator`.  This argument can be either a
+callable or a :term:`dotted Python name` representing a callable.
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid.response import Response
+
+   class MyResponse(Response):
+       pass
+
+   config = Configurator(response_factory=MyResponse)
+
+If you're doing imperative configuration, and you'd rather do it after you've
+already constructed a :term:`configurator` it can also be registered via the
+:meth:`pyramid.config.Configurator.set_response_factory` method:
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid.config import Configurator
+   from pyramid.response import Response
+
+   class MyResponse(Response):
+       pass
+
+   config = Configurator()
+   config.set_response_factory(MyRequest)
+
+If you are already using a custom ```request_factory`` you can also set the
+``ResponseClass`` on your :class:`pyramid.request.Request`:
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid.config import Configurator
+   from pyramid.response import Response
+   from pyramid.request import Request
+
+   class MyResponse(Response):
+       pass
+
+   class MyRequest(Request):
+       ResponseClass = MyResponse
+
+   config = Configurator()
+
 Using The Before Render Event
 -----------------------------
 

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -360,7 +360,7 @@ We attach and cache an object named ``extra`` to the ``request`` object.
 .. _changing_the_response_factory:
 
 Changing the Response Factory
-----------------------------
+-------------------------------
 
 Whenever :app:`Pyramid` returns a response from a view it creates a
 :term:`response` object.  By default, an instance of the

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -362,6 +362,8 @@ We attach and cache an object named ``extra`` to the ``request`` object.
 Changing the Response Factory
 -------------------------------
 
+.. versionadded:: 1.6
+
 Whenever :app:`Pyramid` returns a response from a view it creates a
 :term:`response` object.  By default, an instance of the
 :class:`pyramid.response.Response` class is created to represent the response

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -369,10 +369,10 @@ Whenever :app:`Pyramid` returns a response from a view it creates a
 :class:`pyramid.response.Response` class is created to represent the response
 object.
 
-The class (aka "factory") that :app:`Pyramid` uses to create a response object
-instance can be changed by passing a ``response_factory`` argument to the
-constructor of the :term:`configurator`.  This argument can be either a
-callable or a :term:`dotted Python name` representing a callable.
+The factory that :app:`Pyramid` uses to create a response object instance can be
+changed by passing a ``response_factory`` argument to the constructor of the
+:term:`configurator`.  This argument can be either a callable or a
+:term:`dotted Python name` representing a callable.
 
 .. code-block:: python
    :linenos:
@@ -382,7 +382,7 @@ callable or a :term:`dotted Python name` representing a callable.
    class MyResponse(Response):
        pass
 
-   config = Configurator(response_factory=MyResponse)
+   config = Configurator(response_factory=lambda r: MyResponse())
 
 If you're doing imperative configuration, and you'd rather do it after you've
 already constructed a :term:`configurator` it can also be registered via the
@@ -398,25 +398,8 @@ already constructed a :term:`configurator` it can also be registered via the
        pass
 
    config = Configurator()
-   config.set_response_factory(MyRequest)
+   config.set_response_factory(lambda r: MyResponse())
 
-If you are already using a custom ```request_factory`` you can also set the
-``ResponseClass`` on your :class:`pyramid.request.Request`:
-
-.. code-block:: python
-   :linenos:
-
-   from pyramid.config import Configurator
-   from pyramid.response import Response
-   from pyramid.request import Request
-
-   class MyResponse(Response):
-       pass
-
-   class MyRequest(Request):
-       ResponseClass = MyResponse
-
-   config = Configurator()
 
 Using The Before Render Event
 -----------------------------

--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -179,6 +179,11 @@ class Configurator(
     See :ref:`changing_the_request_factory`.  By default it is ``None``,
     which means use the default request factory.
 
+    If ``response_factory`` is passed, it should be a :term:`response
+    factory` implementation or a :term:`dotted Python name` to the same.
+    See :ref:`changing_the_response_factory`.  By default it is ``None``,
+    which means use the default response factory.
+
     If ``default_permission`` is passed, it should be a
     :term:`permission` string to be used as the default permission for
     all view configuration registrations performed against this
@@ -190,7 +195,7 @@ class Configurator(
     configurations which do not explicitly declare a permission will
     always be executable by entirely anonymous users (any
     authorization policy in effect is ignored).
-    
+
     .. seealso::
 
         See also :ref:`setting_a_default_permission`.
@@ -254,6 +259,7 @@ class Configurator(
 
     .. versionadded:: 1.6
        The ``root_package`` argument.
+       The ``response_factory`` argument.
     """
     manager = manager # for testing injection
     venusian = venusian # for testing injection
@@ -276,6 +282,7 @@ class Configurator(
                  debug_logger=None,
                  locale_negotiator=None,
                  request_factory=None,
+                 response_factory=None,
                  default_permission=None,
                  session_factory=None,
                  default_view_mapper=None,
@@ -310,6 +317,7 @@ class Configurator(
                 debug_logger=debug_logger,
                 locale_negotiator=locale_negotiator,
                 request_factory=request_factory,
+                response_factory=response_factory,
                 default_permission=default_permission,
                 session_factory=session_factory,
                 default_view_mapper=default_view_mapper,
@@ -325,6 +333,7 @@ class Configurator(
                        debug_logger=None,
                        locale_negotiator=None,
                        request_factory=None,
+                       response_factory=None,
                        default_permission=None,
                        session_factory=None,
                        default_view_mapper=None,
@@ -412,6 +421,9 @@ class Configurator(
         if request_factory:
             self.set_request_factory(request_factory)
 
+        if response_factory:
+            self.set_response_factory(response_factory)
+
         if default_permission:
             self.set_default_permission(default_permission)
 
@@ -469,7 +481,7 @@ class Configurator(
             _registry.registerSelfAdapter = registerSelfAdapter
 
     # API
-            
+
     def _get_introspector(self):
         introspector = getattr(self.registry, 'introspector', _marker)
         if introspector is _marker:

--- a/pyramid/config/factories.py
+++ b/pyramid/config/factories.py
@@ -4,6 +4,7 @@ from zope.interface import implementer
 from pyramid.interfaces import (
     IDefaultRootFactory,
     IRequestFactory,
+    IResponseFactory,
     IRequestExtensions,
     IRootFactory,
     ISessionFactory,
@@ -95,6 +96,32 @@ class FactoriesConfiguratorMixin(object):
                                    'request factory')
         intr['factory'] = factory
         self.action(IRequestFactory, register, introspectables=(intr,))
+
+    @action_method
+    def set_response_factory(self, factory):
+        """ The object passed as ``factory`` should be an object (or a
+        :term:`dotted Python name` which refers to an object) which
+        will be used by the :app:`Pyramid` as the default response
+        objects.  This factory object must have the same
+        methods and attributes as the
+        :class:`pyramid.request.Response` class.
+
+        .. note::
+
+           Using the ``response_factory`` argument to the
+           :class:`pyramid.config.Configurator` constructor
+           can be used to achieve the same purpose.
+        """
+        factory = self.maybe_dotted(factory)
+
+        def register():
+            self.registry.registerUtility(factory, IResponseFactory)
+
+        intr = self.introspectable('response factory', None,
+                                   self.object_description(factory),
+                                   'response factory')
+        intr['factory'] = factory
+        self.action(IResponseFactory, register, introspectables=(intr,))
 
     @action_method
     def add_request_method(self,

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -449,8 +449,8 @@ class RendererHelper(object):
         if response is None:
             # request is None or request is not a pyramid.response.Response
             registry = self.registry
-            response_factory = _get_response_factory(registry, request)
-            response = response_factory()
+            response_factory = _get_response_factory(registry)
+            response = response_factory(request)
 
         if result is not None:
             if isinstance(result, text_type):

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -18,15 +18,13 @@ from pyramid.compat import (
     text_type,
     )
 
-from pyramid.util import _get_response_factory
-
 from pyramid.decorator import reify
 
 from pyramid.events import BeforeRender
 
 from pyramid.path import caller_package
 
-from pyramid.response import Response
+from pyramid.response import Response, _get_response_factory
 from pyramid.threadlocal import get_current_registry
 
 # API

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -10,7 +10,6 @@ from zope.interface.registry import Components
 from pyramid.interfaces import (
     IJSONAdapter,
     IRendererFactory,
-    IResponseFactory,
     IRendererInfo,
     )
 
@@ -18,6 +17,8 @@ from pyramid.compat import (
     string_types,
     text_type,
     )
+
+from pyramid.util import _get_response_factory
 
 from pyramid.decorator import reify
 
@@ -448,9 +449,7 @@ class RendererHelper(object):
         if response is None:
             # request is None or request is not a pyramid.response.Response
             registry = self.registry
-            response_factory = registry.queryUtility(IResponseFactory,
-                                                     default=Response)
-
+            response_factory = _get_response_factory(registry, request)
             response = response_factory()
 
         if result is not None:

--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -216,8 +216,8 @@ class Request(
         right" attributes (e.g. by calling ``request.response.set_cookie()``)
         within a view that uses a renderer.  Mutations to this response object
         will be preserved in the response sent to the client."""
-        response_factory = _get_response_factory(self.registry, self)
-        return response_factory()
+        response_factory = _get_response_factory(self.registry)
+        return response_factory(self)
 
     def is_response(self, ob):
         """ Return ``True`` if the object passed as ``ob`` is a valid

--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -10,7 +10,6 @@ from pyramid.interfaces import (
     IRequest,
     IResponse,
     ISessionFactory,
-    IResponseFactory,
     )
 
 from pyramid.compat import (
@@ -27,7 +26,10 @@ from pyramid.security import (
     AuthorizationAPIMixin,
     )
 from pyramid.url import URLMethodsMixin
-from pyramid.util import InstancePropertyMixin
+from pyramid.util import (
+    InstancePropertyMixin,
+    _get_response_factory,
+)
 
 class TemplateContext(object):
     pass
@@ -214,9 +216,7 @@ class Request(
         right" attributes (e.g. by calling ``request.response.set_cookie()``)
         within a view that uses a renderer.  Mutations to this response object
         will be preserved in the response sent to the client."""
-        registry = self.registry
-        response_factory = registry.queryUtility(IResponseFactory,
-                                                 default=Response)
+        response_factory = _get_response_factory(self.registry, self)
         return response_factory()
 
     def is_response(self, ob):

--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -20,16 +20,13 @@ from pyramid.compat import (
 
 from pyramid.decorator import reify
 from pyramid.i18n import LocalizerRequestMixin
-from pyramid.response import Response
+from pyramid.response import Response,  _get_response_factory
 from pyramid.security import (
     AuthenticationAPIMixin,
     AuthorizationAPIMixin,
     )
 from pyramid.url import URLMethodsMixin
-from pyramid.util import (
-    InstancePropertyMixin,
-    _get_response_factory,
-)
+from pyramid.util import InstancePropertyMixin
 
 class TemplateContext(object):
     pass

--- a/pyramid/response.py
+++ b/pyramid/response.py
@@ -8,7 +8,8 @@ import venusian
 
 from webob import Response as _Response
 from zope.interface import implementer
-from pyramid.interfaces import IResponse
+from pyramid.interfaces import IResponse, IResponseFactory
+
 
 def init_mimetypes(mimetypes):
     # this is a function so it can be unittested
@@ -143,7 +144,7 @@ class response_adapter(object):
         @response_adapter(dict, list)
         def myadapter(ob):
             return Response(json.dumps(ob))
-        
+
     This method will have no effect until a :term:`scan` is performed
     agains the package or module which contains it, ala:
 
@@ -167,3 +168,15 @@ class response_adapter(object):
     def __call__(self, wrapped):
         self.venusian.attach(wrapped, self.register, category='pyramid')
         return wrapped
+
+
+def _get_response_factory(registry):
+    """ Obtain a :class: `pyramid.response.Response` using the
+    `pyramid.interfaces.IResponseFactory`.
+    """
+    response_factory = registry.queryUtility(
+        IResponseFactory,
+        default=lambda r: Response()
+    )
+
+    return response_factory

--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -21,7 +21,7 @@ from pyramid.compat import (
 from pyramid.config import Configurator
 from pyramid.decorator import reify
 from pyramid.path import caller_package
-from pyramid.response import Response
+from pyramid.response import Response, _get_response_factory
 from pyramid.registry import Registry
 
 from pyramid.security import (
@@ -39,10 +39,8 @@ from pyramid.threadlocal import (
 from pyramid.i18n import LocalizerRequestMixin
 from pyramid.request import CallbackMethodsMixin
 from pyramid.url import URLMethodsMixin
-from pyramid.util import (
-    InstancePropertyMixin,
-    _get_response_factory
-    )
+from pyramid.util import InstancePropertyMixin
+
 
 _marker = object()
 

--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -9,7 +9,6 @@ from zope.interface import (
 
 from pyramid.interfaces import (
     IRequest,
-    IResponseFactory,
     ISession,
     )
 
@@ -40,7 +39,10 @@ from pyramid.threadlocal import (
 from pyramid.i18n import LocalizerRequestMixin
 from pyramid.request import CallbackMethodsMixin
 from pyramid.url import URLMethodsMixin
-from pyramid.util import InstancePropertyMixin
+from pyramid.util import (
+    InstancePropertyMixin,
+    _get_response_factory
+    )
 
 _marker = object()
 
@@ -383,8 +385,8 @@ class DummyRequest(
 
     @reify
     def response(self):
-        f =  self.registry.queryUtility(IResponseFactory, default=Response)
-        return f()
+        f =  _get_response_factory(self.registry)
+        return f(self)
 
 have_zca = True
 

--- a/pyramid/tests/test_config/test_factories.py
+++ b/pyramid/tests/test_config/test_factories.py
@@ -26,7 +26,7 @@ class TestFactoriesMixin(unittest.TestCase):
     def test_set_response_factory(self):
         from pyramid.interfaces import IResponseFactory
         config = self._makeOne(autocommit=True)
-        factory = object()
+        factory = lambda r: object()
         config.set_response_factory(factory)
         self.assertEqual(config.registry.getUtility(IResponseFactory), factory)
 

--- a/pyramid/tests/test_config/test_factories.py
+++ b/pyramid/tests/test_config/test_factories.py
@@ -23,6 +23,21 @@ class TestFactoriesMixin(unittest.TestCase):
         self.assertEqual(config.registry.getUtility(IRequestFactory),
                          dummyfactory)
 
+    def test_set_response_factory(self):
+        from pyramid.interfaces import IResponseFactory
+        config = self._makeOne(autocommit=True)
+        factory = object()
+        config.set_response_factory(factory)
+        self.assertEqual(config.registry.getUtility(IResponseFactory), factory)
+
+    def test_set_response_factory_dottedname(self):
+        from pyramid.interfaces import IResponseFactory
+        config = self._makeOne(autocommit=True)
+        config.set_response_factory(
+            'pyramid.tests.test_config.dummyfactory')
+        self.assertEqual(config.registry.getUtility(IResponseFactory),
+                         dummyfactory)
+
     def test_set_root_factory(self):
         from pyramid.interfaces import IRootFactory
         config = self._makeOne()

--- a/pyramid/tests/test_config/test_init.py
+++ b/pyramid/tests/test_config/test_init.py
@@ -551,42 +551,12 @@ class ConfiguratorTests(unittest.TestCase):
         from pyramid.interfaces import IResponseFactory
         reg = Registry()
         config = self._makeOne(reg)
-        factory = object()
+        factory = lambda r: object()
         config.setup_registry(response_factory=factory)
         self.assertEqual(reg.queryUtility(IResponseFactory), None)
         config.commit()
         utility = reg.getUtility(IResponseFactory)
         self.assertEqual(utility, factory)
-
-    def test_setup_registry_request_factory_custom_response_class(self):
-        from pyramid.registry import Registry
-        from pyramid.interfaces import IRequestFactory
-        from pyramid.request import Request
-
-        class MyResponse(object):
-            pass
-
-        class MyRequest(Request):
-            ResponseClass = MyResponse
-
-        reg = Registry()
-        config = self._makeOne(reg)
-        factory = MyRequest({
-            'PATH_INFO': '/',
-            'wsgi.url_scheme': 'http',
-            'HTTP_HOST': 'localhost',
-            'SERVER_PROTOCOL': '1.0',
-        })
-        factory.registry = reg
-
-        config.setup_registry(request_factory=factory)
-        self.assertEqual(reg.queryUtility(IRequestFactory), None)
-        config.commit()
-        utility = reg.getUtility(IRequestFactory)
-        self.assertEqual(utility, factory)
-
-        new_response = factory.response
-        self.assertTrue(isinstance(new_response, MyResponse))
 
     def test_setup_registry_request_factory_dottedname(self):
         from pyramid.registry import Registry

--- a/pyramid/tests/test_config/test_init.py
+++ b/pyramid/tests/test_config/test_init.py
@@ -546,6 +546,36 @@ class ConfiguratorTests(unittest.TestCase):
         utility = reg.getUtility(IRequestFactory)
         self.assertEqual(utility, factory)
 
+    def test_setup_registry_request_factory_custom_response_class(self):
+        from pyramid.registry import Registry
+        from pyramid.interfaces import IRequestFactory
+        from pyramid.request import Request
+
+        class MyResponse(object):
+            pass
+
+        class MyRequest(Request):
+            ResponseClass = MyResponse
+
+        reg = Registry()
+        config = self._makeOne(reg)
+        factory = MyRequest({
+            'PATH_INFO': '/',
+            'wsgi.url_scheme': 'http',
+            'HTTP_HOST': 'localhost',
+            'SERVER_PROTOCOL': '1.0',
+        })
+        factory.registry = reg
+
+        config.setup_registry(request_factory=factory)
+        self.assertEqual(reg.queryUtility(IRequestFactory), None)
+        config.commit()
+        utility = reg.getUtility(IRequestFactory)
+        self.assertEqual(utility, factory)
+
+        new_response = factory.response
+        self.assertTrue(isinstance(new_response, MyResponse))
+
     def test_setup_registry_request_factory_dottedname(self):
         from pyramid.registry import Registry
         from pyramid.interfaces import IRequestFactory

--- a/pyramid/tests/test_config/test_init.py
+++ b/pyramid/tests/test_config/test_init.py
@@ -546,6 +546,18 @@ class ConfiguratorTests(unittest.TestCase):
         utility = reg.getUtility(IRequestFactory)
         self.assertEqual(utility, factory)
 
+    def test_setup_registry_response_factory(self):
+        from pyramid.registry import Registry
+        from pyramid.interfaces import IResponseFactory
+        reg = Registry()
+        config = self._makeOne(reg)
+        factory = object()
+        config.setup_registry(response_factory=factory)
+        self.assertEqual(reg.queryUtility(IResponseFactory), None)
+        config.commit()
+        utility = reg.getUtility(IResponseFactory)
+        self.assertEqual(utility, factory)
+
     def test_setup_registry_request_factory_custom_response_class(self):
         from pyramid.registry import Registry
         from pyramid.interfaces import IRequestFactory

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -182,7 +182,10 @@ class TestRendererHelper(unittest.TestCase):
         from pyramid.interfaces import IResponseFactory
         class ResponseFactory(object):
             pass
-        self.config.registry.registerUtility(ResponseFactory, IResponseFactory)
+
+        self.config.registry.registerUtility(
+            lambda r: ResponseFactory(), IResponseFactory
+        )
 
     def test_render_to_response(self):
         self._registerRendererFactory()
@@ -310,7 +313,9 @@ class TestRendererHelper(unittest.TestCase):
         class ResponseFactory(object):
             def __init__(self):
                 pass
-        self.config.registry.registerUtility(ResponseFactory, IResponseFactory)
+        self.config.registry.registerUtility(
+            lambda r: ResponseFactory(), IResponseFactory
+        )
         request = testing.DummyRequest()
         helper = self._makeOne('loo.foo')
         response = helper._make_response(b'abc', request)

--- a/pyramid/tests/test_response.py
+++ b/pyramid/tests/test_response.py
@@ -8,7 +8,7 @@ class TestResponse(unittest.TestCase):
     def _getTargetClass(self):
         from pyramid.response import Response
         return Response
-        
+
     def test_implements_IResponse(self):
         from pyramid.interfaces import IResponse
         cls = self._getTargetClass()
@@ -119,7 +119,7 @@ class Test_patch_mimetypes(unittest.TestCase):
         result = self._callFUT(module)
         self.assertEqual(result, True)
         self.assertEqual(module.initted, True)
-        
+
     def test_missing_init(self):
         class DummyMimetypes(object):
             pass
@@ -174,6 +174,17 @@ class TestResponseAdapter(unittest.TestCase):
         self.assertEqual(dummy_venusian.attached,
                          [(foo, dec.register, 'pyramid')])
 
+
+class TestGetResponseFactory(unittest.TestCase):
+    def test_get_factory(self):
+        from pyramid.registry import Registry
+        from pyramid.response import Response, _get_response_factory
+
+        registry = Registry()
+        response = _get_response_factory(registry)(None)
+        self.assertTrue(isinstance(response, Response))
+
+
 class Dummy(object):
     pass
 
@@ -190,5 +201,3 @@ class DummyVenusian(object):
 
     def attach(self, wrapped, fn, category=None):
         self.attached.append((wrapped, fn, category))
-
-        

--- a/pyramid/tests/test_testing.py
+++ b/pyramid/tests/test_testing.py
@@ -259,7 +259,9 @@ class TestDummyRequest(unittest.TestCase):
         registry = Registry('this_test')
         class ResponseFactory(object):
             pass
-        registry.registerUtility(ResponseFactory, IResponseFactory)
+        registry.registerUtility(
+            lambda r: ResponseFactory(), IResponseFactory
+        )
         request = self._makeOne()
         request.registry = registry
         resp = request.response

--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -619,17 +619,6 @@ class TestActionInfo(unittest.TestCase):
                          "Line 0 of file filename:\n       linerepr  ")
 
 
-class TestGetResponseFactory(unittest.TestCase):
-    def test_get_factory(self):
-        from pyramid.util import _get_response_factory
-        from pyramid.registry import Registry
-        from pyramid.response import Response
-
-        registry = Registry()
-        response = _get_response_factory(registry)(None)
-        self.assertTrue(isinstance(response, Response))
-
-
 def dummyfunc(): pass
 
 class Dummy(object):

--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -619,6 +619,33 @@ class TestActionInfo(unittest.TestCase):
                          "Line 0 of file filename:\n       linerepr  ")
 
 
+class TestGetResponseFactory(unittest.TestCase):
+    def test_no_request(self):
+        from pyramid.util import _get_response_factory
+        from pyramid.registry import Registry
+        from pyramid.response import Response
+
+        registry = Registry()
+        factory = _get_response_factory(registry)
+        self.assertEqual(factory, Response)
+
+    def test_with_request(self):
+        from pyramid.util import _get_response_factory
+        from pyramid.registry import Registry
+        from pyramid.request import Request
+
+        class MyResponse(object):
+            pass
+
+        class MyRequest(Request):
+            ResponseClass = MyResponse
+            registry = Registry()
+
+        request = MyRequest({})
+        factory = _get_response_factory(registry, request)
+        self.assertEqual(factory, MyResponse)
+
+
 def dummyfunc(): pass
 
 class Dummy(object):

--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -324,7 +324,7 @@ class Test_object_description(unittest.TestCase):
         self.assertEqual(
             self._callFUT(inst),
             "object %s" % str(inst))
-        
+
     def test_shortened_repr(self):
         inst = ['1'] * 1000
         self.assertEqual(
@@ -592,7 +592,7 @@ class TestActionInfo(unittest.TestCase):
     def _getTargetClass(self):
         from pyramid.util import ActionInfo
         return ActionInfo
-        
+
     def _makeOne(self, filename, lineno, function, linerepr):
         return self._getTargetClass()(filename, lineno, function, linerepr)
 
@@ -620,30 +620,14 @@ class TestActionInfo(unittest.TestCase):
 
 
 class TestGetResponseFactory(unittest.TestCase):
-    def test_no_request(self):
+    def test_get_factory(self):
         from pyramid.util import _get_response_factory
         from pyramid.registry import Registry
         from pyramid.response import Response
 
         registry = Registry()
-        factory = _get_response_factory(registry)
-        self.assertEqual(factory, Response)
-
-    def test_with_request(self):
-        from pyramid.util import _get_response_factory
-        from pyramid.registry import Registry
-        from pyramid.request import Request
-
-        class MyResponse(object):
-            pass
-
-        class MyRequest(Request):
-            ResponseClass = MyResponse
-            registry = Registry()
-
-        request = MyRequest({})
-        factory = _get_response_factory(request.registry, request)
-        self.assertEqual(factory, MyResponse)
+        response = _get_response_factory(registry)(None)
+        self.assertTrue(isinstance(response, Response))
 
 
 def dummyfunc(): pass

--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -642,7 +642,7 @@ class TestGetResponseFactory(unittest.TestCase):
             registry = Registry()
 
         request = MyRequest({})
-        factory = _get_response_factory(registry, request)
+        factory = _get_response_factory(request.registry, request)
         self.assertEqual(factory, MyResponse)
 
 

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -15,6 +15,10 @@ from pyramid.exceptions import (
     CyclicDependencyError,
     )
 
+from pyramid.interfaces import (
+    IResponseFactory,
+    )
+
 from pyramid.compat import (
     iteritems_,
     is_nonstr_iter,
@@ -25,6 +29,7 @@ from pyramid.compat import (
     )
 
 from pyramid.interfaces import IActionInfo
+from pyramid.response import Response
 from pyramid.path import DottedNameResolver as _DottedNameResolver
 
 class DottedNameResolver(_DottedNameResolver):
@@ -551,3 +556,19 @@ def action_method(wrapped):
     wrapper.__docobj__ = wrapped
     return wrapper
 
+def _get_response_factory(registry, request=None):
+    """ Obtain a :class: `pyramid.response.Response` using the
+    ``request.ResponseClass`` property if available.
+    """
+    # Request is `None` or does not have a `ResponseClass`
+    if hasattr(request, 'ResponseClass'):
+        response_class = request.ResponseClass
+    else:
+        response_class = Response
+
+    response_factory = registry.queryUtility(
+        IResponseFactory,
+        default=response_class
+    )
+
+    return response_factory

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -556,19 +556,14 @@ def action_method(wrapped):
     wrapper.__docobj__ = wrapped
     return wrapper
 
-def _get_response_factory(registry, request=None):
-    """ Obtain a :class: `pyramid.response.Response` using the
-    ``request.ResponseClass`` property if available.
-    """
-    # Request is `None` or does not have a `ResponseClass`
-    if hasattr(request, 'ResponseClass'):
-        response_class = request.ResponseClass
-    else:
-        response_class = Response
 
+def _get_response_factory(registry):
+    """ Obtain a :class: `pyramid.response.Response` using the
+    `pyramid.interfaces.IResponseFactory`.
+    """
     response_factory = registry.queryUtility(
         IResponseFactory,
-        default=response_class
+        default=lambda r: Response()
     )
 
     return response_factory

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -555,15 +555,3 @@ def action_method(wrapped):
         functools.update_wrapper(wrapper, wrapped)
     wrapper.__docobj__ = wrapped
     return wrapper
-
-
-def _get_response_factory(registry):
-    """ Obtain a :class: `pyramid.response.Response` using the
-    `pyramid.interfaces.IResponseFactory`.
-    """
-    response_factory = registry.queryUtility(
-        IResponseFactory,
-        default=lambda r: Response()
-    )
-
-    return response_factory


### PR DESCRIPTION
This is a small clean-up to utilize the `ResponseClass` that is already available on the Request object.  This allows developers to define their own request factory with a new response class and have it used everywhere.

This is an attempt to help with #1256

As was suggested in the ticket, it might make more sense to just create a `set_response_factory` API and a `response_factory` kwarg of the configurator, but since the ResponseClass is already there it doesn't hurt to utilize it.  I can't think of a time you would want to create a response when you don't have a request which is why I opted to take this route instead.