### PR TITLE
Prevent DeprecationWarning from setuptools>=11.3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -125,6 +125,9 @@ Bug Fixes
   callback and thus behave just like the ``pyramid.renderers.JSON` renderer.
   See https://github.com/Pylons/pyramid/pull/1561
 
+- Prevent "parameters to load are deprecated" ``DeprecationWarning``
+  from setuptools>=11.3.
+
 Deprecations
 ------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -240,3 +240,5 @@ Contributors
 - Adrian Teng, 2014/12/17
 
 - Ilja Everila, 2015/02/05
+
+- Geoffrey T. Dairiki, 2015/02/06

--- a/pyramid/path.py
+++ b/pyramid/path.py
@@ -341,9 +341,10 @@ class DottedNameResolver(Resolver):
         # See https://pythonhosted.org/setuptools/history.html#id8
         ep = pkg_resources.EntryPoint.parse('x=%s' % value)
         if hasattr(ep, 'resolve'):
-            return ep.resolve()  # setuptools>=10.2
+            # setuptools>=10.2
+            return ep.resolve()  # pragma: NO COVER
         else:
-            return ep.load(False)
+            return ep.load(False)  # pragma: NO COVER
 
     def _zope_dottedname_style(self, value, package):
         """ package.module.attr style """

--- a/pyramid/path.py
+++ b/pyramid/path.py
@@ -337,8 +337,13 @@ class DottedNameResolver(Resolver):
                 value = package.__name__
             else:
                 value = package.__name__ + value
-        return pkg_resources.EntryPoint.parse(
-            'x=%s' % value).load(False)
+        # Calling EntryPoint.load with an argument is deprecated.
+        # See https://pythonhosted.org/setuptools/history.html#id8
+        ep = pkg_resources.EntryPoint.parse('x=%s' % value)
+        if hasattr(ep, 'resolve'):
+            return ep.resolve()  # setuptools>=10.2
+        else:
+            return ep.load(False)
 
     def _zope_dottedname_style(self, value, package):
         """ package.module.attr style """


### PR DESCRIPTION
Recent versions of `setuptools` have deprecated passing an argument to `EntryPoint.load`.  This prevents the deprecation warning for setuptools >= 11.3.  (The warning may still be issued for setuptools>=10.2,<11.3 — I'm not sure about this, and not sure that it is worth fixing in any case.)

See the changelog entries for [setuptools 11.3](https://pythonhosted.org/setuptools/history.html#id8) and [setuptools 10.2](https://pythonhosted.org/setuptools/history.html#id13) for more on this.

This should probably also be applied to the 1.5-branch.  Let me know if you'd like a separate PR for that.