### PR TITLE
Fix: default content type issues in renderers

### DIFF
--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -162,7 +162,7 @@ def string_renderer_factory(info):
         if request is not None:
             response = request.response
             ct = response.content_type
-            if ct == response.default_content_type:
+            if response.implicit_content_type:
                 response.content_type = 'text/plain'
         return value
     return _render
@@ -259,8 +259,7 @@ class JSON(object):
             request = system.get('request')
             if request is not None:
                 response = request.response
-                ct = response.content_type
-                if ct == response.default_content_type:
+                if response.implicit_content_type:
                     response.content_type = 'application/json'
             default = self._make_default(request)
             return self.serializer(value, default=default, **self.kw)
@@ -366,7 +365,7 @@ class JSONP(JSON):
                     ct = 'application/javascript'
                     body = '%s(%s);' % (callback, val)
                 response = request.response
-                if response.content_type == response.default_content_type:
+                if response.implicit_content_type:
                     response.content_type = ct
             return body
         return _render

--- a/pyramid/tests/test_config/test_views.py
+++ b/pyramid/tests/test_config/test_views.py
@@ -4034,6 +4034,7 @@ from pyramid.interfaces import IResponse
 class DummyResponse(object):
     content_type = None
     default_content_type = None
+    implicit_content_type = True
     body = None
 
 class DummyRequest:

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -624,4 +624,4 @@ class DummyResponse:
     headerlist = ()
     app_iter = ()
     body = ''
-
+    implicit_content_type = True

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -130,6 +130,13 @@ class Test_string_renderer_factory(unittest.TestCase):
         renderer('', {'request':request})
         self.assertEqual(request.response.content_type, 'text/mishmash')
 
+    def test_with_request_content_type_happens_to_be_default(self):
+        request = testing.DummyRequest()
+        request.response.content_type = 'text/html'
+        renderer = self._callFUT(None)
+        renderer('', {'request':request})
+        self.assertEqual(request.response.content_type, 'text/html')
+
 
 class TestRendererHelper(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Alright, I wanted to provide this as a possible way to fix #1344.

This uses the fact that `content_type` is a property in WebOb's `Response` and it is not used when setting the `content_type` to `default_content_type` in `Response.__init__()`, since that just shoves it directly into the headerlist. So this will break if anyone changes WebOb, but WebOb tends to move slower than molasses, this fix should hold for at least a couple of years!

Although I do think that this is a very dirty hack, it does currently fix the issue. I really hope there is a different fix that is much cleaner!