### PR TITLE
Include backported ordereddict package from PYPI when using python 2.…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ tests_require = [
 if not PY3:
     tests_require.append('zope.component>=3.11.0')
 
+if py_version == (2, 6):
+    tests_require.append('ordereddict')
+
 docs_extras = [
     'Sphinx >= 1.3.1',
     'docutils',


### PR DESCRIPTION
…6 since WebTest requires it. see #2071