### PR TITLE
turn the models package into a facade

### DIFF
--- a/pyramid/scaffolds/alchemy/+package+/__init__.py
+++ b/pyramid/scaffolds/alchemy/+package+/__init__.py
@@ -6,7 +6,9 @@ def main(global_config, **settings):
     """
     config = Configurator(settings=settings)
     config.include('pyramid_jinja2')
-    config.include('.models.meta')
+
+    config.include('.models')
+
     config.add_static_view('static', 'static', cache_max_age=3600)
     config.add_route('home', '/')
     config.scan()

--- a/pyramid/scaffolds/alchemy/+package+/models/__init__.py
+++ b/pyramid/scaffolds/alchemy/+package+/models/__init__.py
@@ -1,7 +1,29 @@
-from sqlalchemy.orm import configure_mappers
-# import all models classes here for sqlalchemy mappers
-# to pick up
-from .mymodel import MyModel # flake8: noqa
+def _build_facade():
+    """
+    Build a facade by scanning the entire package.
 
-# run configure mappers to ensure we avoid any race conditions
-configure_mappers()
+    - Scan the entire package to pick up all of the models ensuring that
+      they are attached to the metadata.
+    - Expose the models conveniently at the top level as a single view of
+      the database schema.
+    """
+    from sqlalchemy.orm import configure_mappers
+    from .meta import Base
+    from .utils import scan, get_all_subclasses
+
+    # execute all of the modules in the package
+    registry = scan(__package__)
+
+    # add all the model classes to the facade
+    all_models = get_all_subclasses(Base)
+    for m in all_models:
+        registry[m.__name__] = m
+
+    # expose the public api for the package
+    globals().update(registry)
+
+    # run configure mappers to ensure we avoid any race conditions
+    configure_mappers()
+
+_build_facade()
+del _build_facade

--- a/pyramid/scaffolds/alchemy/+package+/models/mymodel.py
+++ b/pyramid/scaffolds/alchemy/+package+/models/mymodel.py
@@ -1,10 +1,11 @@
-from .meta import Base
 from sqlalchemy import (
     Column,
     Index,
     Integer,
     Text,
 )
+
+from .meta import Base
 
 
 class MyModel(Base):

--- a/pyramid/scaffolds/alchemy/+package+/models/utils.py
+++ b/pyramid/scaffolds/alchemy/+package+/models/utils.py
@@ -1,0 +1,25 @@
+import venusian
+
+def scan(pkg, registry=None):
+    if registry is None:
+        registry = {}
+    scanner = venusian.Scanner(registry=registry)
+    scanner.scan(pkg)
+    return registry
+
+def expose(wrapped):
+    def callback(scanner, name, obj):
+        registry = getattr(scanner, 'registry', None)
+        if registry is not None:
+            registry[name] = wrapped
+    venusian.attach(wrapped, callback)
+    return wrapped
+
+def get_all_subclasses(cls):
+    all_subclasses = []
+
+    for subclass in cls.__subclasses__():
+        all_subclasses.append(subclass)
+        all_subclasses.extend(get_all_subclasses(subclass))
+
+    return all_subclasses

--- a/pyramid/scaffolds/alchemy/setup.py_tmpl
+++ b/pyramid/scaffolds/alchemy/setup.py_tmpl
@@ -16,6 +16,7 @@ requires = [
     'SQLAlchemy',
     'transaction',
     'zope.sqlalchemy',
+    'venusian',
     'waitress',
     ]
 


### PR DESCRIPTION
I'd like thoughts on this but I think it's a handy pattern for breaking apart the model definitions but bringing them together when actually used by views, etc.