### PR TITLE
remove default cache busters

### DIFF
--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -19,7 +19,10 @@ from pkg_resources import (
 
 from repoze.lru import lru_cache
 
-from pyramid.asset import resolve_asset_spec
+from pyramid.asset import (
+    abspath_from_asset_spec,
+    resolve_asset_spec,
+)
 
 from pyramid.compat import text_
 
@@ -211,7 +214,11 @@ class ManifestCacheBuster(object):
     uses a supplied manifest file to map an asset path to a cache-busted
     version of the path.
 
-    The file is expected to conform to the following simple JSON format:
+    The ``manifest_spec`` can be an absolute path or a :term:`asset spec`
+    pointing to a package-relative file.
+
+    The manifest file is expected to conform to the following simple JSON
+    format:
 
     .. code-block:: json
 
@@ -222,7 +229,7 @@ class ManifestCacheBuster(object):
 
     Specifically, it is a JSON-serialized dictionary where the keys are the
     source asset paths used in calls to
-    :meth:`~pyramid.request.Request.static_url. For example::
+    :meth:`~pyramid.request.Request.static_url`. For example::
 
     .. code-block:: python
 
@@ -247,8 +254,10 @@ class ManifestCacheBuster(object):
     exists = staticmethod(exists) # testing
     getmtime = staticmethod(getmtime) # testing
 
-    def __init__(self, manifest_path, reload=False):
-        self.manifest_path = manifest_path
+    def __init__(self, manifest_spec, reload=False):
+        package_name = caller_package().__name__
+        self.manifest_path = abspath_from_asset_spec(
+            manifest_spec, package_name)
         self.reload = reload
 
         self._mtime = None
@@ -260,7 +269,8 @@ class ManifestCacheBuster(object):
         Return a mapping parsed from the ``manifest_path``.
 
         Subclasses may override this method to use something other than
-        ``json.loads``.
+        ``json.loads`` to load any type of file format and return a conforming
+        dictionary.
 
         """
         with open(self.manifest_path, 'rb') as fp:

--- a/pyramid/tests/test_static.py
+++ b/pyramid/tests/test_static.py
@@ -423,6 +423,20 @@ class TestManifestCacheBuster(unittest.TestCase):
             fut('foo', ('css', 'main.css'), {}),
             (['css', 'main-test.css'], {}))
 
+    def test_it_with_relspec(self):
+        fut = self._makeOne('fixtures/manifest.json').pregenerate
+        self.assertEqual(fut('foo', ('bar',), {}), (['bar'], {}))
+        self.assertEqual(
+            fut('foo', ('css', 'main.css'), {}),
+            (['css', 'main-test.css'], {}))
+
+    def test_it_with_absspec(self):
+        fut = self._makeOne('pyramid.tests:fixtures/manifest.json').pregenerate
+        self.assertEqual(fut('foo', ('bar',), {}), (['bar'], {}))
+        self.assertEqual(
+            fut('foo', ('css', 'main.css'), {}),
+            (['css', 'main-test.css'], {}))
+
     def test_reload(self):
         manifest_path = os.path.join(here, 'fixtures', 'manifest.json')
         new_manifest_path = os.path.join(here, 'fixtures', 'manifest2.json')


### PR DESCRIPTION
This is a first cut at removing the default cache busters.

The next step is to improve the documentation inside the "Customizing the Cache Buster" section of `narr/assets.rst` to include some explanation of how to write your own and why. Initial bullet points are:

- Pyramid does not control all of the urls in your app (for example css). You may want to rewrite these another way (within your asset pipeline) or even via middleware.
- You want to integrate with your asset pipeline.
- Common use case is to use an externally defined `manifest.json` that maps assets to busted slugs:
  
  ```json
  {
      "default.css": "default-11223344.css",
  }
  ```

Are there any other common ways to cache bust that we should touch on other than with a manifest?

One hiccup is that it depends on the asset pipeline what the actual file on disk is named. Thus on the matching side of the cache buster it depends on what you want when you map the external url back to the asset on disk.

Thoughts?