### PR TITLE
Return concrete classes from 'pyramid.httpexceptions.exception_response'

### DIFF
--- a/pyramid/httpexceptions.py
+++ b/pyramid/httpexceptions.py
@@ -562,10 +562,7 @@ class HTTPClientError(HTTPError):
     a bug.  A server-side traceback is not warranted.  Unless specialized,
     this is a '400 Bad Request'
     """
-    code = 400
-    title = 'Bad Request'
-    explanation = ('The server could not comply with the request since '
-                   'it is either malformed or otherwise incorrect.')
+    pass
 
 class HTTPBadRequest(HTTPClientError):
     """
@@ -576,7 +573,10 @@ class HTTPBadRequest(HTTPClientError):
 
     code: 400, title: Bad Request
     """
-    pass
+    code = 400
+    title = 'Bad Request'
+    explanation = ('The server could not comply with the request since '
+                   'it is either malformed or otherwise incorrect.')
 
 class HTTPUnauthorized(HTTPClientError):
     """
@@ -988,14 +988,14 @@ class HTTPServerError(HTTPError):
     This is an error condition in which the server is presumed to be
     in-error.  Unless specialized, this is a '500 Internal Server Error'.
     """
+    pass
+
+class HTTPInternalServerError(HTTPServerError):
     code = 500
     title = 'Internal Server Error'
     explanation = (
       'The server has either erred or is incapable of performing '
       'the requested operation.')
-
-class HTTPInternalServerError(HTTPServerError):
-    pass
 
 class HTTPNotImplemented(HTTPServerError):
     """

--- a/pyramid/tests/test_httpexceptions.py
+++ b/pyramid/tests/test_httpexceptions.py
@@ -10,13 +10,22 @@ class Test_exception_response(unittest.TestCase):
         from pyramid.httpexceptions import exception_response
         return exception_response(*arg, **kw)
 
+    def test_status_400(self):
+        from pyramid.httpexceptions import HTTPBadRequest
+        self.assertTrue(isinstance(self._callFUT(400), HTTPBadRequest))
+
     def test_status_404(self):
         from pyramid.httpexceptions import HTTPNotFound
-        self.assertEqual(self._callFUT(404).__class__, HTTPNotFound)
+        self.assertTrue(isinstance(self._callFUT(404), HTTPNotFound))
+
+    def test_status_500(self):
+        from pyramid.httpexceptions import HTTPInternalServerError
+        self.assertTrue(isinstance(self._callFUT(500),
+                        HTTPInternalServerError))
 
     def test_status_201(self):
         from pyramid.httpexceptions import HTTPCreated
-        self.assertEqual(self._callFUT(201).__class__, HTTPCreated)
+        self.assertTrue(isinstance(self._callFUT(201), HTTPCreated))
 
     def test_extra_kw(self):
         resp = self._callFUT(404,  headers=[('abc', 'def')])


### PR DESCRIPTION
The base classes are not appropriate for 400 and 500 status codes.

See: #1832