### PR TITLE
Rename Cookbook to Pyramid Community Cookbook

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -960,7 +960,7 @@ Glossary
      users transition from Pylons and those preferring a more Pylons-like API.
      The scaffold has been retired but the demo plays a similar role. 
 
-   Pyramid Cookbook
+   Pyramid Community Cookbook
      Additional, community-based documentation for Pyramid which presents
      topical, practical uses of Pyramid:
      :ref:`Pyramid Community Cookbook <cookbook:pyramid-cookbook>`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ speed right away.
 
 * Like learning by example? Visit the official :ref:`html_tutorials` as well as
   the community-contributed :ref:`Pyramid Tutorials
-  <tutorials:pyramid-tutorials>` and :ref:`Pyramid Cookbook
+  <tutorials:pyramid-tutorials>` and :ref:`Pyramid Community Cookbook
   <cookbook:pyramid-cookbook>`.
 
 * For help getting Pyramid set up, try :ref:`installing_chapter`.

--- a/docs/narr/advconfig.rst
+++ b/docs/narr/advconfig.rst
@@ -417,7 +417,6 @@ added in configuration execution order.
 More Information
 ----------------
 
-For more information, see the article `"A Whirlwind Tour of Advanced
-Configuration Tactics"
-<http://docs.pylonsproject.org/projects/pyramid_cookbook/en/latest/configuration/whirlwind_tour.html>`_
-in the Pyramid Cookbook.
+For more information, see the article :ref:`A Whirlwind Tour of Advanced
+Configuration Tactics <cookbook:whirlwind-adv-conf>` in the Pyramid Community
+Cookbook.

--- a/docs/narr/i18n.rst
+++ b/docs/narr/i18n.rst
@@ -666,9 +666,9 @@ can always use the more manual translation facility described in
 Mako Pyramid i18n Support
 -------------------------
 
-There exists a recipe within the :term:`Pyramid Cookbook` named ":ref:`Mako
-Internationalization <cookbook:mako_i18n>`" which explains how to add idiomatic
-i18n support to :term:`Mako` templates.
+There exists a recipe within the :term:`Pyramid Community Cookbook` named
+:ref:`Mako Internationalization <cookbook:mako_i18n>` which explains how to add
+idiomatic i18n support to :term:`Mako` templates.
 
 .. index::
    single: localization deployment settings

--- a/docs/narr/introduction.rst
+++ b/docs/narr/introduction.rst
@@ -892,8 +892,7 @@ also maintain a "cookbook" of recipes, which are usually demonstrations of
 common integration scenarios too specific to add to the official narrative
 docs.  In any case, the Pyramid documentation is comprehensive.
 
-Example: The Pyramid Cookbook at
-http://docs.pylonsproject.org/projects/pyramid-cookbook/en/latest/.
+Example: The :ref:`Pyramid Community Cookbook <cookbook:pyramid-cookbook>`.
 
 .. index::
    single: Pylons Project

--- a/docs/whatsnew-1.3.rst
+++ b/docs/whatsnew-1.3.rst
@@ -523,10 +523,11 @@ Documentation Enhancements
   :ref:`making_a_console_script`.
 
 - Removed the "Running Pyramid on Google App Engine" tutorial from the main
-  docs.  It survives on in the Cookbook
-  (http://docs.pylonsproject.org/projects/pyramid_cookbook/en/latest/deployment/gae.html).
-  Rationale: it provides the correct info for the Python 2.5 version of GAE
-  only, and this version of Pyramid does not support Python 2.5.
+  docs.  It survives on in the Pyramid Community Cookbook as
+  :ref:`Pyramid on Google's App Engine (using appengine-monkey)
+  <cookbook:appengine_tutorial>`. Rationale: it provides the correct info for
+  the Python 2.5 version of GAE only, and this version of Pyramid does not
+  support Python 2.5.
 
 - Updated the :ref:`changing_the_forbidden_view` section, replacing
   explanations of registering a view using ``add_view`` or ``view_config``


### PR DESCRIPTION
- use .rst intersphinx labels for pages instead of broken URLs
(cherry picked from commit 34515f3)