### PR TITLE
spell out "specification" so that sphinx will not emit a warning for …

### DIFF
--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -214,8 +214,8 @@ class ManifestCacheBuster(object):
     uses a supplied manifest file to map an asset path to a cache-busted
     version of the path.
 
-    The ``manifest_spec`` can be an absolute path or a :term:`asset spec`
-    pointing to a package-relative file.
+    The ``manifest_spec`` can be an absolute path or a :term:`asset
+    specification` pointing to a package-relative file.
 
     The manifest file is expected to conform to the following simple JSON
     format:


### PR DESCRIPTION
…not being able to find "asset spec"