### PR TITLE
Fixed --browser behaviour when --server-name provided

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -258,3 +258,5 @@ Contributors
 - Rami Chousein, 2015/10/28
 
 - Sri Sanketh Uppalapati, 2015/12/12
+
+- Marcin Raczyński, 2016/01/26

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -9,7 +9,7 @@
 # lib/site.py
 
 import atexit
-import ctypes
+import ctypes.
 import errno
 import logging
 import optparse
@@ -391,7 +391,7 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
 
         if self.options.browser:
             def open_browser():
-                context = loadcontext(SERVER, app_spec, name=app_name, relative_to=base,
+                context = loadcontext(SERVER, app_spec, name=server_name, relative_to=base,
                         global_conf=vars)
                 url = 'http://127.0.0.1:{port}/'.format(**context.config())
                 time.sleep(1)

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -9,7 +9,7 @@
 # lib/site.py
 
 import atexit
-import ctypes.
+import ctypes
 import errno
 import logging
 import optparse


### PR DESCRIPTION
Fixing PR #1533: Calling:
```
   pserve --server-name abc --browser app.ini
```
caused error : "LookupError: No section 'main' (prefixed by 'server') found in config app.ini"
