### PR TITLE
wiki2 documentation precisely matches the scaffolding output, py.test environment prefix

### DIFF
--- a/HACKING.txt
+++ b/HACKING.txt
@@ -189,7 +189,7 @@ Running Tests
   Run the tests like so:
 
    $ $VENV/bin/easy_install pytest
-   $ py.test --strict pyramid/
+   $ $VENV/bin/py.test --strict pyramid/
 
 Test Coverage
 -------------

--- a/docs/tutorials/wiki2/basiclayout.rst
+++ b/docs/tutorials/wiki2/basiclayout.rst
@@ -247,5 +247,8 @@ The ``MyModel`` class has a ``__tablename__`` attribute.  This informs
 SQLAlchemy which table to use to store the data representing instances of this
 class.
 
+The Index import and the Index object creation is not required for this
+tutorial, and will be removed in the next step.
+
 That's about all there is to it regarding models, views, and initialization
 code in our stock application.

--- a/docs/tutorials/wiki2/src/basiclayout/tutorial/models.py
+++ b/docs/tutorials/wiki2/src/basiclayout/tutorial/models.py
@@ -2,6 +2,7 @@ from sqlalchemy import (
     Column,
     Integer,
     Text,
+    Index,
     )
 
 from sqlalchemy.ext.declarative import declarative_base
@@ -22,3 +23,5 @@ class MyModel(Base):
     id = Column(Integer, primary_key=True)
     name = Column(Text, unique=True)
     value = Column(Integer)
+
+Index('my_index', MyModel.name, unique=True, mysql_length=255)


### PR DESCRIPTION
As the user progresses through the wiki2 tutorial, the models.py file differs from the provided documentation at "Content Models with models.py" in basiclayout.html. This can be distracting as the narrative tutorial and previous steps precisely match the expected output.

Updated the referenced models.py file to have matching text to that generated by the sqlalchemy scaffold, inform the user about the subsequent deletions in the next step. These deletions should be covered by the line:

```The highlighted lines are the ones that need to be changed, as well as removing lines that reference Index.```

from the first section in "Defining the Domain Model"