### PR TITLE
config.add cache buster

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -53,11 +53,12 @@ Features
   See https://github.com/Pylons/pyramid/pull/1471
 
 - Cache busting for static resources has been added and is available via a new
-  argument to ``pyramid.config.Configurator.add_static_view``: ``cachebust``.
-  Core APIs are shipped for both cache busting via query strings and
-  path segments and may be extended to fit into custom asset pipelines.
+  ``pyramid.config.Configurator.add_cache_buster`` API. Core APIs are shipped
+  for both cache busting via query strings and via asset manifests for
+  integrating into custom asset pipelines.
   See https://github.com/Pylons/pyramid/pull/1380 and
-  https://github.com/Pylons/pyramid/pull/1583
+  https://github.com/Pylons/pyramid/pull/1583 and
+  https://github.com/Pylons/pyramid/pull/2171
 
 - Add ``pyramid.config.Configurator.root_package`` attribute and init
   parameter to assist with includeable packages that wish to resolve

--- a/docs/narr/assets.rst
+++ b/docs/narr/assets.rst
@@ -557,7 +557,7 @@ use some of the following options to get started:
 
 * Configure your asset pipeline to rewrite URL references inline in
   CSS and JavaScript. This is the best approach because then the files
-  may be hosted by :app:`Pyramid` or an external CDN without haven't to
+  may be hosted by :app:`Pyramid` or an external CDN without having to
   change anything. They really are static.
 
 * Templatize JS and CSS, and call ``request.static_url()`` inside their
@@ -825,7 +825,7 @@ imagine you have overridden an asset defined in this manifest with a new,
 unknown version. By default, the cache buster will be invoked for an asset
 it has never seen before and will likely end up returning a cache busting
 token for the original asset rather than the asset that will actually end up
-being served! In order to get around this issue it's possible to attach a
+being served! In order to get around this issue, it's possible to attach a
 different :class:`pyramid.interfaces.ICacheBuster` implementation to the
 new assets. This would cause the original assets to be served by their
 manifest, and the new assets served by their own cache buster. To do this,
@@ -853,14 +853,14 @@ option. For example:
    theme_cb = ManifestCacheBuster('theme:static/manifest.json')
    config.add_cache_buster('theme:static', theme_cb, explicit=True)
 
-In the above example there is a default cache buster, ``my_cb`` for all assets
-served from the ``myapp:static`` folder. This would also affect
+In the above example there is a default cache buster, ``my_cb``, for all
+assets served from the ``myapp:static`` folder. This would also affect
 ``theme:static/background.png`` when generating URLs via
 ``request.static_url('myapp:static/background.png')``.
 
 The ``theme_cb`` is defined explicitly for any assets loaded from the
 ``theme:static`` folder. Explicit cache busters have priority and thus
 ``theme_cb`` would be invoked for
-``request.static_url('myapp:static/background.png')`` but ``my_cb`` would be
-used for any other assets like
+``request.static_url('myapp:static/background.png')``, but ``my_cb`` would
+be used for any other assets like
 ``request.static_url('myapp:static/favicon.ico')``.

--- a/docs/narr/assets.rst
+++ b/docs/narr/assets.rst
@@ -587,7 +587,7 @@ use some of the following options to get started:
   template code. While this approach may work in certain scenarios, it is not
   recommended because your static assets will not really be static and are now
   dependent on :app:`Pyramid` to be served correctly. See
-  :ref:`advanced static` for more information on this approach.
+  :ref:`advanced_static` for more information on this approach.
 
 If your CSS and JavaScript assets use URLs to reference other assets it is
 recommended that you implement an external asset pipeline that can rewrite the

--- a/pyramid/config/assets.py
+++ b/pyramid/config/assets.py
@@ -262,12 +262,15 @@ class FSAssetSource(object):
     def __init__(self, prefix):
         self.prefix = prefix
 
-    def get_filename(self, resource_name):
+    def get_path(self, resource_name):
         if resource_name:
             path = os.path.join(self.prefix, resource_name)
         else:
             path = self.prefix
+        return path
 
+    def get_filename(self, resource_name):
+        path = self.get_path(resource_name)
         if os.path.exists(path):
             return path
 

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -2102,9 +2102,6 @@ class StaticURLInfo(object):
         config.action(None, callable=register, introspectables=(intr,))
 
     def add_cache_buster(self, config, spec, cachebust, explicit=False):
-        if config.registry.settings.get('pyramid.prevent_cachebust'):
-            return
-
         # ensure the spec always has a trailing slash as we only support
         # adding cache busters to folders, not files
         if os.path.isabs(spec): # FBO windows
@@ -2115,6 +2112,9 @@ class StaticURLInfo(object):
             spec = spec + sep
 
         def register():
+            if config.registry.settings.get('pyramid.prevent_cachebust'):
+                return
+
             cache_busters = self.cache_busters
 
             # find duplicate cache buster (old_idx)
@@ -2138,6 +2138,7 @@ class StaticURLInfo(object):
 
             if old_idx is not None:
                 cache_busters.pop(old_idx)
+
             cache_busters.insert(new_idx, (spec, cachebust, explicit))
 
         intr = config.introspectable('cache busters',

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -1982,15 +1982,16 @@ class StaticURLInfo(object):
         self.cache_busters = []
 
     def generate(self, path, request, **kw):
+        disable_cache_buster = (
+            request.registry.settings['pyramid.prevent_cachebust'])
         for (url, spec, route_name) in self.registrations:
             if path.startswith(spec):
                 subpath = path[len(spec):]
                 if WIN: # pragma: no cover
                     subpath = subpath.replace('\\', '/') # windows
-                # translate spec into overridden spec and lookup cache buster
-                # to modify subpath, kw
-                subpath, kw = self._bust_asset_path(
-                    request.registry, spec, subpath, kw)
+                if not disable_cache_buster:
+                    subpath, kw = self._bust_asset_path(
+                        request.registry, spec, subpath, kw)
                 if url is None:
                     kw['subpath'] = subpath
                     return request.route_url(route_name, **kw)

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -2119,7 +2119,7 @@ class StaticURLInfo(object):
 
     def _bust_asset_path(self, registry, spec, subpath, kw):
         pkg_name, pkg_subpath = spec.split(':')
-        absspec = rawspec = '{0}:{1}{2}'.format(pkg_name, pkg_subpath, subpath)
+        rawspec = None
         overrides = registry.queryUtility(IPackageOverrides, name=pkg_name)
         if overrides is not None:
             resource_name = posixpath.join(pkg_subpath, subpath)
@@ -2130,6 +2130,9 @@ class StaticURLInfo(object):
                     rawspec = '{0}:{1}'.format(source.pkg_name, rawspec)
                 break
 
+        if rawspec is None:
+            rawspec = '{0}:{1}{2}'.format(pkg_name, pkg_subpath, subpath)
+
         for base_spec, cachebust in reversed(self.cache_busters):
             if (
                 base_spec == rawspec or
@@ -2139,6 +2142,6 @@ class StaticURLInfo(object):
                     else base_spec.endswith('/')
                 ) and rawspec.startswith(base_spec)
             ):
-                subpath, kw = cachebust(absspec, subpath, kw)
+                subpath, kw = cachebust(rawspec, subpath, kw)
                 break
         return subpath, kw

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -69,7 +69,6 @@ from pyramid.response import Response
 
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.static import static_view
-from pyramid.threadlocal import get_current_registry
 
 from pyramid.url import parse_url_overrides
 

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -2132,7 +2132,11 @@ class StaticURLInfo(object):
         for base_spec, cachebust in reversed(self.cache_busters):
             if (
                 base_spec == rawspec or
-                (base_spec.endswith('/') and rawspec.startswith(base_spec))
+                (
+                    base_spec.endswith(os.sep)
+                    if os.path.isabs(base_spec)
+                    else base_spec.endswith('/')
+                ) and rawspec.startswith(base_spec)
             ):
                 subpath, kw = cachebust(absspec, subpath, kw)
                 break

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -1,3 +1,4 @@
+import bisect
 import inspect
 import posixpath
 import operator
@@ -2102,7 +2103,9 @@ class StaticURLInfo(object):
                 idx = specs.index(spec)
                 cache_busters.pop(idx)
 
-            cache_busters.insert(0, (spec, cachebust))
+            lengths = [len(t[0]) for t in cache_busters]
+            new_idx = bisect.bisect_left(lengths, len(spec))
+            cache_busters.insert(new_idx, (spec, cachebust))
 
         intr = config.introspectable('cache busters',
                                      spec,
@@ -2126,7 +2129,7 @@ class StaticURLInfo(object):
                     rawspec = '{0}:{1}'.format(source.pkg_name, rawspec)
                 break
 
-        for base_spec, cachebust in self.cache_busters:
+        for base_spec, cachebust in reversed(self.cache_busters):
             if (
                 base_spec == rawspec or
                 (base_spec.endswith('/') and rawspec.startswith(base_spec))

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -1204,8 +1204,16 @@ class ICacheBuster(Interface):
         The ``kw`` argument is a dict of keywords that are to be passed
         eventually to :meth:`~pyramid.request.Request.static_url` for URL
         generation.  The return value should be a two-tuple of
-        ``(subpath, kw)`` which are versions of the same arguments modified
-        to include the cache bust token in the generated URL.
+        ``(subpath, kw)`` where ``subpath`` is the relative URL from where the
+        file is served and ``kw`` is the same input argument. The return value
+        should be modified to include the cache bust token in the generated
+        URL.
+
+        The ``pathspec`` refers to original location of the file, ignoring any
+        calls to :meth:`pyramid.config.Configurator.override_asset`. For
+        example, with a call ``request.static_url('myapp:static/foo.png'), the
+        ``pathspec`` may be ``themepkg:bar.png``, assuming a call to
+        ``config.override_asset('myapp:static/foo.png', 'themepkg:bar.png')``.
         """
 
 # configuration phases: a lower phase number means the actions associated

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -584,6 +584,9 @@ class IStaticURLInfo(Interface):
     def generate(path, request, **kw):
         """ Generate a URL for the given path """
 
+    def add_cache_buster(config, spec, cache_buster):
+        """ Add a new cache buster to a particular set of assets """
+
 class IResponseFactory(Interface):
     """ A utility which generates a response """
     def __call__(request):
@@ -1186,45 +1189,23 @@ class IPredicateList(Interface):
 
 class ICacheBuster(Interface):
     """
-    Instances of ``ICacheBuster`` may be provided as arguments to
-    :meth:`~pyramid.config.Configurator.add_static_view`.  Instances of
-    ``ICacheBuster`` provide mechanisms for generating a cache bust token for
-    a static asset, modifying a static asset URL to include a cache bust token,
-    and, optionally, unmodifying a static asset URL in order to look up an
-    asset.  See :ref:`cache_busting`.
+    A cache buster modifies the URL generation machinery for
+    :meth:`~pyramid.request.Request.static_url`. See :ref:`cache_busting`.
 
     .. versionadded:: 1.6
     """
-    def pregenerate(pathspec, subpath, kw):
+    def __call__(pathspec, subpath, kw):
         """
         Modifies a subpath and/or keyword arguments from which a static asset
         URL will be computed during URL generation.  The ``pathspec`` argument
         is the path specification for the resource to be cache busted.
-        The ``subpath`` argument is a tuple of path elements that represent the
-        portion of the asset URL which is used to find the asset.  The ``kw``
-        argument is a dict of keywords that are to be passed eventually to
-        :meth:`~pyramid.request.Request.route_url` for URL generation.  The
-        return value should be a two-tuple of ``(subpath, kw)`` which are
-        versions of the same arguments modified to include the cache bust token
-        in the generated URL.
-        """
-
-    def match(subpath):
-        """
-        Performs the logical inverse of
-        :meth:`~pyramid.interfaces.ICacheBuster.pregenerate` by taking a
-        subpath from a cache busted URL and removing the cache bust token, so
-        that :app:`Pyramid` can find the underlying asset.
-
-        ``subpath`` is the subpath portion of the URL for an incoming request
-        for a static asset.  The return value should be the same tuple with the
-        cache busting token elided.
-
-        If the cache busting scheme in use doesn't specifically modify the path
-        portion of the generated URL (e.g. it adds a query string), a method
-        which implements this interface may not be necessary.  It is
-        permissible for an instance of
-        :class:`~pyramid.interfaces.ICacheBuster` to omit this method.
+        The ``subpath`` argument is a path of ``/``-delimited segments that
+        represent the portion of the asset URL which is used to find the asset.
+        The ``kw`` argument is a dict of keywords that are to be passed
+        eventually to :meth:`~pyramid.request.Request.static_url` for URL
+        generation.  The return value should be a two-tuple of
+        ``(subpath, kw)`` which are versions of the same arguments modified
+        to include the cache bust token in the generated URL.
         """
 
 # configuration phases: a lower phase number means the actions associated

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -1194,11 +1194,11 @@ class ICacheBuster(Interface):
 
     .. versionadded:: 1.6
     """
-    def __call__(pathspec, subpath, kw):
+    def __call__(request, subpath, kw):
         """
         Modifies a subpath and/or keyword arguments from which a static asset
-        URL will be computed during URL generation.  The ``pathspec`` argument
-        is the path specification for the resource to be cache busted.
+        URL will be computed during URL generation.
+
         The ``subpath`` argument is a path of ``/``-delimited segments that
         represent the portion of the asset URL which is used to find the asset.
         The ``kw`` argument is a dict of keywords that are to be passed
@@ -1209,10 +1209,22 @@ class ICacheBuster(Interface):
         should be modified to include the cache bust token in the generated
         URL.
 
-        The ``pathspec`` refers to original location of the file, ignoring any
-        calls to :meth:`pyramid.config.Configurator.override_asset`. For
-        example, with a call ``request.static_url('myapp:static/foo.png'), the
-        ``pathspec`` may be ``themepkg:bar.png``, assuming a call to
+        The ``kw`` dictionary contains extra arguments passed to
+        :meth:`~pyramid.request.Request.static_url` as well as some extra
+        items that may be usful including:
+
+          - ``pathspec`` is the path specification for the resource
+            to be cache busted.
+
+          - ``rawspec`` is the original location of the file, ignoring
+            any calls to :meth:`pyramid.config.Configurator.override_asset`.
+
+        The ``pathspec`` and ``rawspec`` values are only different in cases
+        where an asset has been mounted into a virtual location using
+        :meth:`pyramid.config.Configurator.override_asset`. For example, with
+        a call to ``request.static_url('myapp:static/foo.png'), the
+        ``pathspec`` is ``myapp:static/foo.png`` whereas the ``rawspec`` may
+        be ``themepkg:bar.png``, assuming a call to
         ``config.override_asset('myapp:static/foo.png', 'themepkg:bar.png')``.
         """
 

--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -227,7 +227,7 @@ class ManifestCacheBuster(object):
            "images/background.png": "images/background-a8169106.png",
        }
 
-    Specifically, it is a JSON-serialized dictionary where the keys are the
+    By default, it is a JSON-serialized dictionary where the keys are the
     source asset paths used in calls to
     :meth:`~pyramid.request.Request.static_url`. For example::
 
@@ -236,6 +236,9 @@ class ManifestCacheBuster(object):
        >>> request.static_url('myapp:static/css/main.css')
        "http://www.example.com/static/css/main-678b7c80.css"
 
+    The file format and location can be changed by subclassing and overriding
+    :meth:`.parse_manifest`.
+
     If a path is not found in the manifest it will pass through unchanged.
 
     If ``reload`` is ``True`` then the manifest file will be reloaded when
@@ -243,11 +246,6 @@ class ManifestCacheBuster(object):
 
     If the manifest file cannot be found on disk it will be treated as
     an empty mapping unless ``reload`` is ``False``.
-
-    The default implementation assumes the requested (possibly cache-busted)
-    path is the actual filename on disk. Subclasses may override the ``match``
-    method to alter this behavior. For example, to strip the cache busting
-    token from the path.
 
     .. versionadded:: 1.6
     """
@@ -262,20 +260,23 @@ class ManifestCacheBuster(object):
 
         self._mtime = None
         if not reload:
-            self._manifest = self.parse_manifest()
+            self._manifest = self.get_manifest()
 
-    def parse_manifest(self):
+    def get_manifest(self):
+        with open(self.manifest_path, 'rb') as fp:
+            return self.parse_manifest(fp.read())
+
+    def parse_manifest(self, content):
         """
-        Return a mapping parsed from the ``manifest_path``.
+        Parse the ``content`` read from the ``manifest_path`` into a
+        dictionary mapping.
 
         Subclasses may override this method to use something other than
         ``json.loads`` to load any type of file format and return a conforming
         dictionary.
 
         """
-        with open(self.manifest_path, 'rb') as fp:
-            content = fp.read().decode('utf-8')
-            return json.loads(content)
+        return json.loads(content.decode('utf-8'))
 
     @property
     def manifest(self):
@@ -285,7 +286,7 @@ class ManifestCacheBuster(object):
                 return {}
             mtime = self.getmtime(self.manifest_path)
             if self._mtime is None or mtime > self._mtime:
-                self._manifest = self.parse_manifest()
+                self._manifest = self.get_manifest()
                 self._mtime = mtime
         return self._manifest
 

--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -172,15 +172,15 @@ class QueryStringCacheBuster(object):
     to the query string and defaults to ``'x'``.
 
     To use this class, subclass it and provide a ``tokenize`` method which
-    accepts a ``pathspec`` and returns a token.
+    accepts ``request, pathspec, kw`` and returns a token.
 
     .. versionadded:: 1.6
     """
     def __init__(self, param='x'):
         self.param = param
 
-    def __call__(self, pathspec, subpath, kw):
-        token = self.tokenize(pathspec)
+    def __call__(self, request, subpath, kw):
+        token = self.tokenize(request, subpath, kw)
         query = kw.setdefault('_query', {})
         if isinstance(query, dict):
             query[self.param] = token
@@ -205,7 +205,7 @@ class QueryStringConstantCacheBuster(QueryStringCacheBuster):
         super(QueryStringConstantCacheBuster, self).__init__(param=param)
         self._token = token
 
-    def tokenize(self, pathspec):
+    def tokenize(self, request, subpath, kw):
         return self._token
 
 class ManifestCacheBuster(object):
@@ -290,6 +290,6 @@ class ManifestCacheBuster(object):
                 self._mtime = mtime
         return self._manifest
 
-    def __call__(self, pathspec, subpath, kw):
+    def __call__(self, request, subpath, kw):
         subpath = self.manifest.get(subpath, subpath)
         return (subpath, kw)

--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -179,7 +179,7 @@ class QueryStringCacheBuster(object):
     def __init__(self, param='x'):
         self.param = param
 
-    def pregenerate(self, pathspec, subpath, kw):
+    def __call__(self, pathspec, subpath, kw):
         token = self.tokenize(pathspec)
         query = kw.setdefault('_query', {})
         if isinstance(query, dict):
@@ -289,8 +289,6 @@ class ManifestCacheBuster(object):
                 self._mtime = mtime
         return self._manifest
 
-    def pregenerate(self, pathspec, subpath, kw):
-        path = '/'.join(subpath)
-        path = self.manifest.get(path, path)
-        new_subpath = path.split('/')
-        return (new_subpath, kw)
+    def __call__(self, pathspec, subpath, kw):
+        subpath = self.manifest.get(subpath, subpath)
+        return (subpath, kw)

--- a/pyramid/tests/test_config/test_views.py
+++ b/pyramid/tests/test_config/test_views.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pyramid import testing
 
@@ -3887,49 +3888,35 @@ class TestStaticURLInfo(unittest.TestCase):
 
     def test_generate_registration_miss(self):
         inst = self._makeOne()
-        registrations = [
-            (None, 'spec', 'route_name', None),
-            ('http://example.com/foo/', 'package:path/', None, None)]
-        inst._get_registrations = lambda *x: registrations
+        inst.registrations = [
+            (None, 'spec', 'route_name'),
+            ('http://example.com/foo/', 'package:path/', None)]
         request = self._makeRequest()
-        result = inst.generate('package:path/abc', request)
-        self.assertEqual(result, 'http://example.com/foo/abc')
-
-    def test_generate_registration_no_registry_on_request(self):
-        inst = self._makeOne()
-        registrations = [
-            ('http://example.com/foo/', 'package:path/', None, None)]
-        inst._get_registrations = lambda *x: registrations
-        request = self._makeRequest()
-        del request.registry
         result = inst.generate('package:path/abc', request)
         self.assertEqual(result, 'http://example.com/foo/abc')
 
     def test_generate_slash_in_name1(self):
         inst = self._makeOne()
-        registrations = [
-            ('http://example.com/foo/', 'package:path/', None, None)]
-        inst._get_registrations = lambda *x: registrations
+        inst.registrations = [('http://example.com/foo/', 'package:path/', None)]
         request = self._makeRequest()
         result = inst.generate('package:path/abc', request)
         self.assertEqual(result, 'http://example.com/foo/abc')
 
     def test_generate_slash_in_name2(self):
         inst = self._makeOne()
-        registrations = [
-            ('http://example.com/foo/', 'package:path/', None, None)]
-        inst._get_registrations = lambda *x: registrations
+        inst.registrations = [('http://example.com/foo/', 'package:path/', None)]
         request = self._makeRequest()
         result = inst.generate('package:path/', request)
         self.assertEqual(result, 'http://example.com/foo/')
 
     def test_generate_quoting(self):
+        from pyramid.interfaces import IStaticURLInfo
         config = testing.setUp()
         try:
             config.add_static_view('images', path='mypkg:templates')
-            inst = self._makeOne()
             request = testing.DummyRequest()
             request.registry = config.registry
+            inst = config.registry.getUtility(IStaticURLInfo)
             result = inst.generate('mypkg:templates/foo%2Fbar', request)
             self.assertEqual(result, 'http://example.com/images/foo%252Fbar')
         finally:
@@ -3937,8 +3924,7 @@ class TestStaticURLInfo(unittest.TestCase):
 
     def test_generate_route_url(self):
         inst = self._makeOne()
-        registrations = [(None, 'package:path/', '__viewname/', None)]
-        inst._get_registrations = lambda *x: registrations
+        inst.registrations = [(None, 'package:path/', '__viewname/')]
         def route_url(n, **kw):
             self.assertEqual(n, '__viewname/')
             self.assertEqual(kw, {'subpath':'abc', 'a':1})
@@ -3950,8 +3936,7 @@ class TestStaticURLInfo(unittest.TestCase):
 
     def test_generate_url_unquoted_local(self):
         inst = self._makeOne()
-        registrations = [(None, 'package:path/', '__viewname/', None)]
-        inst._get_registrations = lambda *x: registrations
+        inst.registrations = [(None, 'package:path/', '__viewname/')]
         def route_url(n, **kw):
             self.assertEqual(n, '__viewname/')
             self.assertEqual(kw, {'subpath':'abc def', 'a':1})
@@ -3963,16 +3948,15 @@ class TestStaticURLInfo(unittest.TestCase):
 
     def test_generate_url_quoted_remote(self):
         inst = self._makeOne()
-        registrations = [('http://example.com/', 'package:path/', None, None)]
-        inst._get_registrations = lambda *x: registrations
+        inst.registrations = [('http://example.com/', 'package:path/', None)]
         request = self._makeRequest()
         result = inst.generate('package:path/abc def', request, a=1)
         self.assertEqual(result, 'http://example.com/abc%20def')
 
     def test_generate_url_with_custom_query(self):
         inst = self._makeOne()
-        registrations = [('http://example.com/', 'package:path/', None, None)]
-        inst._get_registrations = lambda *x: registrations
+        registrations = [('http://example.com/', 'package:path/', None)]
+        inst.registrations = registrations
         request = self._makeRequest()
         result = inst.generate('package:path/abc def', request, a=1,
                                _query='(openlayers)')
@@ -3981,12 +3965,10 @@ class TestStaticURLInfo(unittest.TestCase):
 
     def test_generate_url_with_custom_anchor(self):
         inst = self._makeOne()
-        registrations = [('http://example.com/', 'package:path/', None, None)]
-        inst._get_registrations = lambda *x: registrations
+        inst.registrations = [('http://example.com/', 'package:path/', None)]
         request = self._makeRequest()
         uc = text_(b'La Pe\xc3\xb1a', 'utf-8')
-        result = inst.generate('package:path/abc def', request, a=1,
-                               _anchor=uc)
+        result = inst.generate('package:path/abc def', request, a=1, _anchor=uc)
         self.assertEqual(result,
                          'http://example.com/abc%20def#La%20Pe%C3%B1a')
 
@@ -3995,52 +3977,102 @@ class TestStaticURLInfo(unittest.TestCase):
             kw['foo'] = 'bar'
             return 'foo' + '/' + subpath, kw
         inst = self._makeOne()
-        inst.registrations = [(None, 'package:path/', '__viewname', cachebust)]
+        inst.registrations = [(None, 'package:path/', '__viewname')]
         inst.cache_busters = [('package:path/', cachebust)]
         request = self._makeRequest()
+        called = [False]
         def route_url(n, **kw):
+            called[0] = True
             self.assertEqual(n, '__viewname')
-            self.assertEqual(kw, {'subpath':'foo/abc', 'foo':'bar'})
+            self.assertEqual(kw, {'subpath': 'foo/abc', 'foo': 'bar'})
         request.route_url = route_url
         inst.generate('package:path/abc', request)
+        self.assertTrue(called[0])
+
+    def test_generate_url_cachebust_abspath(self):
+        here = os.path.dirname(__file__) + os.sep
+        def cachebust(pathspec, subpath, kw):
+            kw['foo'] = 'bar'
+            return 'foo' + '/' + subpath, kw
+        inst = self._makeOne()
+        inst.registrations = [(None, here, '__viewname')]
+        inst.cache_busters = [(here, cachebust)]
+        request = self._makeRequest()
+        called = [False]
+        def route_url(n, **kw):
+            called[0] = True
+            self.assertEqual(n, '__viewname')
+            self.assertEqual(kw, {'subpath': 'foo/abc', 'foo': 'bar'})
+        request.route_url = route_url
+        inst.generate(here + 'abc', request)
+        self.assertTrue(called[0])
+
+    def test_generate_url_cachebust_nomatch(self):
+        def fake_cb(*a, **kw): raise AssertionError
+        inst = self._makeOne()
+        inst.registrations = [(None, 'package:path/', '__viewname')]
+        inst.cache_busters = [('package:path2/', fake_cb)]
+        request = self._makeRequest()
+        called = [False]
+        def route_url(n, **kw):
+            called[0] = True
+            self.assertEqual(n, '__viewname')
+            self.assertEqual(kw, {'subpath': 'abc'})
+        request.route_url = route_url
+        inst.generate('package:path/abc', request)
+        self.assertTrue(called[0])
+
+    def test_generate_url_cachebust_with_overrides(self):
+        config = testing.setUp()
+        try:
+            config.add_static_view('static', 'path')
+            config.override_asset(
+                'pyramid.tests.test_config:path/',
+                'pyramid.tests.test_config:other_path/')
+            def cb(pathspec, subpath, kw):
+                kw['_query'] = {'x': 'foo'}
+                return subpath, kw
+            config.add_cache_buster('other_path', cb)
+            request = testing.DummyRequest()
+            result = request.static_url('path/foo.png')
+            self.assertEqual(result, 'http://example.com/static/foo.png?x=foo')
+        finally:
+            testing.tearDown()
 
     def test_add_already_exists(self):
         config = DummyConfig()
         inst = self._makeOne()
         inst.registrations = [('http://example.com/', 'package:path/', None)]
         inst.add(config, 'http://example.com', 'anotherpackage:path')
-        expected = [
-            ('http://example.com/', 'anotherpackage:path/', None, None)]
+        expected = [('http://example.com/', 'anotherpackage:path/', None)]
         self.assertEqual(inst.registrations, expected)
 
     def test_add_package_root(self):
         config = DummyConfig()
         inst = self._makeOne()
         inst.add(config, 'http://example.com', 'package:')
-        expected = [('http://example.com/', 'package:', None, None)]
+        expected = [('http://example.com/', 'package:', None)]
         self.assertEqual(inst.registrations, expected)
 
     def test_add_url_withendslash(self):
         config = DummyConfig()
         inst = self._makeOne()
         inst.add(config, 'http://example.com/', 'anotherpackage:path')
-        expected = [
-            ('http://example.com/', 'anotherpackage:path/', None, None)]
+        expected = [('http://example.com/', 'anotherpackage:path/', None)]
         self.assertEqual(inst.registrations, expected)
 
     def test_add_url_noendslash(self):
         config = DummyConfig()
         inst = self._makeOne()
         inst.add(config, 'http://example.com', 'anotherpackage:path')
-        expected = [
-            ('http://example.com/', 'anotherpackage:path/', None, None)]
+        expected = [('http://example.com/', 'anotherpackage:path/', None)]
         self.assertEqual(inst.registrations, expected)
 
     def test_add_url_noscheme(self):
         config = DummyConfig()
         inst = self._makeOne()
         inst.add(config, '//example.com', 'anotherpackage:path')
-        expected = [('//example.com/', 'anotherpackage:path/', None, None)]
+        expected = [('//example.com/', 'anotherpackage:path/', None)]
         self.assertEqual(inst.registrations, expected)
 
     def test_add_viewname(self):
@@ -4049,7 +4081,7 @@ class TestStaticURLInfo(unittest.TestCase):
         config = DummyConfig()
         inst = self._makeOne()
         inst.add(config, 'view', 'anotherpackage:path', cache_max_age=1)
-        expected = [(None, 'anotherpackage:path/', '__view/', None)]
+        expected = [(None, 'anotherpackage:path/', '__view/')]
         self.assertEqual(inst.registrations, expected)
         self.assertEqual(config.route_args, ('__view/', 'view/*subpath'))
         self.assertEqual(config.view_kw['permission'], NO_PERMISSION_REQUIRED)
@@ -4060,7 +4092,7 @@ class TestStaticURLInfo(unittest.TestCase):
         config.route_prefix = '/abc'
         inst = self._makeOne()
         inst.add(config, 'view', 'anotherpackage:path',)
-        expected = [(None, 'anotherpackage:path/', '__/abc/view/', None)]
+        expected = [(None, 'anotherpackage:path/', '__/abc/view/')]
         self.assertEqual(inst.registrations, expected)
         self.assertEqual(config.route_args, ('__/abc/view/', 'view/*subpath'))
 
@@ -4097,19 +4129,46 @@ class TestStaticURLInfo(unittest.TestCase):
         config = DummyConfig()
         config.registry.settings['pyramid.prevent_cachebust'] = True
         inst = self._makeOne()
-        inst.add(config, 'view', 'mypackage:path', cachebust=True)
-        cachebust = config.registry._static_url_registrations[0][3]
-        self.assertEqual(cachebust, None)
+        cachebust = DummyCacheBuster('foo')
+        inst.add_cache_buster(config, 'mypackage:path', cachebust)
+        self.assertEqual(inst.cache_busters, [])
 
-    def test_add_cachebust_custom(self):
+    def test_add_cachebuster(self):
         config = DummyConfig()
         inst = self._makeOne()
-        inst.add(config, 'view', 'mypackage:path',
-                 cachebust=DummyCacheBuster('foo'))
-        cachebust = config.registry._static_url_registrations[0][3]
-        subpath, kw = cachebust('some/path', {})
+        inst.add_cache_buster(config, 'mypackage:path', DummyCacheBuster('foo'))
+        cachebust = inst.cache_busters[-1][1]
+        subpath, kw = cachebust('mypackage:some/path', 'some/path', {})
         self.assertEqual(subpath, 'some/path')
         self.assertEqual(kw['x'], 'foo')
+
+    def test_add_cachebuster_abspath(self):
+        here = os.path.dirname(__file__)
+        config = DummyConfig()
+        inst = self._makeOne()
+        cb = DummyCacheBuster('foo')
+        inst.add_cache_buster(config, here, cb)
+        self.assertEqual(inst.cache_busters, [(here + '/', cb)])
+
+    def test_add_cachebuster_overwrite(self):
+        config = DummyConfig()
+        inst = self._makeOne()
+        cb1 = DummyCacheBuster('foo')
+        cb2 = DummyCacheBuster('bar')
+        inst.add_cache_buster(config, 'mypackage:path/', cb1)
+        inst.add_cache_buster(config, 'mypackage:path', cb2)
+        self.assertEqual(inst.cache_busters,
+                         [('mypackage:path/', cb2)])
+
+    def test_add_cachebuster_for_more_specific_path(self):
+        config = DummyConfig()
+        inst = self._makeOne()
+        cb1 = DummyCacheBuster('foo')
+        cb2 = DummyCacheBuster('bar')
+        inst.add_cache_buster(config, 'mypackage:path', cb1)
+        inst.add_cache_buster(config, 'mypackage:path/sub', cb2)
+        self.assertEqual(inst.cache_busters,
+                         [('mypackage:path/', cb1), ('mypackage:path/sub/', cb2)])
 
 class Test_view_description(unittest.TestCase):
     def _callFUT(self, view):
@@ -4130,8 +4189,13 @@ class Test_view_description(unittest.TestCase):
 
 
 class DummyRegistry:
+    utility = None
+
     def __init__(self):
         self.settings = {}
+
+    def queryUtility(self, type_or_iface, name=None, default=None):
+        return self.utility or default
 
 from zope.interface import implementer
 from pyramid.interfaces import (
@@ -4193,6 +4257,9 @@ class DummySecurityPolicy:
         return self.permitted
 
 class DummyConfig:
+    def __init__(self):
+        self.registry = DummyRegistry()
+
     route_prefix = ''
     def add_route(self, *args, **kw):
         self.route_args = args

--- a/pyramid/tests/test_static.py
+++ b/pyramid/tests/test_static.py
@@ -385,29 +385,29 @@ class TestQueryStringConstantCacheBuster(unittest.TestCase):
         fut = self._makeOne().tokenize
         self.assertEqual(fut('whatever'), 'foo')
 
-    def test_pregenerate(self):
-        fut = self._makeOne().pregenerate
+    def test_it(self):
+        fut = self._makeOne()
         self.assertEqual(
-            fut('foo', ('bar',), {}),
-            (('bar',), {'_query': {'x': 'foo'}}))
+            fut('foo', 'bar', {}),
+            ('bar', {'_query': {'x': 'foo'}}))
 
-    def test_pregenerate_change_param(self):
-        fut = self._makeOne('y').pregenerate
+    def test_change_param(self):
+        fut = self._makeOne('y')
         self.assertEqual(
-            fut('foo', ('bar',), {}),
-            (('bar',), {'_query': {'y': 'foo'}}))
+            fut('foo', 'bar', {}),
+            ('bar', {'_query': {'y': 'foo'}}))
 
-    def test_pregenerate_query_is_already_tuples(self):
-        fut = self._makeOne().pregenerate
+    def test_query_is_already_tuples(self):
+        fut = self._makeOne()
         self.assertEqual(
-            fut('foo', ('bar',), {'_query': [('a', 'b')]}),
-            (('bar',), {'_query': (('a', 'b'), ('x', 'foo'))}))
+            fut('foo', 'bar', {'_query': [('a', 'b')]}),
+            ('bar', {'_query': (('a', 'b'), ('x', 'foo'))}))
 
-    def test_pregenerate_query_is_tuple_of_tuples(self):
-        fut = self._makeOne().pregenerate
+    def test_query_is_tuple_of_tuples(self):
+        fut = self._makeOne()
         self.assertEqual(
-            fut('foo', ('bar',), {'_query': (('a', 'b'),)}),
-            (('bar',), {'_query': (('a', 'b'), ('x', 'foo'))}))
+            fut('foo', 'bar', {'_query': (('a', 'b'),)}),
+            ('bar', {'_query': (('a', 'b'), ('x', 'foo'))}))
 
 class TestManifestCacheBuster(unittest.TestCase):
 
@@ -417,55 +417,55 @@ class TestManifestCacheBuster(unittest.TestCase):
 
     def test_it(self):
         manifest_path = os.path.join(here, 'fixtures', 'manifest.json')
-        fut = self._makeOne(manifest_path).pregenerate
-        self.assertEqual(fut('foo', ('bar',), {}), (['bar'], {}))
+        fut = self._makeOne(manifest_path)
+        self.assertEqual(fut('foo', 'bar', {}), ('bar', {}))
         self.assertEqual(
-            fut('foo', ('css', 'main.css'), {}),
-            (['css', 'main-test.css'], {}))
+            fut('foo', 'css/main.css', {}),
+            ('css/main-test.css', {}))
 
     def test_it_with_relspec(self):
-        fut = self._makeOne('fixtures/manifest.json').pregenerate
-        self.assertEqual(fut('foo', ('bar',), {}), (['bar'], {}))
+        fut = self._makeOne('fixtures/manifest.json')
+        self.assertEqual(fut('foo', 'bar', {}), ('bar', {}))
         self.assertEqual(
-            fut('foo', ('css', 'main.css'), {}),
-            (['css', 'main-test.css'], {}))
+            fut('foo', 'css/main.css', {}),
+            ('css/main-test.css', {}))
 
     def test_it_with_absspec(self):
-        fut = self._makeOne('pyramid.tests:fixtures/manifest.json').pregenerate
-        self.assertEqual(fut('foo', ('bar',), {}), (['bar'], {}))
+        fut = self._makeOne('pyramid.tests:fixtures/manifest.json')
+        self.assertEqual(fut('foo', 'bar', {}), ('bar', {}))
         self.assertEqual(
-            fut('foo', ('css', 'main.css'), {}),
-            (['css', 'main-test.css'], {}))
+            fut('foo', 'css/main.css', {}),
+            ('css/main-test.css', {}))
 
     def test_reload(self):
         manifest_path = os.path.join(here, 'fixtures', 'manifest.json')
         new_manifest_path = os.path.join(here, 'fixtures', 'manifest2.json')
         inst = self._makeOne('foo', reload=True)
         inst.getmtime = lambda *args, **kwargs: 0
-        fut = inst.pregenerate
+        fut = inst
 
         # test without a valid manifest
         self.assertEqual(
-            fut('foo', ('css', 'main.css'), {}),
-            (['css', 'main.css'], {}))
+            fut('foo', 'css/main.css', {}),
+            ('css/main.css', {}))
 
         # swap to a real manifest, setting mtime to 0
         inst.manifest_path = manifest_path
         self.assertEqual(
-            fut('foo', ('css', 'main.css'), {}),
-            (['css', 'main-test.css'], {}))
+            fut('foo', 'css/main.css', {}),
+            ('css/main-test.css', {}))
 
         # ensure switching the path doesn't change the result
         inst.manifest_path = new_manifest_path
         self.assertEqual(
-            fut('foo', ('css', 'main.css'), {}),
-            (['css', 'main-test.css'], {}))
+            fut('foo', 'css/main.css', {}),
+            ('css/main-test.css', {}))
 
         # update mtime, should cause a reload
         inst.getmtime = lambda *args, **kwargs: 1
         self.assertEqual(
-            fut('foo', ('css', 'main.css'), {}),
-            (['css', 'main-678b7c80.css'], {}))
+            fut('foo', 'css/main.css', {}),
+            ('css/main-678b7c80.css', {}))
 
     def test_invalid_manifest(self):
         self.assertRaises(IOError, lambda: self._makeOne('foo'))

--- a/pyramid/tests/test_static.py
+++ b/pyramid/tests/test_static.py
@@ -383,7 +383,7 @@ class TestQueryStringConstantCacheBuster(unittest.TestCase):
 
     def test_token(self):
         fut = self._makeOne().tokenize
-        self.assertEqual(fut('whatever'), 'foo')
+        self.assertEqual(fut(None, 'whatever', None), 'foo')
 
     def test_it(self):
         fut = self._makeOne()


### PR DESCRIPTION
Remove `cachebust=` from `config.add_static_view` and provide a `config.add_cache_buster` API. The cache busters are tied directly to raw asset paths instead of high-level specifications. For example:

```python
config.add_static_view('static', 'myapp:static')
config.override_asset('myapp:static/', 'theme:static/')

def cb(pathspec, subpath, kw):
    # pathspec -> 'theme:static/foo.png'
    # subpath -> 'foo.png'
    # kw -> args to route_url
    return subpath, kw
config.add_cache_buster('theme:static', cb)
```

Note that the cache buster is tied to `theme:static` and not `myapp:static`.

I'm open to tweaking this API. For example, it might be more intuitive to tie the cache busters to the high-level specs in many cases. Perhaps it would be a better default to tie things to the high-level spec and provide an option to add_cache_buster such as `base_spec=True` or `raw_spec=True` for scenarios where the cache buster is a manifest tied directly to the specific assets. I don't think this would be very difficult to support and it'd be better to get a sane default to start with versus trying to change it. The advantage of using a high-level spec by default is that it would encompass overrides without having to add new cache busters per override.

This PR also drops the entire matching side of the cache busting and focuses purely on generating urls, allowing custom tweens, etc to serve the urls as they see fit.

Fixes #2145.

ping @mcdonc @bertjwregeer @dstufft 