### PR TITLE
ensure IAssetDescriptor.abspath always returns an abspath

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -252,6 +252,11 @@ Bug Fixes
   process failed to fork because it could not find the pserve script to
   run. See https://github.com/Pylons/pyramid/pull/2137
 
+- Ensure that ``IAssetDescriptor.abspath`` always returns an absolute path.
+  There were cases depending on the process CWD that a relative path would
+  be returned. See https://github.com/Pylons/pyramid/issues/2187
+
+
 Deprecations
 ------------
 

--- a/pyramid/path.py
+++ b/pyramid/path.py
@@ -396,7 +396,8 @@ class PkgResourcesAssetDescriptor(object):
         return '%s:%s' % (self.pkg_name, self.path)
 
     def abspath(self):
-        return self.pkg_resources.resource_filename(self.pkg_name, self.path)
+        return os.path.abspath(
+            self.pkg_resources.resource_filename(self.pkg_name, self.path))
 
     def stream(self):
         return self.pkg_resources.resource_stream(self.pkg_name, self.path)


### PR DESCRIPTION
fixes #2184 

I tried to write a test for this but couldn't make it work. The return value of `pkg_resources.resource_filename(module, fname)` is relative to `module.__file__` which is not always absolute. It is only absolute if the file being loaded is not in the CWD tree. Since `__file__`  is cached at import-time changing the CWD in a test prior to using `resource_filename` has no effect.