### PR TITLE
use getfullargspec in PY3, allowing annotations in subscribers

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -238,3 +238,5 @@ Contributors
 - Hugo Branquinho, 2014/11/25
 
 - Adrian Teng, 2014/12/17
+
+- Ilja Everila, 2015/02/05

--- a/pyramid/config/util.py
+++ b/pyramid/config/util.py
@@ -22,6 +22,12 @@ ActionInfo = ActionInfo # support bw compat imports
 MAX_ORDER = 1 << 30
 DEFAULT_PHASH = md5().hexdigest()
 
+# support annotations and keyword-only arguments in PY3
+try:
+    getargspec = inspect.getfullargspec
+except AttributeError:
+    getargspec = inspect.getargspec
+
 def as_sorted_tuple(val):
     if not is_nonstr_iter(val):
         val = (val,)
@@ -201,7 +207,7 @@ def takes_one_arg(callee, attr=None, argname=None):
             return False
 
     try:
-        argspec = inspect.getargspec(fn)
+        argspec = getargspec(fn)
     except TypeError:
         return False
 

--- a/pyramid/tests/test_config/test_util.py
+++ b/pyramid/tests/test_config/test_util.py
@@ -1,5 +1,5 @@
 import unittest
-from pyramid.compat import text_
+from pyramid.compat import text_, PY3
 
 class TestPredicateList(unittest.TestCase):
 
@@ -567,6 +567,14 @@ class Test_takes_one_arg(unittest.TestCase):
                 """ """
         foo = Foo()
         self.assertTrue(self._callFUT(foo.method))
+
+    if PY3:
+        def test_function_annotations(self):
+            def foo(bar):
+                """ """
+            # avoid SyntaxErrors in python2
+            foo.__annotations__.update({'bar': 'baz'})
+            self.assertTrue(self._callFUT(foo))
 
 class TestNotted(unittest.TestCase):
     def _makeOne(self, predicate):

--- a/pyramid/tests/test_config/test_util.py
+++ b/pyramid/tests/test_config/test_util.py
@@ -568,13 +568,12 @@ class Test_takes_one_arg(unittest.TestCase):
         foo = Foo()
         self.assertTrue(self._callFUT(foo.method))
 
-    if PY3:
-        def test_function_annotations(self):
-            def foo(bar):
-                """ """
-            # avoid SyntaxErrors in python2
-            foo.__annotations__.update({'bar': 'baz'})
-            self.assertTrue(self._callFUT(foo))
+    def test_function_annotations(self):
+        def foo(bar):
+            """ """
+        # avoid SyntaxErrors in python2, this if effectively nop
+        getattr(foo, '__annotations__', {}).update({'bar': 'baz'})
+        self.assertTrue(self._callFUT(foo))
 
 class TestNotted(unittest.TestCase):
     def _makeOne(self, predicate):

--- a/pyramid/tests/test_config/test_util.py
+++ b/pyramid/tests/test_config/test_util.py
@@ -1,5 +1,5 @@
 import unittest
-from pyramid.compat import text_, PY3
+from pyramid.compat import text_
 
 class TestPredicateList(unittest.TestCase):
 


### PR DESCRIPTION
Subscribing event handlers with python3 annotations prevents launching applications.

Though annotations may seem a bit redundant in event handlers, since `@subscriber(IEvent)` already states the type of event received, it does serve a purpose for IDEs and autocompletion etc.

Here's a sample traceback from failed app launch before the patch:

```py3tb
  File "/home/foo/venv/lib/python3.4/site-packages/pyramid-1.5-py3.4.egg/pyramid/config/adapters.py", line 60, in register
    derived_predicates,
  File "/home/foo/venv/lib/python3.4/site-packages/pyramid-1.5-py3.4.egg/pyramid/config/adapters.py", line 101, in _derive_subscriber
    if eventonly(subscriber):
  File "/home/foo/venv/lib/python3.4/site-packages/pyramid-1.5-py3.4.egg/pyramid/config/adapters.py", line 327, in eventonly
    return takes_one_arg(callee, argname='event')
  File "/home/foo/venv/lib/python3.4/site-packages/pyramid-1.5-py3.4.egg/pyramid/config/util.py", line 204, in takes_one_arg
    argspec = inspect.getargspec(fn)
  File "/usr/lib/python3.4/inspect.py", line 930, in getargspec
    raise ValueError("Function has keyword-only arguments or annotations"
pyramid.exceptions.ConfigurationExecutionError: <class 'ValueError'>: Function has keyword-only arguments or annotations, use getfullargspec() API which can support them
```