### PR TITLE
Explicitly declare the PickleSerializer()

### DIFF
--- a/pyramid/tests/test_session.py
+++ b/pyramid/tests/test_session.py
@@ -299,7 +299,9 @@ class TestBaseCookieSession(SharedCookieSessionTests, unittest.TestCase):
 class TestSignedCookieSession(SharedCookieSessionTests, unittest.TestCase):
     def _makeOne(self, request, **kw):
         from pyramid.session import SignedCookieSessionFactory
+        from pyramid.session import PickleSerializer
         kw.setdefault('secret', 'secret')
+        kw.setdefault('serializer', PickleSerializer())
         return SignedCookieSessionFactory(**kw)(request)
 
     def _serialize(self, value, salt=b'pyramid.session.', hashalg='sha512'):


### PR DESCRIPTION
The default currently for SignedCookieSessionFactory is the PickleSerializer. If this was to ever change tests will fail.
Looking forwardly to a JSONSerializer and related tests in a seperate PR but interested in any comments. Thanks.