### PR TITLE
Added support for a prefixed base url that does not contain a trailing slash

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -230,3 +230,5 @@ Contributors
 - Antti Haapala, 2013/11/15
 
 - Amit Mane, 2014/01/23
+
+- Charlie Choiniere, 2017/04/03

--- a/docs/narr/urldispatch.rst
+++ b/docs/narr/urldispatch.rst
@@ -964,6 +964,24 @@ then only match if the URL path is ``/users/show``, and when the
 :meth:`pyramid.request.Request.route_url` function is called with the route
 name ``show_users``, it will generate a URL with that same path.
 
+To create a prefixed route that matches requests to the ``route_prefix``
+without a trailing slash set the route ``pattern`` to an empty string.
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid.config import Configurator
+
+   def users_include(config):
+       config.add_route('show_users', '')
+
+   def main(global_config, **settings):
+       config = Configurator()
+       config.include(users_include, route_prefix='/users')
+
+The above configuration will match ``/users`` instead of ``/users/`` if a slash
+had been supplied to the :meth:`pyramid.config.Configurator.add_route` function.
+
 Route prefixes are recursive, so if a callable executed via an include itself
 turns around and includes another callable, the second-level route prefix
 will be prepended with the first:

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -333,7 +333,10 @@ class RoutesConfiguratorMixin(object):
             static = True
 
         elif self.route_prefix:
-            pattern = self.route_prefix.rstrip('/') + '/' + pattern.lstrip('/')
+            if pattern == '':
+                pattern = self.route_prefix.rstrip('/')
+            else:
+                pattern = self.route_prefix.rstrip('/') + '/' + pattern.lstrip('/')
 
         mapper = self.get_routes_mapper()
 

--- a/pyramid/tests/test_config/test_routes.py
+++ b/pyramid/tests/test_config/test_routes.py
@@ -50,6 +50,18 @@ class RoutesConfiguratorMixinTests(unittest.TestCase):
         config.add_route('name', 'path')
         self._assertRoute(config, 'name', 'root/path')
 
+    def test_add_route_with_empty_string_with_route_prefix(self):
+        config = self._makeOne(autocommit=True)
+        config.route_prefix = 'root'
+        config.add_route('name', '')
+        self._assertRoute(config, 'name', 'root')
+
+    def test_add_route_with_root_slash_with_route_prefix(self):
+        config = self._makeOne(autocommit=True)
+        config.route_prefix = 'root'
+        config.add_route('name', '/')
+        self._assertRoute(config, 'name', 'root/')
+
     def test_add_route_discriminator(self):
         config = self._makeOne()
         config.add_route('name', 'path')


### PR DESCRIPTION
This was simply a behavior I wanted so I went through to see if I could accomplish hacking on pyramid to make it so. Pyramid's current behavior when supplying an empty string is to match the root of the domain I think this behavior should be carried through to routes with a route prefix. At first I wanted to match both an empty string and '/' but that would break a lot of existing applications that depend on the current behavior.

Right before submitting this patch I looked and found a long discussion for issue #406 which in hindsight I should have read prior to doing this work. I will go back and read through the discussion to see if what I changed makes sense based on the content there.
