### PR TITLE
Update views.py

### DIFF
--- a/docs/quick_tutorial/templating/tutorial/views.py
+++ b/docs/quick_tutorial/templating/tutorial/views.py
@@ -2,12 +2,12 @@ from pyramid.view import view_config
 
 
 # First view, available at http://localhost:6543/
-@view_config(route_name='home', renderer='home.pt')
+@view_config(route_name='home', renderer='tutorial:home.pt')
 def home(request):
     return {'name': 'Home View'}
 
 
 # /howdy
-@view_config(route_name='hello', renderer='home.pt')
+@view_config(route_name='hello', renderer='tutorial:home.pt')
 def hello(request):
     return {'name': 'Hello View'}


### PR DESCRIPTION
Previous version of views.py looked for templates in:
python3.4/site-packages/pyramid/home.pt

adding >tutorial:< makes it look for the template in the correct tutorial folder.

This bug is caused by not specifying the app-module too look for templates in.