### PR TITLE
only reset terminal echo flag if stdin is a tty

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -121,7 +121,8 @@ Bug Fixes
 
 - Work around an issue where ``pserve --reload`` would leave terminal echo
   disabled if it reloaded during a pdb session.
-  See https://github.com/Pylons/pyramid/pull/1577
+  See https://github.com/Pylons/pyramid/pull/1577,
+  https://github.com/Pylons/pyramid/pull/1592
 
 - ``pyramid.wsgi.wsgiapp`` and ``pyramid.wsgi.wsgiapp2`` now raise
   ``ValueError`` when accidentally passed ``None``.

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -716,11 +716,12 @@ def _turn_sigterm_into_systemexit(): # pragma: no cover
 
 def ensure_echo_on(): # pragma: no cover
     if termios:
-        fd = sys.stdin.fileno()
-        attr_list = termios.tcgetattr(fd)
-        if not attr_list[3] & termios.ECHO:
-            attr_list[3] |= termios.ECHO
-            termios.tcsetattr(fd, termios.TCSANOW, attr_list)
+        fd = sys.stdin
+        if fd.isatty():
+            attr_list = termios.tcgetattr(fd)
+            if not attr_list[3] & termios.ECHO:
+                attr_list[3] |= termios.ECHO
+                termios.tcsetattr(fd, termios.TCSANOW, attr_list)
 
 def install_reloader(poll_interval=1, extra_files=None): # pragma: no cover
     """


### PR DESCRIPTION
This fixes the following regression reported when running pserve --reload as a system service:

```
Traceback (most recent call last):
File "/opt/clearsky/bin/pserve", line 9, in <module> load_entry_point('pyramid==1.5.3', 'console_scripts', 'pserve')()
File "/opt/clearsky/lib/python2.7/site-packages/pyramid-1.5.3-py2.7.egg/pyramid/scripts/pserve.py", line 58, in main return command.run()
File "/opt/clearsky/lib/python2.7/site-packages/pyramid-1.5.3-py2.7.egg/pyramid/scripts/pserve.py", line 226, in run install_reloader(int(self.options.reload_interval), [app_spec])
File "/opt/clearsky/lib/python2.7/site-packages/pyramid-1.5.3-py2.7.egg/pyramid/scripts/pserve.py", line 734, in install_reloader ensure_echo_on()
File "/opt/clearsky/lib/python2.7/site-packages/pyramid-1.5.3-py2.7.egg/pyramid/scripts/pserve.py", line 720, in ensure_echo_on attr_list = termios.tcgetattr(fd)
termios.error: (25, 'Inappropriate ioctl for device')
```

Backport for 1.5 on its way...