### PR TITLE
wiki2 authentication bug fix and improvement against timing attack

### DIFF
--- a/docs/tutorials/wiki2/src/authentication/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/models/user.py
@@ -1,5 +1,4 @@
 import bcrypt
-import hmac
 from sqlalchemy import (
     Column,
     Integer,
@@ -26,5 +25,5 @@ class User(Base):
         if self.password_hash is not None:
             expected_hash = self.password_hash
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
-            return hmac.compare_digest(expected_hash, actual_hash)
+            return expected_hash == actual_hash
         return False

--- a/docs/tutorials/wiki2/src/authentication/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/models/user.py
@@ -1,4 +1,5 @@
 import bcrypt
+import hmac
 from sqlalchemy import (
     Column,
     Integer,
@@ -23,7 +24,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash.encode('utf8')
+            expected_hash = self.password_hash
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
-            return expected_hash == actual_hash
+            return hmac.compare_digest(expected_hash, actual_hash)
         return False

--- a/docs/tutorials/wiki2/src/authorization/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash.encode('utf8')
+            expected_hash = self.password_hash
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False

--- a/docs/tutorials/wiki2/src/models/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/models/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash.encode('utf8')
+            expected_hash = self.password_hash
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False

--- a/docs/tutorials/wiki2/src/tests/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash.encode('utf8')
+            expected_hash = self.password_hash
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False

--- a/docs/tutorials/wiki2/src/views/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash.encode('utf8')
+            expected_hash = self.password_hash
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False


### PR DESCRIPTION
ping @mmerickel @bertjwregeer for review and comment (thanks to @ztane @Themanwithoutaplan and @wichert for IRC help)

- Bytes type does not have encode method. The `expected_hash` retrieved from the database is a bytes object.
- Use `hmac.compare_digest()` instead of `==` to avoid timing attacks as a recommended security best practice. See https://www.python.org/dev/peps/pep-0466/ https://bugs.python.org/issue21306 and https://codahale.com/a-lesson-in-timing-attacks/ for details.

  Note, however, `hmac.compare_digest()` was not backported to py2.6. For a tutorial, I am OK with stating this will not work on Python 2.6 with a clear warning note at the start of the tutorial and on the authentication step.