### PR TITLE
base64 encode cookie values

### DIFF
--- a/pyramid/tests/test_session.py
+++ b/pyramid/tests/test_session.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import unittest
 from pyramid import testing
@@ -277,7 +278,7 @@ class TestBaseCookieSession(SharedCookieSessionTests, unittest.TestCase):
         return BaseCookieSessionFactory(serializer, **kw)(request)
 
     def _serialize(self, value):
-        return json.dumps(value)
+        return base64.b64encode(json.dumps(value).encode('utf-8'))
 
     def test_reissue_not_triggered(self):
         import time
@@ -650,10 +651,10 @@ class Test_check_csrf_token(unittest.TestCase):
 
 class DummySerializer(object):
     def dumps(self, value):
-        return json.dumps(value).encode('utf-8')
+        return base64.b64encode(json.dumps(value).encode('utf-8'))
 
     def loads(self, value):
-        return json.loads(value.decode('utf-8'))
+        return json.loads(base64.b64decode(value).decode('utf-8'))
 
 class DummySessionFactory(dict):
     _dirty = False


### PR DESCRIPTION
This way they are valid according to the RFC, and newer versions of WebOb (>=1.5.0) won't complain about cookie values containing invalid bytes.

Testing completed this way:

    python -W error -W ignore::PendingDeprecationWarning -W ignore::DeprecationWarning setup.py test

Using Python 3.4.3.