### PR TITLE
[Backport from 1.6] Give pserve the ability to open server in browser (pserve --browser)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@ Next release
   output by showing the module instead of just ``__repr__``.
   See: https://github.com/Pylons/pyramid/pull/1542
 
+- ``pserve`` can now take a ``-b`` or ``--browser`` option to open the server
+  URL in a web browser. See https://github.com/Pylons/pyramid/pull/1533
+
 .. _changes_1.5.2:
 
 1.5.2 (2014-11-09)

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -345,7 +345,7 @@ class PServeCommand(object):
             def open_browser():
                 context = loadcontext(SERVER, app_spec, name=app_name, relative_to=base,
                         global_conf=vars)
-                url = 'http://{host}:{port}/'.format(**context.config())
+                url = 'http://127.0.0.1:{port}/'.format(**context.config())
                 time.sleep(1)
                 webbrowser.open(url)
             t = threading.Thread(target=open_browser)

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -21,9 +21,11 @@ import textwrap
 import threading
 import time
 import traceback
+import webbrowser
 
 from paste.deploy import loadserver
 from paste.deploy import loadapp
+from paste.deploy.loadwsgi import loadcontext, SERVER
 
 from pyramid.compat import PY3
 from pyramid.compat import WIN
@@ -121,6 +123,11 @@ class PServeCommand(object):
         dest='monitor_restart',
         action='store_true',
         help="Auto-restart server if it dies")
+    parser.add_option(
+        '-b', '--browser',
+        dest='browser',
+        action='store_true',
+        help="Open a web browser to server url")
     parser.add_option(
         '--status',
         action='store_true',
@@ -333,6 +340,17 @@ class PServeCommand(object):
                 else:
                     msg = ''
                 self.out('Exiting%s (-v to see traceback)' % msg)
+
+        if self.options.browser:
+            def open_browser():
+                context = loadcontext(SERVER, app_spec, name=app_name, relative_to=base,
+                        global_conf=vars)
+                url = 'http://{host}:{port}/'.format(**context.config())
+                time.sleep(1)
+                webbrowser.open(url)
+            t = threading.Thread(target=open_browser)
+            t.setDaemon(True)
+            t.start()
 
         serve()
 


### PR DESCRIPTION
E.g.:

    pserve app.ini --browser

or:

    pserve app.ini -b