### PR TITLE
Revert #1576 "Don't create sdist with tox"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-skipsdist = True
 envlist = 
     py26,py27,py32,py33,py34,pypy,pypy3,cover
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,14 @@ envlist =
 
 [testenv]
 commands = 
-    python setup.py -q dev
+    pip -q install pyramid[testing]
     python setup.py -q test -q
 
 [testenv:cover]
 basepython =
     python2.6
 commands = 
-    python setup.py -q dev
+    pip install pyramid[testing]
     nosetests --with-xunit --with-xcoverage
 deps =
     nosexcover


### PR DESCRIPTION
" (latest setuptools doesn't like mixing)"

This reverts commit c534e00ed06ef17506cf5f74553310ec15653834.

I can see no valid reason for that change, and it loses us the assurance that our sdists can be correctly installed.