### PR TITLE
literalinclude line number was off for Base object

### DIFF
--- a/docs/tutorials/wiki2/basiclayout.rst
+++ b/docs/tutorials/wiki2/basiclayout.rst
@@ -220,7 +220,7 @@ We also need to create a declarative ``Base`` object to use as a
 base class for our model:
 
    .. literalinclude:: src/basiclayout/tutorial/models.py
-      :lines: 17
+      :lines: 18
       :language: py
 
 Our model classes will inherit from this ``Base`` class so they can be


### PR DESCRIPTION
literalinclude line number was off for Base object, wiki2 tutorial basic layout 