### PR TITLE
Add new event BeforeAplicationCreated

### DIFF
--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -30,7 +30,7 @@ from pyramid.compat import (
     zip_longest,
     )
 
-from pyramid.events import ApplicationCreated
+from pyramid.events import ApplicationCreated, BeforeApplicationCreated
 
 from pyramid.exceptions import (
     ConfigurationConflictError,
@@ -975,11 +975,14 @@ class Configurator(
 
     def make_wsgi_app(self):
         """ Commits any pending configuration statements, sends a
-        :class:`pyramid.events.ApplicationCreated` event to all listeners,
-        adds this configuration's registry to
-        :attr:`pyramid.config.global_registries`, and returns a
-        :app:`Pyramid` WSGI application representing the committed
+        :class:`pyramid.events.BeforeApplicationCreated` event to all
+        listeners, adds this configuration's registry to
+        :attr:`pyramid.config.global_registries`, then sends a
+        :class:`pyramid.events.ApplicationCreated` event to all listeners, and
+        returns a :app:`Pyramid` WSGI application representing the committed
         configuration state."""
+        self.commit()
+        self.registry.notify(BeforeApplicationCreated(self))
         self.commit()
         app = Router(self.registry)
 

--- a/pyramid/events.py
+++ b/pyramid/events.py
@@ -10,6 +10,7 @@ from pyramid.interfaces import (
     INewRequest,
     INewResponse,
     IApplicationCreated,
+    IBeforeApplicationCreated,
     IBeforeRender,
     )
 
@@ -156,10 +157,10 @@ class ContextFound(object):
 AfterTraversal = ContextFound # b/c as of 1.0
 
 @implementer(IApplicationCreated)
-class ApplicationCreated(object):    
+class ApplicationCreated(object):
     """ An instance of this class is emitted as an :term:`event` when
     the :meth:`pyramid.config.Configurator.make_wsgi_app` is
-    called.  The instance has an attribute, ``app``, which is an
+    called. The instance has an attribute, ``app``, which is an
     instance of the :term:`router` that will handle WSGI requests.
     This class implements the
     :class:`pyramid.interfaces.IApplicationCreated` interface.
@@ -167,7 +168,7 @@ class ApplicationCreated(object):
     .. note::
 
        For backwards compatibility purposes, this class can also be imported as
-       :class:`pyramid.events.WSGIApplicationCreatedEvent`.  This was the name
+       :class:`pyramid.events.WSGIApplicationCreatedEvent`. This was the name
        of the event class before :app:`Pyramid` 1.0.
     """
     def __init__(self, app):
@@ -175,6 +176,18 @@ class ApplicationCreated(object):
         self.object = app
 
 WSGIApplicationCreatedEvent = ApplicationCreated # b/c (as of 1.0)
+
+@implementer(IBeforeApplicationCreated)
+class BeforeApplicationCreated(object):
+    """ An instance of this class is emitted as an :term:`event` when the
+    :meth:`pyramid.config.Configurator.make_wsgi_app` is called, before the
+    application is created. The instance has an attribute, ``config``, which is
+    an instance of the :class:`pyramid.config.Configurator`. See that will
+    handle WSGI requests.  This class implements the
+    :class:`pyramid.interfaces.IBeforeApplicationCreated` interface.
+    """
+    def __init__(self, config):
+        self.config = config
 
 @implementer(IBeforeRender)
 class BeforeRender(dict):
@@ -242,5 +255,3 @@ class BeforeRender(dict):
     def __init__(self, system, rendering_val=None):
         dict.__init__(self, system)
         self.rendering_val = rendering_val
-
-

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -56,6 +56,15 @@ class IApplicationCreated(Interface):
 
 IWSGIApplicationCreatedEvent = IApplicationCreated # b /c
 
+class IBeforeApplicationCreated(Interface):
+    """ Event issued when the
+    :meth:`pyramid.config.Configurator.make_wsgi_app` method
+    is called.  See the documentation attached to
+    :class:`pyramid.events.BeforeApplicationCreated` for more
+    information.
+    """
+    config = Attribute("Config of application")
+
 class IResponse(Interface):
     """ Represents a WSGI response using the WebOb response interface.
     Some attribute and method documentation of this interface references

--- a/pyramid/tests/test_events.py
+++ b/pyramid/tests/test_events.py
@@ -89,6 +89,24 @@ class WSGIApplicationCreatedEventTests(ApplicationCreatedEventTests):
         from zope.interface.verify import verifyObject
         verifyObject(IWSGIApplicationCreatedEvent, self._makeOne())
 
+class BeforeApplicationCreatedEventTests(unittest.TestCase):
+    def _getTargetClass(self):
+        from pyramid.events import BeforeApplicationCreated
+        return BeforeApplicationCreated
+
+    def _makeOne(self, context=object()):
+        return self._getTargetClass()(context)
+
+    def test_class_conforms_to_IApplicationCreated(self):
+        from pyramid.interfaces import IBeforeApplicationCreated
+        from zope.interface.verify import verifyClass
+        verifyClass(IBeforeApplicationCreated, self._getTargetClass())
+
+    def test_object_conforms_to_IApplicationCreated(self):
+        from pyramid.interfaces import IBeforeApplicationCreated
+        from zope.interface.verify import verifyObject
+        verifyObject(IBeforeApplicationCreated, self._makeOne())
+
 class ContextFoundEventTests(unittest.TestCase):
     def _getTargetClass(self):
         from pyramid.events import ContextFound


### PR DESCRIPTION
This event allows you to add the settings in any order. For example, I configured my include application:

```python
# myapp.__init__.py

    config.include("pyramid_pages")
    ...
    settings[CONFIG_MODELS] =\
            {
                '': WebPage,
                'pages': WebPage,
                'news': NewsResource,
                'gallery': GalleryResource,
            }
```

The following code raises an exception because these  ``settings[CONFIG_MODELS]`` settings are no:

```python
# pyramid_pages.__init__.py

def includeme()
    config = event.config
    # Models from setting factory
    settings = config.registry.settings
    models = settings[CONFIG_MODELS]
    for resource in models.values():
        if hasattr(resource, '__table__') and not hasattr(resource, 'model'):
            continue

        config.add_view(resource.view,
                        attr=resource.attr,
                        route_name=PREFIX_PAGE,
                        renderer=resource.template,
                        context=resource,
                        permission=PREFIX_PAGE)
```

Therefore, it would be very convenient to add this before making an WSGI application.

```python
@subscriber(BeforeApplicationCreated)
def resource_routes(event):
    config = event.config
    # Models from setting factory
    settings = config.registry.settings
    models = settings[CONFIG_MODELS]
    for resource in models.values():
        if hasattr(resource, '__table__') and not hasattr(resource, 'model'):
            continue

        config.add_view(resource.view,
                        attr=resource.attr,
                        route_name=PREFIX_PAGE,
                        renderer=resource.template,
                        context=resource,
                        permission=PREFIX_PAGE)
```