### PR TITLE
update render_to_response to prevent renderers from mutating request.response

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -80,6 +80,16 @@ Features
 - Support keyword-only arguments and function annotations in views in
   Python 3. See https://github.com/Pylons/pyramid/pull/1556
 
+- ``request.response`` will no longer be mutated when using the
+  ``pyramid.renderers.render_to_response()`` API.  Almost all renderers
+  mutate the ``request.response`` response object (for example, the JSON
+  renderer sets ``request.response.content_type`` to ``application/json``).
+  However, when invoking ``render_to_response`` it is not expected that the
+  response object being returned would be the same one used later in the
+  request. The response object returned from ``render_to_response`` is now
+  explicitly different from ``request.response``. This does not change the
+  API of a renderers. See https://github.com/Pylons/pyramid/pull/1563
+
 Bug Fixes
 ---------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,14 +81,18 @@ Features
   Python 3. See https://github.com/Pylons/pyramid/pull/1556
 
 - ``request.response`` will no longer be mutated when using the
-  ``pyramid.renderers.render_to_response()`` API.  Almost all renderers
+  ``pyramid.renderers.render_to_response()`` API.  It is now necessary to
+  pass in a ``response=`` argument to ``render_to_response`` if you wish to
+  supply the renderer with a custom response object for it to use. If you
+  do not pass one then a response object will be created using the
+  application's ``IResponseFactory``. Almost all renderers
   mutate the ``request.response`` response object (for example, the JSON
   renderer sets ``request.response.content_type`` to ``application/json``).
   However, when invoking ``render_to_response`` it is not expected that the
   response object being returned would be the same one used later in the
   request. The response object returned from ``render_to_response`` is now
   explicitly different from ``request.response``. This does not change the
-  API of a renderers. See https://github.com/Pylons/pyramid/pull/1563
+  API of a renderer. See https://github.com/Pylons/pyramid/pull/1563
 
 Bug Fixes
 ---------

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -79,7 +79,11 @@ def render(renderer_name, value, request=None, package=None):
 
     return result
 
-def render_to_response(renderer_name, value, request=None, package=None):
+def render_to_response(renderer_name,
+                       value,
+                       request=None,
+                       package=None,
+                       response=None):
     """ Using the renderer ``renderer_name`` (a template
     or a static renderer), render the value (or set of values) using
     the result of the renderer's ``__call__`` method (usually a string
@@ -112,12 +116,14 @@ def render_to_response(renderer_name, value, request=None, package=None):
     with the most correct 'system' values (``request`` and ``context``
     in particular). Keep in mind that any changes made to ``request.response``
     prior to calling this function will not be reflected in the resulting
-    response object. A new response object will be created for each call.
+    response object. A new response object will be created for each call
+    unless one is passed as the ``response`` argument.
 
     .. versionchanged:: 1.6
        In previous versions, any changes made to ``request.response`` outside
        of this function call would affect the returned response. This is no
-       longer the case.
+       longer the case. If you wish to send in a pre-initialized response
+       then you may pass one in the ``response`` argument.
 
     """
     try:
@@ -130,6 +136,8 @@ def render_to_response(renderer_name, value, request=None, package=None):
                             registry=registry)
 
     with temporary_response(request):
+        if response is not None:
+            request.response = response
         result = helper.render_to_response(value, None, request=request)
 
     return result

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -114,6 +114,11 @@ def render_to_response(renderer_name, value, request=None, package=None):
     prior to calling this function will not be reflected in the resulting
     response object. A new response object will be created for each call.
 
+    .. versionchanged:: 1.6
+       In previous versions, any changes made to ``request.response`` outside
+       of this function call would affect the returned response. This is no
+       longer the case.
+
     """
     try:
         registry = request.registry

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -110,9 +110,9 @@ def render_to_response(renderer_name, value, request=None, package=None):
 
     Supply a ``request`` parameter in order to provide the renderer
     with the most correct 'system' values (``request`` and ``context``
-    in particular). Keep in mind that if the ``request`` parameter is
-    not passed in, any changes to ``request.response`` attributes made
-    before calling this function will be ignored.
+    in particular). Keep in mind that any changes made to ``request.response``
+    prior to calling this function will not be reflected in the resulting
+    response object. A new response object will be created for each call.
 
     """
     try:

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -517,10 +517,11 @@ class Test_render_to_response(unittest.TestCase):
     def tearDown(self):
         testing.tearDown()
 
-    def _callFUT(self, renderer_name, value, request=None, package=None):
+    def _callFUT(self, renderer_name, value, request=None, package=None,
+                 response=None):
         from pyramid.renderers import render_to_response
         return render_to_response(renderer_name, value, request=request,
-                                  package=package)
+                                  package=package, response=response)
 
     def test_it_no_request(self):
         renderer = self.config.testing_add_renderer(
@@ -576,6 +577,18 @@ class Test_render_to_response(unittest.TestCase):
         request = DummyRequestWithClassResponse()
         # use a json renderer, which will mutate the response
         result = self._callFUT('json', dict(a=1), request=request)
+        self.assertEqual(result.body, b'{"a": 1}')
+        self.assertFalse('response' in request.__dict__)
+
+    def test_custom_response_object(self):
+        class DummyRequestWithClassResponse(object):
+            pass
+        request = DummyRequestWithClassResponse()
+        response = DummyResponse()
+        # use a json renderer, which will mutate the response
+        result = self._callFUT('json', dict(a=1), request=request,
+                               response=response)
+        self.assertTrue(result is response)
         self.assertEqual(result.body, b'{"a": 1}')
         self.assertFalse('response' in request.__dict__)
 
@@ -639,7 +652,14 @@ class Dummy:
 
 class DummyResponse:
     status = '200 OK'
+    default_content_type = 'text/html'
+    content_type = default_content_type
     headerlist = ()
     app_iter = ()
-    body = ''
+    body = b''
+
+    # compat for renderer that will set unicode on py3
+    def _set_text(self, val): # pragma: no cover
+        self.body = val.encode('utf8')
+    text = property(fset=_set_text)
 


### PR DESCRIPTION
fixes #1536

I think this should be fairly non-controversial. When using `render_to_response` you'd probably expect that to not have any side effects on `request.response` which you may also end up using during the request. This patch just keeps them separate.