### PR TITLE
Add some validation for the JSONP callback

### DIFF
--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -586,6 +586,14 @@ class TestJSONP(unittest.TestCase):
         result = renderer({'a':'1'}, {})
         self.assertEqual(result, '{"a": "1"}')
 
+    def test_render_to_jsonp_invalid_callback(self):
+        from pyramid.httpexceptions import HTTPBadRequest
+        renderer_factory = self._makeOne()
+        renderer = renderer_factory(None)
+        request = testing.DummyRequest()
+        request.GET['callback'] = '78mycallback'
+        self.assertRaises(HTTPBadRequest, renderer, {'a':'1'}, {'request':request})
+
 
 class Dummy:
     pass


### PR DESCRIPTION
The callback variable could be used to arbitrarily inject javascript
into the response object. This validates that the callback doesn't begin
with a number and is standard US ASCII characters, because trying to
make sure the JavaScript function name is actually valid would require
parsing JavaScript itself...