### PR TITLE
populate pshell's env_help with docstring of values

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -250,3 +250,5 @@ Contributors
 - Karen Dalton, 2015/06/01
 
 - Igor Stroh, 2015/06/10
+
+- Jesse Dhillon, 2015/10/07

--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -122,7 +122,10 @@ class PShellCommand(object):
             # remove any objects from default help that were overidden
             for k, v in env.items():
                 if k not in orig_env or env[k] != orig_env[k]:
-                    env_help[k] = v
+                    if getattr(v, '__doc__', False):
+                        env_help[k] = v.__doc__.replace("\n", " ")
+                    else:
+                        env_help[k] = v
 
         # load the pshell section of the ini file
         env.update(self.loaded_objects)

--- a/pyramid/tests/test_scripts/test_pshell.py
+++ b/pyramid/tests/test_scripts/test_pshell.py
@@ -289,6 +289,7 @@ class TestPShellCommand(unittest.TestCase):
         def setup(env):
             env['a'] = 1
             env['root'] = 'root override'
+            env['none'] = None
         self.config_factory.items = [('setup', setup)]
         shell = dummy.DummyShell()
         command.run(shell)
@@ -302,6 +303,7 @@ class TestPShellCommand(unittest.TestCase):
             'request':self.bootstrap.request,
             'root_factory':self.bootstrap.root_factory,
             'a':1,
+            'none': None,
         })
         self.assertTrue(self.bootstrap.closer.called)
         self.assertTrue(shell.help)


### PR DESCRIPTION
This changes `pshell` to check the docstring of values assigned to `env`, and if present, use it to as the value for `env_help` for that value instead of the `repr`. For example:

**Before**
```shell
Environment:
  app          The WSGI application.
  pp           <function pprint at 0x7f1b37960050>
  registry     Active Pyramid registry.
  request      Active request object.
  root         Root of the default resource tree.
  root_factory Default root factory used to create `root`.
  transction   <module 'transaction' from '/home/jesse/.virtualenvs/boutique/local/lib/python2.7/site-packages/transaction/__init__.pyc'>
```

**After**
```shell
Environment:
  app          The WSGI application.
  pp           Pretty-print a Python object to a stream [default is sys.stdout].
  registry     Active Pyramid registry.
  request      Active request object.
  root         Root of the default resource tree.
  root_factory Default root factory used to create `root`.
  transaction  Exported transaction functions.  $Id$
```

_SooooOOO nice!_

:haircut: :dancers: :+1: 