### PR TITLE
added configure_mappers call to alchemy scaffold

### DIFF
--- a/pyramid/scaffolds/alchemy/+package+/models.py
+++ b/pyramid/scaffolds/alchemy/+package+/models.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import (
     scoped_session,
     sessionmaker,
+    configure_mappers,
     )
 
 from zope.sqlalchemy import ZopeTransactionExtension
@@ -25,3 +26,5 @@ class MyModel(Base):
     value = Column(Integer)
 
 Index('my_index', MyModel.name, unique=True, mysql_length=255)
+
+configure_mappers()


### PR DESCRIPTION
I propose the following fix to the SQLAlchemy ORM to add the explicit `configure_mappers` call - not having it makes the code prone to really hard-to-find [heisenbugs](http://stackoverflow.com/questions/14921777/backref-class-attribute) that trigger only when no model object instances were created prior to accessing the backreffed properties and such.

The docs would be out of date (I can update them if this is deemed an acceptable change).