### PR TITLE
handle conflicting project names gracefully, fixes: #1357

### DIFF
--- a/pyramid/scaffolds/__init__.py
+++ b/pyramid/scaffolds/__init__.py
@@ -18,10 +18,6 @@ class PyramidTemplate(Template):
         misnamings (such as naming a package "site" or naming a package
         logger "root".
         """
-        if vars['package'] == 'site':
-            raise ValueError('Sorry, you may not name your package "site". '
-                             'The package name "site" has a special meaning in '
-                             'Python.  Please name it anything except "site".')
         vars['random_string'] = native_(binascii.hexlify(os.urandom(20)))
         package_logger = vars['package']
         if package_logger == 'root':

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -9,6 +9,8 @@ import pkg_resources
 import re
 import sys
 
+user_input = input if sys.version_info[0] == 3 else raw_input
+
 _bad_chars_re = re.compile('[^a-zA-Z0-9_]')
 
 def main(argv=sys.argv, quiet=False):
@@ -92,8 +94,6 @@ class PCreateCommand(object):
 
     @property
     def project_vars(self):
-        options = self.options
-        args = self.args
         output_dir = self.output_path
         project_name = os.path.basename(os.path.split(output_dir)[1])
         pkg_name = _bad_chars_re.sub(
@@ -202,11 +202,11 @@ class PCreateCommand(object):
         if self.options.force_bad_name:
             return True
         self.out('Package "{}" already exists, are you sure you want '
-                    'to use it as your project\'s name?'.format(pkg_name))
+                 'to use it as your project\'s name?'.format(pkg_name))
         return self.confirm_bad_name('Really use "{}"?: '.format(pkg_name))
 
     def confirm_bad_name(self, prompt): # pragma: no cover
-        answer = raw_input('{} [y|N]: '.format(prompt))
+        answer = user_input('{} [y|N]: '.format(prompt))
         return answer.strip().lower() == 'y'
 
 if __name__ == '__main__': # pragma: no cover

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -9,7 +9,10 @@ import pkg_resources
 import re
 import sys
 
-user_input = input if sys.version_info[0] == 3 else raw_input
+if sys.version_info[0] == 3:
+    user_input = input # pragma: no cover
+else:
+    user_input = raw_input # NOQA
 
 _bad_chars_re = re.compile('[^a-zA-Z0-9_]')
 
@@ -187,7 +190,7 @@ class PCreateCommand(object):
             self.out('The package name "site" has a special meaning in '
                      'Python. Are you sure you want to use it as your '
                      'project\'s name?')
-            return self.confirm_bad_name('Really use "{}"?: '.format(pkg_name))
+            return self.confirm_bad_name('Really use "{0}"?: '.format(pkg_name))
 
         # check if pkg_name can be imported (i.e. already exists in current
         # $PYTHON_PATH, if so - let the user confirm
@@ -201,12 +204,12 @@ class PCreateCommand(object):
 
         if self.options.force_bad_name:
             return True
-        self.out('Package "{}" already exists, are you sure you want '
+        self.out('Package "{0}" already exists, are you sure you want '
                  'to use it as your project\'s name?'.format(pkg_name))
-        return self.confirm_bad_name('Really use "{}"?: '.format(pkg_name))
+        return self.confirm_bad_name('Really use "{0}"?: '.format(pkg_name))
 
     def confirm_bad_name(self, prompt): # pragma: no cover
-        answer = user_input('{} [y|N]: '.format(prompt))
+        answer = user_input('{0} [y|N]: '.format(prompt))
         return answer.strip().lower() == 'y'
 
 if __name__ == '__main__': # pragma: no cover

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -13,7 +13,21 @@ _bad_chars_re = re.compile('[^a-zA-Z0-9_]')
 
 def main(argv=sys.argv, quiet=False):
     command = PCreateCommand(argv, quiet)
-    return command.run()
+    try:
+        return command.run()
+    except KeyboardInterrupt: # pragma: no cover
+        return 1
+
+
+class InvalidInputError(Exception):
+    """ This is raised in case a project name is
+    missing or a scaffold name was omitted.
+    """
+    pass
+
+class ExistingProjectNameError(InvalidInputError):
+    pass
+
 
 class PCreateCommand(object):
     verbosity = 1 # required
@@ -52,6 +66,13 @@ class PCreateCommand(object):
                       dest='interactive',
                       action='store_true',
                       help='When a file would be overwritten, interrogate')
+    parser.add_option('--force-conflicting-name',
+                      dest='force_bad_name',
+                      action='store_true',
+                      default=False,
+                      help='Do create a project even if the chosen name '
+                           'is the name of an already existing / importable '
+                           'package.')
 
     pyramid_dist = pkg_resources.get_distribution("pyramid")
 
@@ -69,25 +90,21 @@ class PCreateCommand(object):
                 self.out('')
                 self.show_scaffolds()
             return 2
-        if not self.options.scaffold_name:
-            self.out('You must provide at least one scaffold name: -s <scaffold name>')
-            self.out('')
-            self.show_scaffolds()
+
+        if not self.validate_input():
             return 2
-        if not self.args:
-            self.out('You must provide a project name')
-            return 2
-        available = [x.name for x in self.scaffolds]
-        diff = set(self.options.scaffold_name).difference(available)
-        if diff:
-            self.out('Unavailable scaffolds: %s' % list(diff))
-            return 2
+
         return self.render_scaffolds()
 
-    def render_scaffolds(self):
+    @property
+    def output_path(self):
+        return os.path.abspath(os.path.normpath(self.args[0]))
+
+    @property
+    def project_vars(self):
         options = self.options
         args = self.args
-        output_dir = os.path.abspath(os.path.normpath(args[0]))
+        output_dir = self.output_path
         project_name = os.path.basename(os.path.split(output_dir)[1])
         pkg_name = _bad_chars_re.sub(
             '', project_name.lower().replace('-', '_'))
@@ -111,17 +128,22 @@ class PCreateCommand(object):
             else:
                 pyramid_docs_branch = 'latest'
 
-        vars = {
+        return {
             'project': project_name,
             'package': pkg_name,
             'egg': egg_name,
             'pyramid_version': pyramid_version,
             'pyramid_docs_branch': pyramid_docs_branch,
-            }
-        for scaffold_name in options.scaffold_name:
+        }
+
+
+    def render_scaffolds(self):
+        props = self.project_vars
+        output_dir = self.output_path
+        for scaffold_name in self.options.scaffold_name:
             for scaffold in self.scaffolds:
                 if scaffold.name == scaffold_name:
-                    scaffold.run(self, output_dir, vars)
+                    scaffold.run(self, output_dir, props)
         return 0
 
     def show_scaffolds(self):
@@ -153,6 +175,49 @@ class PCreateCommand(object):
     def out(self, msg): # pragma: no cover
         if not self.quiet:
             print(msg)
+
+    def validate_input(self):
+        if not self.options.scaffold_name:
+            self.out('You must provide at least one scaffold name: -s <scaffold name>')
+            self.out('')
+            self.show_scaffolds()
+            return False
+        if not self.args:
+            self.out('You must provide a project name')
+            return False
+        available = [x.name for x in self.scaffolds]
+        diff = set(self.options.scaffold_name).difference(available)
+        if diff:
+            self.out('Unavailable scaffolds: %s' % ", ".join(list(diff)))
+            return False
+
+        pkg_name = self.project_vars['package']
+
+        if pkg_name == 'site' and not self.options.force_bad_name:
+            self.out('The package name "site" has a special meaning in '
+                     'Python. Are you sure you want to use it as your '
+                     'project\'s name?')
+            return self.confirm_bad_name('Really use "{}"?: '.format(pkg_name))
+
+        # check if pkg_name can be imported (i.e. already exists in current
+        # $PYTHON_PATH, if so - let the user confirm
+        pkg_exists = True
+        try:
+            __import__(pkg_name, globals(), locals(), [], 0) # use absolute imports
+        except ImportError as error:
+            pkg_exists = False
+        if not pkg_exists:
+            return True
+
+        if self.options.force_bad_name:
+            return True
+        self.out('Package "{}" already exists, are you sure you want '
+                    'to use it as your project\'s name?'.format(pkg_name))
+        return self.confirm_bad_name('Really use "{}"?: '.format(pkg_name))
+
+    def confirm_bad_name(self, prompt): # pragma: no cover
+        answer = raw_input('{} [y|N]: '.format(prompt))
+        return answer.strip().lower() == 'y'
 
 if __name__ == '__main__': # pragma: no cover
     sys.exit(main() or 0)

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -8,11 +8,7 @@ import os.path
 import pkg_resources
 import re
 import sys
-
-if sys.version_info[0] == 3:
-    user_input = input # pragma: no cover
-else:
-    user_input = raw_input # NOQA
+from pyramid.compat import input_
 
 _bad_chars_re = re.compile('[^a-zA-Z0-9_]')
 
@@ -61,7 +57,7 @@ class PCreateCommand(object):
                       dest='interactive',
                       action='store_true',
                       help='When a file would be overwritten, interrogate')
-    parser.add_option('--force-conflicting-name',
+    parser.add_option('--ignore-conflicting-name',
                       dest='force_bad_name',
                       action='store_true',
                       default=False,
@@ -181,7 +177,7 @@ class PCreateCommand(object):
         available = [x.name for x in self.scaffolds]
         diff = set(self.options.scaffold_name).difference(available)
         if diff:
-            self.out('Unavailable scaffolds: %s' % ", ".join(list(diff)))
+            self.out('Unavailable scaffolds: %s' % ", ".join(sorted(diff)))
             return False
 
         pkg_name = self.project_vars['package']
@@ -204,12 +200,12 @@ class PCreateCommand(object):
 
         if self.options.force_bad_name:
             return True
-        self.out('Package "{0}" already exists, are you sure you want '
+        self.out('A package named "{0}" already exists, are you sure you want '
                  'to use it as your project\'s name?'.format(pkg_name))
         return self.confirm_bad_name('Really use "{0}"?: '.format(pkg_name))
 
     def confirm_bad_name(self, prompt): # pragma: no cover
-        answer = user_input('{0} [y|N]: '.format(prompt))
+        answer = input_('{0} [y|N]: '.format(prompt))
         return answer.strip().lower() == 'y'
 
 if __name__ == '__main__': # pragma: no cover

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -19,16 +19,6 @@ def main(argv=sys.argv, quiet=False):
         return 1
 
 
-class InvalidInputError(Exception):
-    """ This is raised in case a project name is
-    missing or a scaffold name was omitted.
-    """
-    pass
-
-class ExistingProjectNameError(InvalidInputError):
-    pass
-
-
 class PCreateCommand(object):
     verbosity = 1 # required
     description = "Render Pyramid scaffolding to an output directory"

--- a/pyramid/tests/test_scaffolds/test_init.py
+++ b/pyramid/tests/test_scaffolds/test_init.py
@@ -12,11 +12,6 @@ class TestPyramidTemplate(unittest.TestCase):
         self.assertTrue(vars['random_string'])
         self.assertEqual(vars['package_logger'], 'one')
 
-    def test_pre_site(self):
-        inst = self._makeOne()
-        vars = {'package':'site'}
-        self.assertRaises(ValueError, inst.pre, 'command', 'output dir', vars)
-        
     def test_pre_root(self):
         inst = self._makeOne()
         vars = {'package':'root'}

--- a/pyramid/tests/test_scripts/test_pcreate.py
+++ b/pyramid/tests/test_scripts/test_pcreate.py
@@ -240,7 +240,7 @@ class TestPCreateCommand(unittest.TestCase):
              'pyramid_docs_branch': 'master'})
 
     def test_force_override_conflicting_name(self):
-        cmd = self._makeOne('-s', 'dummy', 'Unittest', '--force-conflicting-name')
+        cmd = self._makeOne('-s', 'dummy', 'Unittest', '--ignore-conflicting-name')
         scaffold = DummyScaffold('dummy')
         cmd.scaffolds = [scaffold]
         cmd.pyramid_dist = DummyDist("0.10.1dev")


### PR DESCRIPTION
- Check for importable packages/modules with the same
  name as the package to be created
- Added --force-conflicting-name option to enforce the
  use of a conflicting package
- Added appropriate tests