### PR TITLE
Add support for a json serializer (JSONSerializer) to the session module...

### DIFF
--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -11,6 +11,7 @@ from zope.interface import implementer
 from webob.cookies import SignedSerializer
 
 from pyramid.compat import (
+    json,
     pickle,
     PY3,
     text_,
@@ -140,6 +141,16 @@ class PickleSerializer(object):
 
     def dumps(self, appstruct):
         return pickle.dumps(appstruct, pickle.HIGHEST_PROTOCOL)
+
+class JSONSerializer(object):
+    """ A Webob cookie serializer that uses the JSON protocol to dump supported 
+    Python objects to the JSON equivalent."""
+    _compact = (',', ':')
+    def loads(self, bstruct):
+        return json.loads(text_(bstruct))
+
+    def dumps(self, objstruct):
+        return bytes_(json.dumps(objstruct, separators=self._compact))
 
 def BaseCookieSessionFactory(
     serializer,

--- a/pyramid/tests/test_session.py
+++ b/pyramid/tests/test_session.py
@@ -386,6 +386,21 @@ class TestSignedCookieSession(SharedCookieSessionTests, unittest.TestCase):
         session = self._makeOne(request, serializer=serializer)
         self.assertEqual(session['state'], 1)
 
+    def test_json_serializer(self):
+        import base64
+        from hashlib import sha512
+        import hmac
+        import time
+        from pyramid.session import JSONSerializer
+        request = testing.DummyRequest()
+        serializer = JSONSerializer()
+        json_struct = serializer.dumps((time.time(), 0, {'state': 1}))
+        sig = hmac.new(b'pyramid.session.secret', json_struct, sha512).digest()
+        cookieval = base64.urlsafe_b64encode(sig + json_struct).rstrip(b'=')
+        request.cookies['session'] = cookieval
+        session = self._makeOne(request, serializer=serializer)
+        self.assertEqual(session['state'], 1)
+
     def test_invalid_data_size(self):
         from hashlib import sha512
         import base64


### PR DESCRIPTION
Do you think this would be a good idea to add to the library? The test is pretty much exactly like the DummySerializer except for the fact that the JSONSerializer is more pyramid specific (using pyramid.compat helpers). Thanks.