### PR TITLE
add reference to latest 1.5.5 version

### DIFF
--- a/docs/whatsnew-1.5.rst
+++ b/docs/whatsnew-1.5.rst
@@ -19,6 +19,7 @@ include documentation improvements and other minor feature changes.
 - :ref:`changes_1.5.2`
 - :ref:`changes_1.5.3`
 - :ref:`changes_1.5.4`
+- :ref:`changes_1.5.5`
 
 
 Major Backwards Incompatibilities


### PR DESCRIPTION
missing a link in the What's New