### PR TITLE
Enable optional session encryption

### DIFF
--- a/docs/api/session.rst
+++ b/docs/api/session.rst
@@ -17,4 +17,4 @@
 
   .. autofunction:: BaseCookieSessionFactory
 
-
+  .. autoclass:: BlowfishPickleSerializer

--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -71,6 +71,35 @@ using the :meth:`pyramid.config.Configurator.set_session_factory` method.
    security doesn't matter", and you are sure your application has no
    cross-site scripting vulnerabilities.
 
+.. _encrypting_the_session:
+
+Encrypting the Session
+----------------------
+
+Pyramid provides an optional session serializer which encrypts the pickled
+session data using the Blowfish algorithm.  You can use this serializer in
+your :app:`Pyramid` application by using the
+:meth:`pyramid.config.Configurator.set_session_factory` method.
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid.session import BaseCookieSessionFactory
+   from pyramid.session import BlowfishPickleSerializer
+   serializer = BlowfishPickleSerializer('itsaseekreet')
+   my_session_factory = BaseCookieSessionFactory(serializer)
+
+   from pyramid.config import Configurator
+   config = Configurator()
+   config.set_session_factory(my_session_factory)
+
+.. note::
+
+   The :class:`BlowfishPickleSerializer` requires that you install
+   the optional ``pycrypto`` dependency, either directly (e.g., via
+   ``easy_install pycrypto``) or via the ``encrypted_cookies`` extra
+   (e.g., ``easy_install pyramid[encrypted_cookies]``).
+
 .. index::
    single: session object
 

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(name='pyramid',
       extras_require = {
           'testing':testing_extras,
           'docs':docs_extras,
+          'encrypted_cookies': ['pycrypto'],
           },
       tests_require = tests_require,
       test_suite="pyramid.tests",

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ basepython =
 
 commands =
     pip install -q pyramid[testing]
+    pip install -q pyramid[encrypted_cookies]
     nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
 
 # we separate coverage into its own testenv because a) "last run wins" wrt
@@ -29,6 +30,7 @@ commands =
 [testenv:py2-cover]
 commands =
     pip install -q pyramid[testing]
+    pip install -q pyramid[encrypted_cookies]
     coverage run --source=pyramid {envbindir}/nosetests
     coverage xml -o coverage-py2.xml
 setenv =
@@ -37,6 +39,7 @@ setenv =
 [testenv:py3-cover]
 commands =
     pip install -q pyramid[testing]
+    pip install -q pyramid[encrypted_cookies]
     coverage run --source=pyramid {envbindir}/nosetests
     coverage xml -o coverage-py3.xml
 setenv =
@@ -58,6 +61,7 @@ setenv =
 whitelist_externals = make
 commands =
     pip install -q pyramid[docs]
+    pip install -q pyramid[encrypted_cookies]
     make -C docs html epub BUILDDIR={envdir} "SPHINXOPTS=-W -E"
 
 [testenv:py3-docs]

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ basepython =
     py3: python3.5
 
 commands =
-    pip install pyramid[testing]
+    pip install -q pyramid[testing]
     nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
 
 # we separate coverage into its own testenv because a) "last run wins" wrt
@@ -28,7 +28,7 @@ commands =
 # combination of versions of coverage and nosexcover that i can find.
 [testenv:py2-cover]
 commands =
-    pip install pyramid[testing]
+    pip install -q pyramid[testing]
     coverage run --source=pyramid {envbindir}/nosetests
     coverage xml -o coverage-py2.xml
 setenv =
@@ -36,7 +36,7 @@ setenv =
 
 [testenv:py3-cover]
 commands =
-    pip install pyramid[testing]
+    pip install -q pyramid[testing]
     coverage run --source=pyramid {envbindir}/nosetests
     coverage xml -o coverage-py3.xml
 setenv =
@@ -57,13 +57,13 @@ setenv =
 [testenv:py2-docs]
 whitelist_externals = make
 commands =
-    pip install pyramid[docs]
+    pip install -q pyramid[docs]
     make -C docs html epub BUILDDIR={envdir} "SPHINXOPTS=-W -E"
 
 [testenv:py3-docs]
 whitelist_externals = make
 commands =
-    pip install pyramid[docs]
+    pip install -q pyramid[docs]
     make -C docs html epub BUILDDIR={envdir} "SPHINXOPTS=-W -E"
 
 [testenv:py26-scaffolds]


### PR DESCRIPTION
Adds `pyramid.session.BlowfishPickleSerializer`. This class is an encrypting Webob cookie serializer, which uses the pickle protocol to dump Python data to bytes, then encrypts the value symmetrically using the Blowfish algorithm.

To encrypt sessions, pass an instance of this class as the `serializer` argument to `pyramid.session.BaseCookieSessionFactory`.

Before using this serializer, install `pyramid[encrypted_cookies]` to get the necessary dependency (`pycrypto`).