### PR TITLE
Add ApplicationCreated.config variable.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,17 @@
+.. _changes_1.6.2:
+
+1.6.2 (unreleased)
+==================
+
+
+Features
+--------
+
+- Add a new ``config`` attribute to the ``ApplicationCreated`` event. This
+  can be helpful to discover which application was created.
+
+
+
 .. _changes_1.6.1:
 
 1.6.1 (2016-02-02)

--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -992,7 +992,7 @@ class Configurator(
         # IApplicationCreated event.
         self.manager.push({'registry':self.registry, 'request':None})
         try:
-            self.registry.notify(ApplicationCreated(app))
+            self.registry.notify(ApplicationCreated(app, self))
         finally:
             self.manager.pop()
 

--- a/pyramid/events.py
+++ b/pyramid/events.py
@@ -156,13 +156,19 @@ class ContextFound(object):
 AfterTraversal = ContextFound # b/c as of 1.0
 
 @implementer(IApplicationCreated)
-class ApplicationCreated(object):    
+class ApplicationCreated(object):
     """ An instance of this class is emitted as an :term:`event` when
     the :meth:`pyramid.config.Configurator.make_wsgi_app` is
-    called.  The instance has an attribute, ``app``, which is an
-    instance of the :term:`router` that will handle WSGI requests.
-    This class implements the
-    :class:`pyramid.interfaces.IApplicationCreated` interface.
+    called. The instance has two attribuets:
+
+    * ``app``, which is an instance of the :term:`router` that will handle WSGI
+      requests.
+    * ``config``, which is an instance of the
+      :class:`pyramid.config.Configurator` that was used to create the
+      application.
+
+    This class implements the :class:`pyramid.interfaces.IApplicationCreated`
+    interface.
 
     .. note::
 
@@ -170,9 +176,10 @@ class ApplicationCreated(object):
        :class:`pyramid.events.WSGIApplicationCreatedEvent`.  This was the name
        of the event class before :app:`Pyramid` 1.0.
     """
-    def __init__(self, app):
+    def __init__(self, app, config=None):
         self.app = app
         self.object = app
+        self.config = config
 
 WSGIApplicationCreatedEvent = ApplicationCreated # b/c (as of 1.0)
 

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -53,6 +53,7 @@ class IApplicationCreated(Interface):
        :class:`pyramid.interfaces.IWSGIApplicationCreatedEvent`.
     """
     app = Attribute("Created application")
+    config = Attribute("Configurator used to create application")
 
 IWSGIApplicationCreatedEvent = IApplicationCreated # b /c
 

--- a/pyramid/tests/test_events.py
+++ b/pyramid/tests/test_events.py
@@ -61,7 +61,7 @@ class ApplicationCreatedEventTests(unittest.TestCase):
         from pyramid.events import ApplicationCreated
         return ApplicationCreated
 
-    def _makeOne(self, context=object()):
+    def _makeOne(self, app=object(), config=object()):
         return self._getTargetClass()(context)
 
     def test_class_conforms_to_IApplicationCreated(self):


### PR DESCRIPTION
I have some common code which is used in multiple applications. One of things I would like to do there is setup an event handler that logs application startup and dump a bunch of used package versions. To make that more useful I would like to know which application was started. I can get that using ``config.package``, but that is not accessible through the `ApplicationCreated` event.