### PR TITLE
Fix python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,28 @@
 language: python
 sudo: false
 
-env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py32
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=pypy
-  - TOXENV=pypy3
-  - TOXENV=py2-docs
-  - TOXENV=py3-docs
-  - TOXENV=py2-cover,py3-cover,coverage
-  - TOXENV=pep8
+matrix:
+    include:
+        - python: 2.6
+          env: TOXENV=py26
+        - python: 2.7
+          env: TOXENV=py27
+        - python: 3.2
+          env: TOXENV=py32
+        - python: 3.3
+          env: TOXENV=py33
+        - python: 3.4
+          env: TOXENV=py34
+        - python: 3.5
+          env: TOXENV=py35
+        - python: pypy
+          env: TOXENV=pypy
+        - python: pypy3
+          env: TOXENV=pypy3
+        - python: 3.5
+          env: TOXENV=py2-cover,py3-cover,coverage
+        - python: 3.5
+          env: TOXENV=pep8
 
 install:
   - travis_retry pip install tox

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -560,7 +560,7 @@ def action_method(wrapped):
                 # extra stack frame. This should no longer be necessary in
                 # Python 3.5.1
                 last_frame = ActionInfo(*f[-1])
-                if last_frame.function == 'extract_stack':
+                if last_frame.function == 'extract_stack': # pragma: no cover
                     f.pop()
                 info = ActionInfo(*f[-backframes])
             except: # pragma: no cover

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -554,7 +554,14 @@ def action_method(wrapped):
             info = ActionInfo(*info)
         if info is None:
             try:
-                f = traceback.extract_stack(limit=3)
+                f = traceback.extract_stack(limit=4)
+
+                # Work around a Python 3.5 issue whereby it would insert an
+                # extra stack frame. This should no longer be necessary in
+                # Python 3.5.1
+                last_frame = ActionInfo(*f[-1])
+                if last_frame.function == 'extract_stack':
+                    f.pop()
                 info = ActionInfo(*f[-backframes])
             except: # pragma: no cover
                 info = ActionInfo(None, 0, '', '')

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ basepython =
     pypy: pypy
     pypy3: pypy3
     py2: python2.7
-    py3: python3.4
+    py3: python3.5
 
 commands =
     pip install pyramid[testing]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py32,py33,py34,pypy,pypy3,pep8,
+    py26,py27,py32,py33,py34,py35,pypy,pypy3,pep8,
     {py2,py3}-docs,
     {py2,py3}-cover,coverage,
 
@@ -13,6 +13,7 @@ basepython =
     py32: python3.2
     py33: python3.3
     py34: python3.4
+    py35: python3.5
     pypy: pypy
     pypy3: pypy3
     py2: python2.7


### PR DESCRIPTION
This fixes Python 3.5 support for Pyramid on the master branch and closes https://github.com/Pylons/pyramid/issues/1973.