### PR TITLE
add ptpython support for pshell

### DIFF
--- a/docs/narr/commandline.rst
+++ b/docs/narr/commandline.rst
@@ -273,20 +273,21 @@ exposed, and the request is configured to generate urls from the host
 
 .. _ipython_or_bpython:
 
-IPython or bpython
-~~~~~~~~~~~~~~~~~~
+IPython, bpython or ptpython
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you have `IPython <http://en.wikipedia.org/wiki/IPython>`_ and/or
-`bpython <http://bpython-interpreter.org/>`_ in
+If you have `IPython <http://en.wikipedia.org/wiki/IPython>`_,
+`bpython <http://bpython-interpreter.org/>`_ and/or
+`ptpython <https://github.com/jonathanslenders/ptpython>` in
 the interpreter you use to invoke the ``pshell`` command, ``pshell`` will 
 autodiscover and use the first one found, in this order:
-IPython, bpython, standard Python interpreter. However you could 
+IPython, bpython, ptpython, standard Python interpreter. However you could
 specifically invoke one of your choice with the ``-p choice`` or 
 ``--python-shell choice`` option.
 
 .. code-block:: text
 
-   $ $VENV/bin/pshell -p ipython | bpython | python development.ini#MyProject
+   $ $VENV/bin/pshell -p ipython | bpython | ptpython | ptipython | python development.ini#MyProject
 
 .. index::
    pair: routes; printing

--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from code import interact
 import optparse
 import os
@@ -40,7 +41,7 @@ class PShellCommand(object):
         )
     parser.add_option('-p', '--python-shell',
                       action='store', type='string', dest='python_shell',
-                      default='', help='ipython | bpython | python')
+                      default='', help='ipython | bpython | ptpython | ptipython | python')
     parser.add_option('--setup',
                       dest='setup',
                       help=("A callable that will be passed the environment "
@@ -165,12 +166,20 @@ class PShellCommand(object):
             shell = self.make_ipython_shell()
             if shell is None:
                 shell = self.make_bpython_shell()
+            if shell is None:
+                shell = self.make_ptpython_shell()
 
         elif user_shell == 'ipython':
             shell = self.make_ipython_shell()
 
         elif user_shell == 'bpython':
             shell = self.make_bpython_shell()
+
+        elif user_shell == 'ptpython':
+            shell = self.make_ptpython_shell()
+
+        elif user_shell == 'ptipython':
+            shell = self.make_ptipython_shell()
 
         if shell is None:
             shell = self.make_default_shell()
@@ -183,6 +192,30 @@ class PShellCommand(object):
             banner = "Python %s on %s\n%s" % (sys.version, sys.platform, cprt)
             banner += '\n\n' + help + '\n'
             interact(banner, local=env)
+        return shell
+
+    def make_ptpython_shell(self, PTPShell=None):
+        if PTPShell is None:  # pragma: no cover
+            try:
+                from ptpython.repl import embed
+                def PTPShell(banner, **kwargs):
+                    print(banner)
+                    return embed(**kwargs)
+            except ImportError:
+                return None
+        def shell(env, help):
+            PTPShell(banner=help, locals=env)
+        return shell
+
+    def make_ptipython_shell(self, PTIPShell=None):
+        if PTIPShell is None:  # pragma: no cover
+            try:
+                from ptpython.ipython import embed
+                PTIPShell = embed
+            except ImportError:
+                return None
+        def shell(env, help):
+            PTIPShell(banner2=help + '\n', user_ns=env)
         return shell
 
     def make_bpython_shell(self, BPShell=None):

--- a/pyramid/tests/test_scripts/dummy.py
+++ b/pyramid/tests/test_scripts/dummy.py
@@ -36,6 +36,16 @@ class DummyBPythonShell:
         self.locals_ = locals_
         self.banner = banner
 
+class DummyPTPythonShell:
+    def __call__(self, locals, banner):
+        self.locals = locals
+        self.banner = banner
+
+class DummyPTIPythonShell:
+    def __call__(self, user_ns, banner2):
+        self.user_ns = user_ns
+        self.banner2 = banner2
+
 class DummyIPShell(object):
     IP = Dummy()
     IP.BANNER = 'foo'


### PR DESCRIPTION
This pull request adds support for ptpython and ptipython in pshell.
Unfortunately ptpython.repl.embed is not capable of displaying a banner when
the shell is created. I opened an issue for it on https://github.com/jonathanslenders/ptpython/issues/41
ptipython does display a banner though.
ptipython is not in the fall-thru chain of shells since it depends on ipython and if ipython is not installed (first fall thru) then it doesn't make sense to try ptipython of course. 
