### PR TITLE
Implement OWASP session management recommendations

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -1053,23 +1053,38 @@ class SessionAuthenticationPolicy(CallbackAuthenticationPolicy):
         steps.  The output from debugging is useful for reporting to maillist
         or IRC channels when asking for support.
 
+    ``invalidate``
+
+        Default: ``False``. If ``invalidate`` is ``True``, every call to the
+        ``remember`` or ``forget`` methods will invalidate session first.
+        This is considered as best practice and recommended by OWASP.
+
     """
 
-    def __init__(self, prefix='auth.', callback=None, debug=False):
+    def __init__(self, prefix='auth.', callback=None, debug=False,
+        invalidate=False):
+
         self.callback = callback
         self.prefix = prefix or ''
         self.userid_key = prefix + 'userid'
         self.debug = debug
+        self.invalidate = invalidate
 
     def remember(self, request, userid, **kw):
         """ Store a userid in the session."""
+        if self.invalidate:
+            request.session.invalidate()
+
         request.session[self.userid_key] = userid
         return []
 
     def forget(self, request):
         """ Remove the stored userid from the session."""
         if self.userid_key in request.session:
-            del request.session[self.userid_key]
+            if self.invalidate:
+                request.session.invalidate()
+            else:
+                del request.session[self.userid_key]
         return []
 
     def unauthenticated_userid(self, request):


### PR DESCRIPTION
According to [OWASP Session management Cheat Sheet](https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Renew_the_Session_ID_After_Any_Privilege_Level_Change) renewing session is mandatory, on any privilege change, which is happening on all calls to `remember` or `forget` of `SessionAuthenticationPolicy`.

This change is backward-compatible, but probably
we should really empathize turning this on in docs.

I want to hear some feedback first, before I jump into updating docs, a covering this change with tests.

### TODO:
- [ ] docs updates
- [ ] unit-tests
- [ ] update `AuthTKTAuthenticationPolicy`