### PR TITLE
Add a subscriber_predicate decorator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -77,6 +77,9 @@ Features
   output by showing the module instead of just ``__repr__``.
   See https://github.com/Pylons/pyramid/pull/1488
 
+- Added ``pyramid.events.subscriber_predicate`` decorator to register a class
+  as a subscriber predicate. See https://github.com/Pylons/pyramid/pull/1546
+
 Bug Fixes
 ---------
 

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -1514,6 +1514,16 @@ Once you've created a subscriber predicate, it may registered via
     config.add_subscriber_predicate(
         'request_path_startswith', RequestPathStartsWith)
 
+If instead you prefer to use decorators and a :term:`scan`, you can use the
+:class:`pyramid.events.subscriber_predicate` decorator to register a class as a
+subscriber predicate:
+
+.. code-block:: python
+
+    @subscriber_predicate('request_path_startswith')
+    class RequestPathStartsWith(object):
+        # Rest of class definition is the same
+
 Once a subscriber predicate is registered, you can use it in a call to
 :meth:`pyramid.config.Configurator.add_subscriber` or to
 :class:`pyramid.events.subscriber`.  Here's an example of using the

--- a/pyramid/events.py
+++ b/pyramid/events.py
@@ -83,6 +83,46 @@ class subscriber(object):
         self.venusian.attach(wrapped, self.register, category='pyramid')
         return wrapped
 
+class subscriber_predicate(object):
+    """ Decorator activated via a :term:`scan` which treats the class
+    being decorated as a :term:`subscriber predicate` with name ``name``.
+
+    For example:
+
+    .. code-block:: python
+
+        @subscriber_predicate('context')
+        class ContextSubscriberPredicate(object):
+            events = (ContextFound,)
+
+            def __init__(self, val, config):
+                self.val = val
+
+            def text(self):
+                return 'context = %s' % (self.val,)
+
+            phash = text
+
+            def __call__(self, event):
+                return isinstance(event.request.context, self.val)
+
+       @subscriber(ContextFound, context=Host)
+       def mysubscriber(event):
+           print(event)
+    """
+    venusian = venusian # for unit testing
+
+    def __init__(self, name):
+        self.name = name
+
+    def register(self, scanner, name, wrapped):
+        config = scanner.config
+        config.add_subscriber_predicate(self.name, wrapped)
+
+    def __call__(self, wrapped):
+        self.venusian.attach(wrapped, self.register, category='pyramid')
+        return wrapped
+
 @implementer(INewRequest)
 class NewRequest(object):
     """ An instance of this class is emitted as an :term:`event`

--- a/pyramid/tests/pkgs/eventonly/__init__.py
+++ b/pyramid/tests/pkgs/eventonly/__init__.py
@@ -1,6 +1,7 @@
 from pyramid.view import view_config
-from pyramid.events import subscriber
+from pyramid.events import subscriber, subscriber_predicate
 
+@subscriber_predicate('yup')
 class Yup(object):
     def __init__(self, val, config):
         self.val = val
@@ -59,6 +60,4 @@ def sendfoobar(request):
     return response
 
 def includeme(config):
-    config.add_subscriber_predicate('yup', Yup)
     config.scan('pyramid.tests.pkgs.eventonly')
-    


### PR DESCRIPTION
The declarative version of the imperative way: `add_subscriber_predicate`

E.g.:

```python
    @subscriber_predicate('context')
    class ContextSubscriberPredicate(object):
        def __init__(self, val, config):
            self.val = val

        def text(self):
            return 'context = %s' % (self.val,)

        phash = text

        def __call__(self, event):
            return isinstance(event.request.context, self.val)
```

Cc: @mmerickel, @sontek 