### PR TITLE
Quick Tutorial Database: Logging configs for db script output + fix scoped session warning

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -246,3 +246,5 @@ Contributors
 - David Glick, 2015/02/12
 
 - Donald Stufft, 2015/03/15
+
+- Karen Dalton, 2015/06/01

--- a/docs/quick_tutorial/databases.rst
+++ b/docs/quick_tutorial/databases.rst
@@ -90,16 +90,28 @@ Steps
    .. code-block:: bash
 
     $ $VENV/bin/initialize_tutorial_db development.ini
-    2013-09-06 15:54:08,050 INFO  [sqlalchemy.engine.base.Engine][MainThread] PRAGMA table_info("wikipages")
-    2013-09-06 15:54:08,050 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
-    2013-09-06 15:54:08,051 INFO  [sqlalchemy.engine.base.Engine][MainThread]
+    2015-06-01 11:22:52,650 INFO  [sqlalchemy.engine.base.Engine][MainThread] SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
+    2015-06-01 11:22:52,650 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
+    2015-06-01 11:22:52,651 INFO  [sqlalchemy.engine.base.Engine][MainThread] SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
+    2015-06-01 11:22:52,651 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
+    2015-06-01 11:22:52,652 INFO  [sqlalchemy.engine.base.Engine][MainThread] PRAGMA table_info("wikipages")
+    2015-06-01 11:22:52,652 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
+    2015-06-01 11:22:52,653 INFO  [sqlalchemy.engine.base.Engine][MainThread]
     CREATE TABLE wikipages (
-            uid INTEGER NOT NULL,
-            title TEXT,
-            body TEXT,
-            PRIMARY KEY (uid),
-            UNIQUE (title)
+      uid INTEGER NOT NULL,
+      title TEXT,
+      body TEXT,
+      PRIMARY KEY (uid),
+      UNIQUE (title)
     )
+
+
+    2015-06-01 11:22:52,653 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
+    2015-06-01 11:22:52,655 INFO  [sqlalchemy.engine.base.Engine][MainThread] COMMIT
+    2015-06-01 11:22:52,658 INFO  [sqlalchemy.engine.base.Engine][MainThread] BEGIN (implicit)
+    2015-06-01 11:22:52,659 INFO  [sqlalchemy.engine.base.Engine][MainThread] INSERT INTO wikipages (title, body) VALUES (?, ?)
+    2015-06-01 11:22:52,659 INFO  [sqlalchemy.engine.base.Engine][MainThread] ('Root', '<p>Root</p>')
+    2015-06-01 11:22:52,659 INFO  [sqlalchemy.engine.base.Engine][MainThread] COMMIT
 
 #. With our data now driven by SQLAlchemy queries, we need to update
    our ``databases/tutorial/views.py``:

--- a/docs/quick_tutorial/databases/development.ini
+++ b/docs/quick_tutorial/databases/development.ini
@@ -11,3 +11,39 @@ sqlalchemy.url = sqlite:///%(here)s/sqltutorial.sqlite
 use = egg:pyramid#wsgiref
 host = 0.0.0.0
 port = 6543
+
+# Begin logging configuration
+
+[loggers]
+keys = root, tutorial, sqlalchemy.engine.base.Engine
+
+[logger_tutorial]
+level = DEBUG
+handlers =
+qualname = tutorial
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_sqlalchemy.engine.base.Engine]
+level = INFO
+handlers =
+qualname = sqlalchemy.engine.base.Engine
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s
+
+# End logging configuration

--- a/docs/quick_tutorial/databases/tutorial/tests.py
+++ b/docs/quick_tutorial/databases/tutorial/tests.py
@@ -40,7 +40,6 @@ class WikiViewTests(unittest.TestCase):
 
 class WikiFunctionalTests(unittest.TestCase):
     def setUp(self):
-        self.session = _initTestingDB()
         self.config = testing.setUp()
         from pyramid.paster import get_app
         app = get_app('development.ini')
@@ -48,7 +47,8 @@ class WikiFunctionalTests(unittest.TestCase):
         self.testapp = TestApp(app)
 
     def tearDown(self):
-        self.session.remove()
+        from .models import DBSession
+        DBSession.remove()
         testing.tearDown()
 
     def test_it(self):

--- a/docs/quick_tutorial/databases/tutorial/tests.py
+++ b/docs/quick_tutorial/databases/tutorial/tests.py
@@ -23,9 +23,11 @@ def _initTestingDB():
 class WikiViewTests(unittest.TestCase):
     def setUp(self):
         self.session = _initTestingDB()
+        self.config = testing.setUp()
 
     def tearDown(self):
         self.session.remove()
+        testing.tearDown()
 
     def test_wiki_view(self):
         from tutorial.views import WikiViews

--- a/docs/quick_tutorial/databases/tutorial/tests.py
+++ b/docs/quick_tutorial/databases/tutorial/tests.py
@@ -23,11 +23,9 @@ def _initTestingDB():
 class WikiViewTests(unittest.TestCase):
     def setUp(self):
         self.session = _initTestingDB()
-        self.config = testing.setUp()
 
     def tearDown(self):
         self.session.remove()
-        testing.tearDown()
 
     def test_wiki_view(self):
         from tutorial.views import WikiViews
@@ -40,7 +38,6 @@ class WikiViewTests(unittest.TestCase):
 
 class WikiFunctionalTests(unittest.TestCase):
     def setUp(self):
-        self.config = testing.setUp()
         from pyramid.paster import get_app
         app = get_app('development.ini')
         from webtest import TestApp
@@ -49,7 +46,6 @@ class WikiFunctionalTests(unittest.TestCase):
     def tearDown(self):
         from .models import DBSession
         DBSession.remove()
-        testing.tearDown()
 
     def test_it(self):
         res = self.testapp.get('/', status=200)


### PR DESCRIPTION
--development.ini: adds additional logging configs necessary for output from db setup script
--databases.rst: updates script output user would see displayed from db setup script
--tests.py: remove self.session declaration (in setUp) and removal (in tearDown) in WikiFunctionalTests because the `app = get_app('development.ini')` already sets up a session, and adds `DBSession.remove()` to tearDown in WikiFunctionalTests to clear the session so it doesn't interfere with the session created in WikiViewTests