### PR TITLE
Allow sub-classing Request and add_request_method, fixes #1529

### DIFF
--- a/pyramid/tests/test_request.py
+++ b/pyramid/tests/test_request.py
@@ -438,6 +438,7 @@ class Test_call_app_with_subpath_as_path_info(unittest.TestCase):
 class Test_subclassing_Request(unittest.TestCase):
 
     def test_subclass(self):
+        from pyramid.interfaces import IRequest
         from pyramid.request import Request
         from zope.interface import providedBy, implementedBy
 
@@ -445,7 +446,16 @@ class Test_subclassing_Request(unittest.TestCase):
             pass
 
         self.assertTrue(hasattr(Request, '__provides__'))
+        self.assertTrue(hasattr(Request, '__implemented__'))
+        self.assertTrue(hasattr(Request, '__providedBy__'))
         self.assertFalse(hasattr(RequestSub, '__provides__'))
+        self.assertTrue(hasattr(RequestSub, '__providedBy__'))
+        self.assertTrue(hasattr(RequestSub, '__implemented__'))
+
+        self.assertTrue(IRequest.implementedBy(RequestSub))
+        # The call to implementedBy will add __provides__ to the class
+        self.assertTrue(hasattr(RequestSub, '__provides__'))
+
 
     def test_subclass_with_implementer(self):
         from pyramid.interfaces import IRequest
@@ -457,11 +467,18 @@ class Test_subclassing_Request(unittest.TestCase):
             pass
 
         self.assertTrue(hasattr(Request, '__provides__'))
+        self.assertTrue(hasattr(Request, '__implemented__'))
+        self.assertTrue(hasattr(Request, '__providedBy__'))
         self.assertTrue(hasattr(RequestSub, '__provides__'))
+        self.assertTrue(hasattr(RequestSub, '__providedBy__'))
+        self.assertTrue(hasattr(RequestSub, '__implemented__'))
 
         req = RequestSub({})
         req._set_properties({'b': 'b'})
-        self.assertEqual(providedBy(req), implementedBy(RequestSub))
+
+        self.assertTrue(IRequest.providedBy(req))
+        self.assertTrue(IRequest.implementedBy(RequestSub))
+
 
 class DummyRequest:
     def __init__(self, environ=None):

--- a/pyramid/tests/test_request.py
+++ b/pyramid/tests/test_request.py
@@ -435,6 +435,34 @@ class Test_call_app_with_subpath_as_path_info(unittest.TestCase):
         self.assertEqual(request.environ['SCRIPT_NAME'], '/' + encoded)
         self.assertEqual(request.environ['PATH_INFO'], '/' + encoded)
 
+class Test_subclassing_Request(unittest.TestCase):
+
+    def test_subclass(self):
+        from pyramid.request import Request
+        from zope.interface import providedBy, implementedBy
+
+        class RequestSub(Request):
+            pass
+
+        self.assertTrue(hasattr(Request, '__provides__'))
+        self.assertFalse(hasattr(RequestSub, '__provides__'))
+
+    def test_subclass_with_implementer(self):
+        from pyramid.interfaces import IRequest
+        from pyramid.request import Request
+        from zope.interface import providedBy, implementedBy, implementer
+
+        @implementer(IRequest)
+        class RequestSub(Request):
+            pass
+
+        self.assertTrue(hasattr(Request, '__provides__'))
+        self.assertTrue(hasattr(RequestSub, '__provides__'))
+
+        req = RequestSub({})
+        req._set_properties({'b': 'b'})
+        self.assertEqual(providedBy(req), implementedBy(RequestSub))
+
 class DummyRequest:
     def __init__(self, environ=None):
         if environ is None:

--- a/pyramid/tests/test_request.py
+++ b/pyramid/tests/test_request.py
@@ -479,6 +479,20 @@ class Test_subclassing_Request(unittest.TestCase):
         self.assertTrue(IRequest.providedBy(req))
         self.assertTrue(IRequest.implementedBy(RequestSub))
 
+    def test_subclass_mutate_before_providedBy(self):
+        from pyramid.interfaces import IRequest
+        from pyramid.request import Request
+        from zope.interface import providedBy, implementedBy, implementer
+
+        class RequestSub(Request):
+            pass
+
+        req = RequestSub({})
+        req._set_properties({'b': 'b'})
+
+        self.assertTrue(IRequest.providedBy(req))
+        self.assertTrue(IRequest.implementedBy(RequestSub))
+
 
 class DummyRequest:
     def __init__(self, environ=None):

--- a/pyramid/tests/test_request.py
+++ b/pyramid/tests/test_request.py
@@ -436,7 +436,6 @@ class Test_call_app_with_subpath_as_path_info(unittest.TestCase):
         self.assertEqual(request.environ['PATH_INFO'], '/' + encoded)
 
 class Test_subclassing_Request(unittest.TestCase):
-
     def test_subclass(self):
         from pyramid.interfaces import IRequest
         from pyramid.request import Request

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -87,10 +87,10 @@ class InstancePropertyMixin(object):
         if attrs:
             parent = self.__class__
             cls = type(parent.__name__, (parent, object), attrs)
-            # We assign __provides__, __implemented__ and __providedBy__ below
-            # to prevent a memory leak that results from from the usage of this
-            # instance's eventual use in an adapter lookup.  Adapter lookup
-            # results in ``zope.interface.implementedBy`` being called with the
+            # We assign __provides__ and __implemented__ below to prevent a
+            # memory leak that results from from the usage of this instance's
+            # eventual use in an adapter lookup.  Adapter lookup results in
+            # ``zope.interface.implementedBy`` being called with the
             # newly-created class as an argument.  Because the newly-created
             # class has no interface specification data of its own, lookup
             # causes new ClassProvides and Implements instances related to our
@@ -99,7 +99,7 @@ class InstancePropertyMixin(object):
             # want this new class to behave exactly like it is the parent class
             # instead.  See https://github.com/Pylons/pyramid/issues/1212 for
             # more information.
-            for name in ('__implemented__', '__providedBy__', '__provides__'):
+            for name in ('__implemented__', '__provides__'):
                 # we assign these attributes conditionally to make it possible
                 # to test this class in isolation without having any interfaces
                 # attached to it


### PR DESCRIPTION
I wrote some additional tests to try and track down what was going on, on top of that I've applied a fix that seems to work.

Fixes: https://github.com/Pylons/pyramid/issues/1529