### PR TITLE
Document the factory requires a positional argument

### DIFF
--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -368,6 +368,9 @@ changed by passing a ``response_factory`` argument to the constructor of the
 :term:`configurator`.  This argument can be either a callable or a
 :term:`dotted Python name` representing a callable.
 
+The factory takes a single positional argument, which is a :term:`Request`
+object. The argument may be the value ``None``.
+
 .. code-block:: python
    :linenos:
 


### PR DESCRIPTION
Start on https://github.com/Pylons/pyramid/issues/1537

Since it was never documented other than in the glossary that it takes a single positional argument, we don't need to add much to document that it may be None.