### PR TITLE
- establish minimum version of 1.2.3 for Sphinx. I hope this works. See ...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ if not PY3:
     tests_require.append('zope.component>=3.11.0')
 
 docs_extras = [
-    'Sphinx',
+    'Sphinx >= 1.2.3',
     'docutils',
     'repoze.sphinx.autointerface',
     ]


### PR DESCRIPTION
...https://github.com/Pylons/pyramid/issues/1068
