### PR TITLE
Preserve capitalization of Custom Variables

### DIFF
--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -61,6 +61,7 @@ class PShellCommand(object):
 
     def pshell_file_config(self, filename):
         config = self.ConfigParser()
+        config.optionxform = str
         config.read(filename)
         try:
             items = config.items('pshell')


### PR DESCRIPTION
Currently, ConfigParser applies lowercase to keys when parsing a configuration file like ``development.ini``. For easier cut and paste testing in ``pshell``, it would be great if pshell preserves case exactly as specified in the configuration file.

    [pshell]
    User = xyz.models.User
    m = xyz.models
    db = xyz.models.db

http://stackoverflow.com/questions/19359556/configparser-reads-capital-keys-and-make-them-lower-case