### PR TITLE
ensure IAssetDescriptor.abspath always returns an abspath

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,13 @@ Features
 - Add a new ``config.add_cache_buster`` API for attaching cache busters to
   static assets. See https://github.com/Pylons/pyramid/pull/2186
 
+Bug Fixes
+---------
+
+- Ensure that ``IAssetDescriptor.abspath`` always returns an absolute path.
+  There were cases depending on the process CWD that a relative path would
+  be returned. See https://github.com/Pylons/pyramid/issues/2188
+
 1.6b2 (2015-10-15)
 ==================
 

--- a/pyramid/path.py
+++ b/pyramid/path.py
@@ -396,7 +396,8 @@ class PkgResourcesAssetDescriptor(object):
         return '%s:%s' % (self.pkg_name, self.path)
 
     def abspath(self):
-        return self.pkg_resources.resource_filename(self.pkg_name, self.path)
+        return os.path.abspath(
+            self.pkg_resources.resource_filename(self.pkg_name, self.path))
 
     def stream(self):
         return self.pkg_resources.resource_stream(self.pkg_name, self.path)


### PR DESCRIPTION
backport from #2187 