### PR TITLE
Bump sphinx to 1.3.5; revert comment syntax. Closes #2251.

### DIFF
--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -435,7 +435,7 @@ commenting out a line.  For example, instead of:
    :linenos:
 
    [app:main]
-   ...
+   # ... elided configuration
    pyramid.includes =
        pyramid_debugtoolbar
 
@@ -445,7 +445,7 @@ Put a hash mark at the beginning of the ``pyramid_debugtoolbar`` line:
    :linenos:
 
    [app:main]
-   ...
+   # ... elided configuration
    pyramid.includes =
    #    pyramid_debugtoolbar
 

--- a/docs/narr/webob.rst
+++ b/docs/narr/webob.rst
@@ -269,7 +269,7 @@ to a :app:`Pyramid` application:
 When such a request reaches a view in your application, the
 ``request.json_body`` attribute will be available in the view callable body.
 
-.. code-block:: javascript
+.. code-block:: python
 
     @view_config(renderer='string')
     def aview(request):

--- a/docs/quick_tour/requests/app.py
+++ b/docs/quick_tour/requests/app.py
@@ -4,7 +4,7 @@ from pyramid.response import Response
 
 
 def hello_world(request):
-    """ Some parameters from a request such as /?name=lisa """
+    # Some parameters from a request such as /?name=lisa
     url = request.url
     name = request.params.get('name', 'No Name Provided')
 

--- a/docs/quick_tutorial/requirements.rst
+++ b/docs/quick_tutorial/requirements.rst
@@ -109,7 +109,7 @@ For Linux, the commands to do so are as follows:
 
 For Windows:
 
-.. code-block:: posh
+.. code-block:: ps1con
 
     # Windows
     c:\> cd \

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ if not PY3:
     tests_require.append('zope.component>=3.11.0')
 
 docs_extras = [
-    'Sphinx >= 1.3.4',
+    'Sphinx >= 1.3.5',
     'docutils',
     'repoze.sphinx.autointerface',
     'pylons_sphinx_latesturl',


### PR DESCRIPTION
(cherry picked from commit 1779c2a)