### PR TITLE
Fix Pyramid against WebOb >=1.5.0

### DIFF
--- a/pyramid/httpexceptions.py
+++ b/pyramid/httpexceptions.py
@@ -160,6 +160,13 @@ class HTTPException(Response, Exception):
     # title = 'OK'
     # explanation = 'why this happens'
     # body_template_obj = Template('response template')
+    #
+    # This class itself uses the error code "520" with the error message/title
+    # of "Unknown Error". This is not an RFC standard, however it is
+    # implemented in practice. Sub-classes should be overriding the default
+    # values and 520 should not be seen in the wild from Pyramid applications.
+    # Due to changes in WebOb, a code of "None" is not valid, and WebOb due to
+    # more strict error checking rejects it now.
 
     # differences from webob.exc.WSGIHTTPException:
     #
@@ -178,8 +185,8 @@ class HTTPException(Response, Exception):
     #
     # - documentation improvements (Pyramid-specific docstrings where necessary)
     #
-    code = None
-    title = None
+    code = 520
+    title = 'Unknown Error'
     explanation = ''
     body_template_obj = Template('''\
 ${explanation}${br}${br}

--- a/pyramid/tests/test_httpexceptions.py
+++ b/pyramid/tests/test_httpexceptions.py
@@ -120,7 +120,7 @@ class TestHTTPException(unittest.TestCase):
 
     def test_ctor_calls_Response_ctor(self):
         exc = self._makeOne('message')
-        self.assertEqual(exc.status, 'None None')
+        self.assertEqual(exc.status, '520 Unknown Error')
 
     def test_ctor_extends_headers(self):
         exc = self._makeOne(headers=[('X-Foo', 'foo')])
@@ -329,7 +329,7 @@ class Test_HTTPMove(unittest.TestCase):
         start_response = DummyStartResponse()
         app_iter = exc(environ, start_response)
         self.assertEqual(app_iter[0],
-                         (b'None None\n\nThe resource has been moved to foo; '
+                         (b'520 Unknown Error\n\nThe resource has been moved to foo; '
                           b'you should be redirected automatically.\n\n'))
 
 class TestHTTPForbidden(unittest.TestCase):


### PR DESCRIPTION
Due to changes in WebOb we may no longer create a Response() object with
an invalid status (i.e. 'None None'). For the top-level HTTPException if
it is not correctly overriden in child classes then we now use '520
Unknown Error'.

While not an official RFC error, this has been used by Microsoft's Azure
as well as CloudFlare to signify an error that doesn't have a more
appropriate error message.

See #1864 