### PR TITLE
Remove Python 3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
           env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27
-        - python: 3.2
-          env: TOXENV=py32
         - python: 3.3
           env: TOXENV=py33
         - python: 3.4

--- a/docs/narr/install.rst
+++ b/docs/narr/install.rst
@@ -15,8 +15,8 @@ You will need `Python <http://python.org>`_ version 2.6 or better to run
 .. sidebar:: Python Versions
 
     As of this writing, :app:`Pyramid` has been tested under Python 2.6, Python
-    2.7, Python 3.2, Python 3.3, Python 3.4, Python 3.5, PyPy, and PyPy3.
-    :app:`Pyramid` does not run under any version of Python before 2.6.
+    2.7, Python 3.3, Python 3.4, Python 3.5, PyPy, and PyPy3. :app:`Pyramid`
+    does not run under any version of Python before 2.6.
 
 :app:`Pyramid` is known to run on all popular UNIX-like systems such as Linux,
 Mac OS X, and FreeBSD as well as on Windows platforms.  It is also known to run

--- a/docs/narr/introduction.rst
+++ b/docs/narr/introduction.rst
@@ -860,11 +860,11 @@ Every release of Pyramid has 100% statement coverage via unit and integration
 tests, as measured by the ``coverage`` tool available on PyPI.  It also has
 greater than 95% decision/condition coverage as measured by the
 ``instrumental`` tool available on PyPI.  It is automatically tested by the
-Jenkins tool on Python 2.6, Python 2.7, Python 3.2, Python 3.3, Python 3.4,
-Python 3.5, PyPy, and PyPy3 after each commit to its GitHub repository.
-Official Pyramid add-ons are held to a similar testing standard.  We still find
-bugs in Pyramid and its official add-ons, but we've noticed we find a lot more
-of them while working on other projects that don't have a good testing regime.
+Jenkins tool on Python 2.6, Python 2.7, Python 3.3, Python 3.4, Python 3.5,
+PyPy, and PyPy3 after each commit to its GitHub repository. Official Pyramid
+add-ons are held to a similar testing standard.  We still find bugs in Pyramid
+and its official add-ons, but we've noticed we find a lot more of them while
+working on other projects that don't have a good testing regime.
 
 Example: http://jenkins.pylonsproject.org/
 

--- a/docs/quick_tutorial/requirements.rst
+++ b/docs/quick_tutorial/requirements.rst
@@ -19,7 +19,7 @@ make an isolated environment, and setup packaging tools.)
 
 This *Quick Tutorial* is based on:
 
-* **Python 3.3**. Pyramid fully supports Python 3.2+ and Python 2.6+.
+* **Python 3.3**. Pyramid fully supports Python 3.3+ and Python 2.6+.
   This tutorial uses **Python 3.3** but runs fine under Python 2.7.
 
 * **pyvenv**. We believe in virtual environments. For this tutorial,

--- a/docs/tutorials/wiki/installation.rst
+++ b/docs/tutorials/wiki/installation.rst
@@ -65,11 +65,11 @@ Python 2.7:
 
    c:\> c:\Python27\Scripts\virtualenv %VENV%
 
-Python 3.2:
+Python 3.3:
 
 .. code-block:: text
 
-   c:\> c:\Python32\Scripts\virtualenv %VENV%
+   c:\> c:\Python33\Scripts\virtualenv %VENV%
 
 Install Pyramid and tutorial dependencies into the virtual Python environment
 -----------------------------------------------------------------------------

--- a/docs/tutorials/wiki2/installation.rst
+++ b/docs/tutorials/wiki2/installation.rst
@@ -65,11 +65,11 @@ Python 2.7:
 
    c:\> c:\Python27\Scripts\virtualenv %VENV%
 
-Python 3.2:
+Python 3.3:
 
 .. code-block:: text
 
-   c:\> c:\Python32\Scripts\virtualenv %VENV%
+   c:\> c:\Python33\Scripts\virtualenv %VENV%
 
 Install Pyramid into the virtual Python environment
 ---------------------------------------------------

--- a/docs/whatsnew-1.3.rst
+++ b/docs/whatsnew-1.3.rst
@@ -18,7 +18,7 @@ Python 3 Compatibility
 .. image:: python-3.png
 
 Pyramid continues to run on Python 2, but Pyramid is now also Python 3
-compatible.  To use Pyramid under Python 3, Python 3.2 or better is required.
+compatible.  To use Pyramid under Python 3, Python 3.3 or better is required.
 
 Many Pyramid add-ons are already Python 3 compatible.  For example,
 ``pyramid_debugtoolbar``, ``pyramid_jinja2``, ``pyramid_exclog``,

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,13 @@ import sys
 from setuptools import setup, find_packages
 
 py_version = sys.version_info[:2]
+is_pypy = '__pypy__' in sys.builtin_module_names
 
 PY3 = py_version[0] == 3
 
 if PY3:
-    if py_version < (3, 2):
-        raise RuntimeError('On Python 3, Pyramid requires Python 3.2 or better')
+    if py_version < (3, 3) and not is_pypy: # PyPy3 masquerades as Python 3.2...
+        raise RuntimeError('On Python 3, Pyramid requires Python 3.3 or better')
 else:
     if py_version < (2, 6):
         raise RuntimeError('On Python 2, Pyramid requires Python 2.6 or better')
@@ -81,7 +82,6 @@ setup(name='pyramid',
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py32,py33,py34,py35,pypy,pypy3,
+    py26,py27,py33,py34,py35,pypy,pypy3,
     docs,pep8,
     {py2,py3}-cover,coverage,
 
@@ -10,7 +10,6 @@ envlist =
 basepython =
     py26: python2.6
     py27: python2.7
-    py32: python3.2
     py33: python3.3
     py34: python3.4
     py35: python3.5


### PR DESCRIPTION
This removes Python 3.2 support from the testing path, and from setup.py. At this point testing it becomes more difficult because pip no longer installs/runs under Python 3.2, and tox pulls in the latest version of pip.