### PR TITLE
deprecate pserve --user and --group options

### DIFF
--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -212,8 +212,9 @@ class PServeCommand(object):
             self.options.set_user = self.options.set_group = None
 
         # @@: Is this the right stage to set the user at?
-        self.change_user_group(
-            self.options.set_user, self.options.set_group)
+        if self.options.set_user or self.options.set_group:
+            self.change_user_group(
+                self.options.set_user, self.options.set_group)
 
         if not self.args:
             self.out('You must give a config file')
@@ -624,10 +625,15 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
                 self.out('%s %s %s' % ('-' * 20, 'Restarting', '-' * 20))
 
     def change_user_group(self, user, group): # pragma: no cover
-        if not user and not group:
-            return
         import pwd
         import grp
+
+        self.out('''\
+The --user and --group options have been deprecated in Pyramid 1.6. They will
+be removed in a future release per Pyramid's deprecation policy. Please
+consider using a real process manager for your processes like Systemd, Circus,
+or Supervisor, all of which support process security.
+''')
 
         uid = gid = None
         if group:


### PR DESCRIPTION
This should complete the deprecation process for pserve, drastically simplifying its codebase. We've already deprecated `--daemon`, `--stop-server`, `--monitor-restart`, `--pid-file`, `--status`, and `[start,stop,restart,status]`. This would leave the server focused only on options for loading code (apps and servers) and reloading.