### PR TITLE
Add some validation for the JSONP callback

### DIFF
--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import os
+import re
 
 from zope.interface import (
     implementer,
@@ -22,6 +23,8 @@ from pyramid.compat import (
 from pyramid.decorator import reify
 
 from pyramid.events import BeforeRender
+
+from pyramid.httpexceptions import HTTPBadRequest
 
 from pyramid.path import caller_package
 
@@ -308,6 +311,8 @@ class JSON(object):
 
 json_renderer_factory = JSON() # bw compat
 
+JSONP_VALID_CALLBACK = re.compile(r"^[a-zA-Z_$][0-9a-zA-Z_$]+$")
+
 class JSONP(JSON):
     """ `JSONP <http://en.wikipedia.org/wiki/JSONP>`_ renderer factory helper
     which implements a hybrid json/jsonp renderer.  JSONP is useful for
@@ -388,7 +393,11 @@ class JSONP(JSON):
             body = val
             if request is not None:
                 callback = request.GET.get(self.param_name)
+
                 if callback is not None:
+                    if not JSONP_VALID_CALLBACK.match(callback):
+                        raise HTTPBadRequest('Invalid JSONP callback function name.')
+
                     ct = 'application/javascript'
                     body = '%s(%s);' % (callback, val)
                 response = request.response

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -646,6 +646,14 @@ class TestJSONP(unittest.TestCase):
         result = renderer({'a':'1'}, {})
         self.assertEqual(result, '{"a": "1"}')
 
+    def test_render_to_jsonp_invalid_callback(self):
+        from pyramid.httpexceptions import HTTPBadRequest
+        renderer_factory = self._makeOne()
+        renderer = renderer_factory(None)
+        request = testing.DummyRequest()
+        request.GET['callback'] = '78mycallback'
+        self.assertRaises(HTTPBadRequest, renderer, {'a':'1'}, {'request':request})
+
 
 class Dummy:
     pass


### PR DESCRIPTION
The callback variable could be used to arbitrarily inject javascript
into the response object. This validates that the callback doesn't begin
with a number and is standard US ASCII characters, because trying to
make sure the JavaScript function name is actually valid would require
parsing JavaScript itself...