### PR TITLE
fixed documentation; wrong line in docs

### DIFF
--- a/docs/tutorials/wiki2/authorization.rst
+++ b/docs/tutorials/wiki2/authorization.rst
@@ -211,7 +211,7 @@ routes:
    ``view_page`` route definition:
 
    .. literalinclude:: src/authorization/tutorial/__init__.py
-      :lines: 32
+      :lines: 33
       :linenos:
       :language: python
 


### PR DESCRIPTION
The code in note box in [wiki2 tutorial, Authorization](http://docs.pylonsproject.org/projects/pyramid/en/latest/tutorials/wiki2/authorization.html#login-logout), is from wrong line; should be line 33:

    config.add_route('view_page', '/{pagename}')

but it is from line 32 (which is the `logout` registration from before the box).