### PR TITLE
Mention Circus as a pserve --daemon replacement. Refs #1554, #1641

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -215,8 +215,8 @@ Deprecations
 
   Please use a real process manager in the future instead of relying on the
   ``pserve`` to daemonize itself. Many options exist including your Operating
-  System's services such as systemd or upstart, as well as the excellent
-  and simple supervisord.
+  System's services such as Systemd or Upstart, as well as Python-based
+  solutions like Circus and Supervisor.
 
   See https://github.com/Pylons/pyramid/pull/1641
 

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -622,7 +622,7 @@ class PServeCommand(object):
         self.out('''\
 The daemon options have been deprecated in Pyramid 1.6. They will be removed
 in a future release per Pyramid's deprecation policy. Please consider using
-a real process manager for handling your processes like supervisord or systemd.
+a real process manager for your processes like Systemd, Circus, or Supervisor.
 
 The following commands are deprecated:
     [start,stop,restart,status] --daemon, --stop-server, --status, --pid-file


### PR DESCRIPTION
[Circus](https://github.com/circus-tent/circus) is a newer Python-based process manager similar to Supervisor. It is worth mentioning as a ``pserve --daemon`` replacement.