### PR TITLE
Remove references to python-distribute.org

### DIFF
--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -680,8 +680,7 @@ testing, packaging, and distributing your application.
    ``setup.py`` is the de facto standard which Python developers use to
    distribute their reusable code.  You can read more about ``setup.py`` files
    and their usage in the `Setuptools documentation
-   <http://peak.telecommunity.com/DevCenter/setuptools>`_ and `The Hitchhiker's
-   Guide to Packaging <http://guide.python-distribute.org/>`_.
+   <http://peak.telecommunity.com/DevCenter/setuptools>`_.
 
 Our generated ``setup.py`` looks like this:
 

--- a/docs/narr/scaffolding.rst
+++ b/docs/narr/scaffolding.rst
@@ -22,9 +22,7 @@ found by the ``pcreate`` command.
 
 To create a scaffold template, create a Python :term:`distribution` to house
 the scaffold which includes a ``setup.py`` that relies on the ``setuptools``
-package.  See `Creating a Package
-<http://guide.python-distribute.org/creation.html>`_ for more information about
-how to do this.  For example, we'll pretend the distribution you create is
+package.  For example, we'll pretend the distribution you create is
 named ``CoolExtension``, and it has a package directory within it named
 ``coolextension``.
 


### PR DESCRIPTION
That domain no longer holds the Guide to Packaging.