### PR TITLE
Subscriber predicates can list events supported

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -80,6 +80,11 @@ Features
 - Support keyword-only arguments and function annotations in views in
   Python 3. See https://github.com/Pylons/pyramid/pull/1556
 
+- Subscriber predicates can have an ``events`` attribute that will be checked
+  when adding a subscriber. A ``ConfigurationError`` will be raised when
+  attempting to use a subscriber predicate with an event that it doesn't
+  support. See https://github.com/Pylons/pyramid/pull/1545
+
 Bug Fixes
 ---------
 

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -1555,12 +1555,33 @@ for example, the predicate can be used with subscribers registered for
 :class:`pyramid.events.NewRequest` and :class:`pyramid.events.ContextFound`
 events, but it cannot be used with subscribers registered for
 :class:`pyramid.events.ApplicationCreated` because the latter type of event
-has no ``request`` attribute.  The point being: unlike route and view
-predicates, not every type of subscriber predicate will necessarily be
-applicable for use in every subscriber registration.  It is not the
-responsibility of the predicate author to make every predicate make sense for
-every event type; it is the responsibility of the predicate consumer to use
-predicates that make sense for a particular event type registration.
+has no ``request`` attribute.
 
+Pyramid 1.6 adds the ability to raise an exception when a subscriber predicate
+is used for an event type that it doesn't support. To use this feature, add an
+``events`` attribute to the subscriber predicate with one or more event classes
+that the predicate supports. So the ``RequestPathStartsWith`` subscriber
+predicate shown earlier could be written like this:
 
+.. code-block:: python
+    :linenos:
 
+    class RequestPathStartsWith(object):
+        events = (NewRequest, ContextFound)
+
+        # The rest of the class is the same as before...
+
+    config.add_subscriber_predicate(
+        'request_path_startswith', RequestPathStartsWith)
+
+Now if you try to use the subscriber predicate for an unsupported event type,
+say ``ApplicationCreated``:
+
+.. code-block:: python
+    :linenos:
+
+    @subscriber(ApplicationCreated, request_path_startswith='/path')
+    def test_context_found_subscriber(event):
+        pass
+
+then a ``ConfigurationError`` will be raised.

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -1557,28 +1557,36 @@ events, but it cannot be used with subscribers registered for
 :class:`pyramid.events.ApplicationCreated` because the latter type of event
 has no ``request`` attribute.
 
-Pyramid 1.6 adds the ability to raise an exception when a subscriber predicate
-is used for an event type that it doesn't support. To use this feature, add an
-``events`` attribute to the subscriber predicate with one or more event classes
-that the predicate supports. So the ``RequestPathStartsWith`` subscriber
-predicate shown earlier could be written like this:
+Pyramid 1.6 adds the ability to raise an exception when an attempt is made to
+use a subscriber predicate with an event that doesn't work with that predicate.
+To use this feature, add a ``needed_attrs`` attribute to the subscriber
+predicate class with the names (strings) of one or more attribute names that
+the predicate needs to have in the ``event`` object. So the
+``RequestPathStartsWith`` subscriber predicate shown earlier could be written
+like this:
 
 .. code-block:: python
     :linenos:
+    :emphasize-lines: 2
 
     class RequestPathStartsWith(object):
-        events = (NewRequest, ContextFound)
+        needed_attrs = ('request',)
 
         # The rest of the class is the same as before...
 
     config.add_subscriber_predicate(
         'request_path_startswith', RequestPathStartsWith)
 
-Now if you try to use the subscriber predicate for an unsupported event type,
-say ``ApplicationCreated``:
+The ``needed_attrs`` attribute here is specifying that the
+``RequestPathStartsWith`` subscriber predicate only works with events that have
+a ``request`` attribute.
+
+Now if you try to use the subscriber predicate for an event that doesn't have a
+``request`` attribute, say ``ApplicationCreated``:
 
 .. code-block:: python
     :linenos:
+    :emphasize-lines: 1
 
     @subscriber(ApplicationCreated, request_path_startswith='/path')
     def test_context_found_subscriber(event):

--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -373,6 +373,7 @@ class Configurator(
         self.add_default_renderers()
         self.add_default_view_predicates()
         self.add_default_route_predicates()
+        self.add_default_subscriber_predicates()
 
         if exceptionresponse_view is not None:
             exceptionresponse_view = self.maybe_dotted(exceptionresponse_view)

--- a/pyramid/config/adapters.py
+++ b/pyramid/config/adapters.py
@@ -2,7 +2,7 @@ from webob import Response as WebobResponse
 
 from functools import update_wrapper
 
-from zope.interface import Interface
+from zope.interface import Interface, implementedBy
 
 from pyramid.interfaces import (
     IResponse,
@@ -18,6 +18,15 @@ from pyramid.config.util import (
 from pyramid.exceptions import ConfigurationError
 
 import pyramid.config.predicates
+
+
+def doesClassImplementAttribute(cls, attr_name):
+    for iface in implementedBy(cls):
+        # Attributes of interfaces are represented as dict keys
+        if iface.get(attr_name):
+            return True
+
+    return False
 
 
 class AdaptersConfiguratorMixin(object):
@@ -61,14 +70,18 @@ class AdaptersConfiguratorMixin(object):
             # Check for predicates that are not supported by the events we're
             # subscribing for
             for pred in preds:
-                pred_events = getattr(pred, 'events', None)
-                if pred_events:
-                    for event_class in iface:
-                        if event_class not in pred_events:
+                # Each predicate can require the event to have attributes
+                needed_attrs = getattr(pred, 'needed_attrs', [])
+                for needed_attr in needed_attrs:
+                    # @todo: It's confusing that `iface` is a tuple
+                    # It should be called `ifaces`
+                    # `iface1` is **actually** a single interface. :-)
+                    for iface1 in iface:
+                        if not doesClassImplementAttribute(iface1, needed_attr):
                             raise ConfigurationError(
-                                'Event %r not supported '
-                                'by subscriber predicate %r; supports: %r'
-                                % (event_class, pred.__class__, pred_events))
+                                'Event %r not supported by subscriber predicate %r; '
+                                'Event does not have needed attribute: %r'
+                                % (iface1, pred.__class__, needed_attr))
 
             derived_predicates = [ self._derive_predicate(p) for p in preds ]
             derived_subscriber = self._derive_subscriber(
@@ -86,7 +99,7 @@ class AdaptersConfiguratorMixin(object):
                 )
 
             self.registry.registerHandler(derived_subscriber, iface)
-            
+
         intr = self.introspectable(
             'subscribers',
             id(subscriber),
@@ -180,7 +193,40 @@ class AdaptersConfiguratorMixin(object):
             )
 
     def add_default_subscriber_predicates(self):
+        def get_subscriber_predicate_from_view_predicate(ViewPred):
+            # view pred takes args: (context, request)
+            # subscriber pred takes arg: (event) (which has event.request.context)
+            class SubscriberPred(ViewPred):
+                def __call__(self, event):
+                    try:
+                        return super(SubscriberPred, self).__call__(
+                            event.request.context,
+                            event.request
+                            )
+                    except AttributeError:
+                        return False
+            return SubscriberPred
+
         p = pyramid.config.predicates
+
+        for (name, factory) in (
+            ('xhr', p.XHRPredicate),
+            ('request_method', p.RequestMethodPredicate),
+            ('path_info', p.PathInfoPredicate),
+            ('request_param', p.RequestParamPredicate),
+            ('header', p.HeaderPredicate),
+            ('accept', p.AcceptPredicate),
+            ('containment', p.ContainmentPredicate),
+            ('request_type', p.RequestTypePredicate),
+            ('match_param', p.MatchParamPredicate),
+            ('check_csrf', p.CheckCSRFTokenPredicate),
+            ('physical_path', p.PhysicalPathPredicate),
+            ('effective_principals', p.EffectivePrincipalsPredicate),
+            ('custom', p.CustomPredicate),
+            ):
+            factory = get_subscriber_predicate_from_view_predicate(factory)
+            self.add_subscriber_predicate(name, factory)
+
         for (name, factory) in (
             ('context', p.ContextSubscriberPredicate),
             ):

--- a/pyramid/config/adapters.py
+++ b/pyramid/config/adapters.py
@@ -17,6 +17,8 @@ from pyramid.config.util import (
 
 from pyramid.exceptions import ConfigurationError
 
+import pyramid.config.predicates
+
 
 class AdaptersConfiguratorMixin(object):
     @action_method
@@ -176,6 +178,13 @@ class AdaptersConfiguratorMixin(object):
             weighs_more_than=weighs_more_than,
             weighs_less_than=weighs_less_than
             )
+
+    def add_default_subscriber_predicates(self):
+        p = pyramid.config.predicates
+        for (name, factory) in (
+            ('context', p.ContextSubscriberPredicate),
+            ):
+            self.add_subscriber_predicate(name, factory)
 
     @action_method
     def add_response_adapter(self, adapter, type_or_iface):

--- a/pyramid/config/predicates.py
+++ b/pyramid/config/predicates.py
@@ -1,5 +1,6 @@
 import re
 
+from pyramid.events import ContextFound
 from pyramid.exceptions import ConfigurationError
 
 from pyramid.compat import is_nonstr_iter
@@ -294,3 +295,19 @@ class EffectivePrincipalsPredicate(object):
                 return True
         return False
 
+class ContextSubscriberPredicate(object):
+    events = (ContextFound,)
+
+    def __init__(self, val, config):
+        self.val = val
+
+    def text(self):
+        return 'context = %s' % (self.val,)
+
+    phash = text
+
+    def __call__(self, event):
+        try:
+            return isinstance(event.request.context, self.val)
+        except AttributeError as e:
+            pass

--- a/pyramid/tests/test_config/test_adapters.py
+++ b/pyramid/tests/test_config/test_adapters.py
@@ -223,6 +223,23 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertRaises(ConfigurationError,
             config.add_subscriber, subscriber, Event2, custom=1)
 
+    def test_context_found_subscriber_predicate(self):
+        from pyramid.events import ContextFound
+        class Foo(object): pass
+        class DummyRequest: pass
+        L = []
+        def subscriber(event): L.append(event)
+        config = self._makeOne(autocommit=True)
+        config.add_subscriber(subscriber, ContextFound, context=Foo)
+        request = DummyRequest()
+        event = ContextFound(request)
+        config.registry.notify(event)
+        self.assertEqual(len(L), 0)
+        request.context = Foo()
+        event = ContextFound(request)
+        config.registry.notify(event)
+        self.assertEqual(len(L), 1)
+
     def test_add_response_adapter(self):
         from pyramid.interfaces import IResponse
         config = self._makeOne(autocommit=True)


### PR DESCRIPTION
A subscriber predicate can specify what events it supports by setting an attribute called `events` -- e.g.:

```python
class ContextSubscriberPredicate(object):
    events = (ContextFound,)
    ...


def includeme(config):
    config.add_subscriber_predicate('context', ContextSubscriberPredicate)
```

If an attempt is made to add a subscriber for an event that they don't support:

```python
@subscriber(BeforeRender, context=Role)
def test_context_found_subscriber(event):
    print('*** ContextFound: %r ***' % event.request.context)
```

then a `ConfigurationError` is raised - e.g.:

    pyramid.exceptions.ConfigurationExecutionError:
    <class 'pyramid.exceptions.ConfigurationError'>: Event
    <class 'pyramid.events.BeforeRender'> not supported by subscriber predicate
    <class 'kotti_gabriel.ContextSubscriberPredicate'>;
    supports: (<class 'pyramid.events.ContextFound'>,)
      in:
      Line 80 of file /Users/marca/dev/git-repos/pyramid/pyramid/events.py:
        config.add_subscriber(wrapped, iface, **self.predicates)

This solves a limitation that @mmerickel mentioned in #1544.

Cc: @mmerickel, @sontek 