### PR TITLE
Protect against Session Fixation and session data leakage when crossing privilege boundaries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -128,6 +128,14 @@ Features
   that as the response class instead of the default ``HTTPFound``.  See
   https://github.com/Pylons/pyramid/pull/1610
 
+- Protect against session fixation attacks and leaking session data across
+  privilege boundaries by ensuring that ``pyramid.security.remember`` and
+  ``pyramid.security.forget`` invalidate the old session when a session factory
+  has been configured. However, ensure that session data is kept intact when
+  calling ``pyramid.security.remember()`` when the previous userid was either
+  ``None`` or the same as the userid that is being remembered.
+  See https://github.com/Pylons/pyramid/pull/1570
+
 Bug Fixes
 ---------
 


### PR DESCRIPTION
This will invalidate the session in the ``SessionAuthenticationPolicy().remember()``, ensuring that all the data is copied over to the new session. This will ensure that for server side sessions which have a session ID, a new session ID is granted when going from an unauthenticated user to an authenticated user. For client side sessions this will simply do a little extra work but ultimately be a no-op.

Fixes #1569