### PR TITLE
Restore link target used by 'whatsnew-1.3.rst'.

### DIFF
--- a/docs/narr/commandline.rst
+++ b/docs/narr/commandline.rst
@@ -261,6 +261,8 @@ request is configured to generate urls from the host
     >>> request.route_url('home')
     'https://www.example.com/'
 
+.. _ipython_or_bpython:
+
 Alternative Shells
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Should fix Jenkins breakage.
(cherry picked from commit 4429b54)