### PR TITLE
configurable view deriver tweaks

### DIFF
--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -1189,7 +1189,21 @@ class IPredicateList(Interface):
 
 class IViewDerivers(Interface):
     """ Interface for view derivers list """
-    
+
+class IViewDeriverInfo(Interface):
+    """ An object implementing this interface is passed to every
+    :term:`view deriver` during configuration."""
+    registry = Attribute('The "current" application registry when the '
+                         'view was created')
+    package = Attribute('The "current package" when the view '
+                        'configuration statement was found')
+    settings = Attribute('The deployment settings dictionary related '
+                         'to the current application')
+    options = Attribute('The view options passed to the view, including any '
+                        'default values that were not overriden')
+    predicates = Attribute('The list of predicates active on the view')
+    orig_view = Attribute('The original view object being wrapped')
+
 class ICacheBuster(Interface):
     """
     A cache buster modifies the URL generation machinery for

--- a/pyramid/tests/test_config/test_derivations.py
+++ b/pyramid/tests/test_config/test_derivations.py
@@ -1097,9 +1097,9 @@ class TestDerivationOrder(unittest.TestCase):
     def test_right_order_user_sorted(self):
         from pyramid.interfaces import IViewDerivers
 
-        self.config.add_view_derivation('deriv1', None, default=None)
-        self.config.add_view_derivation('deriv2', None, default=None, over='deriv1')
-        self.config.add_view_derivation('deriv3', None, default=None, under='deriv2')
+        self.config.add_view_derivation('deriv1', None)
+        self.config.add_view_derivation('deriv2', None, over='deriv1')
+        self.config.add_view_derivation('deriv3', None, under='deriv2')
 
         derivers = self.config.registry.queryUtility(IViewDerivers, default=[])
         derivers_sorted = derivers.sorted()
@@ -1119,9 +1119,9 @@ class TestDerivationOrder(unittest.TestCase):
     def test_right_order_implicit(self):
         from pyramid.interfaces import IViewDerivers
 
-        self.config.add_view_derivation('deriv1', None, default=None)
-        self.config.add_view_derivation('deriv2', None, default=None)
-        self.config.add_view_derivation('deriv3', None, default=None)
+        self.config.add_view_derivation('deriv1', None)
+        self.config.add_view_derivation('deriv2', None)
+        self.config.add_view_derivation('deriv3', None)
 
         derivers = self.config.registry.queryUtility(IViewDerivers, default=[])
         derivers_sorted = derivers.sorted()
@@ -1141,7 +1141,7 @@ class TestDerivationOrder(unittest.TestCase):
     def test_right_order_over_rendered_view(self):
         from pyramid.interfaces import IViewDerivers
 
-        self.config.add_view_derivation('deriv1', None, default=None, over='rendered_view')
+        self.config.add_view_derivation('deriv1', None, over='rendered_view')
 
         derivers = self.config.registry.queryUtility(IViewDerivers, default=[])
         derivers_sorted = derivers.sorted()
@@ -1159,9 +1159,9 @@ class TestDerivationOrder(unittest.TestCase):
     def test_right_order_over_rendered_view_others(self):
         from pyramid.interfaces import IViewDerivers
 
-        self.config.add_view_derivation('deriv1', None, default=None, over='rendered_view')
-        self.config.add_view_derivation('deriv2', None, default=None)
-        self.config.add_view_derivation('deriv3', None, default=None)
+        self.config.add_view_derivation('deriv1', None, over='rendered_view')
+        self.config.add_view_derivation('deriv2', None)
+        self.config.add_view_derivation('deriv3', None)
 
         derivers = self.config.registry.queryUtility(IViewDerivers, default=[])
         derivers_sorted = derivers.sorted()
@@ -1192,32 +1192,17 @@ class TestAddDerivation(unittest.TestCase):
         response.deriv = False
         view = lambda *arg: response
 
-        def deriv(view, value, **kw):
+        def deriv(view, info):
             self.assertFalse(response.deriv)
-            self.assertEqual(value, None)
             response.deriv = True
             return view
 
         result = self.config._derive_view(view)
         self.assertFalse(response.deriv)
-        self.config.add_view_derivation('test_deriv', deriv, default=None)
+        self.config.add_view_derivation('test_deriv', deriv)
 
         result = self.config._derive_view(view)
         self.assertTrue(response.deriv)
-
-    def test_derivation_default(self):
-        response = DummyResponse()
-        response.deriv_value = None
-        test_default = object()
-        view = lambda *arg: response
-
-        def deriv(view, value, **kw):
-            response.deriv_value = value
-            return view
-
-        self.config.add_view_derivation('test_default_deriv', deriv, default=test_default)
-        result = self.config._derive_view(view)
-        self.assertEqual(response.deriv_value, test_default)
 
     def test_override_derivation(self):
         flags = {}
@@ -1235,35 +1220,17 @@ class TestAddDerivation(unittest.TestCase):
             return view
 
         view1 = AView()
-        self.config.add_view_derivation('test_deriv', deriv1, default=None)
+        self.config.add_view_derivation('test_deriv', deriv1)
         result = self.config._derive_view(view1)
         self.assertTrue(flags.get('deriv1'))
         self.assertFalse(flags.get('deriv2'))
 
         flags.clear()
         view2 = AView()
-        self.config.add_view_derivation('test_deriv', deriv2, default=None)
+        self.config.add_view_derivation('test_deriv', deriv2)
         result = self.config._derive_view(view2)
         self.assertFalse(flags.get('deriv1'))
         self.assertTrue(flags.get('deriv2'))
-
-    def test_override_derivation_default(self):
-        response = DummyResponse()
-        response.deriv_value = None
-        test_default1 = 'first default'
-        test_default2 = 'second default'
-        view = lambda *arg: response
-
-        def deriv(view, value, **kw):
-            response.deriv_value = value
-            return view
-
-        self.config.add_view_derivation('test_default_deriv', deriv, default=test_default1)
-        result = self.config._derive_view(view)
-        self.assertEqual(response.deriv_value, test_default1)
-        self.config.add_view_derivation('test_default_deriv', deriv, default=test_default2)
-        result = self.config._derive_view(view)
-        self.assertEqual(response.deriv_value, test_default2)
 
     def test_add_multi_derivations_ordered(self):
         response = DummyResponse()
@@ -1282,9 +1249,9 @@ class TestAddDerivation(unittest.TestCase):
             response.deriv.append('deriv3')
             return view
 
-        self.config.add_view_derivation('deriv1', deriv1, default=None)
-        self.config.add_view_derivation('deriv2', deriv2, default=None, over='deriv1')
-        self.config.add_view_derivation('deriv3', deriv3, default=None, under='deriv2')
+        self.config.add_view_derivation('deriv1', deriv1)
+        self.config.add_view_derivation('deriv2', deriv2, over='deriv1')
+        self.config.add_view_derivation('deriv3', deriv3, under='deriv2')
         result = self.config._derive_view(view)
         self.assertEqual(response.deriv, ['deriv2', 'deriv3', 'deriv1'])
 
@@ -1323,16 +1290,16 @@ class TestDerivationIntegration(unittest.TestCase):
         view = lambda *arg: response
         response.deriv = []
 
-        def deriv1(view, value, **kw):
-            response.deriv.append(kw['options']['deriv1'])
+        def deriv1(view, info):
+            response.deriv.append(info.options['deriv1'])
             return view
 
-        def deriv2(view, value, **kw):
-            response.deriv.append(kw['options']['deriv2'])
+        def deriv2(view, info):
+            response.deriv.append(info.options['deriv2'])
             return view
 
-        self.config.add_view_derivation('deriv1', deriv1, default=None)
-        self.config.add_view_derivation('deriv2', deriv2, default=None)
+        self.config.add_view_derivation('deriv1', deriv1)
+        self.config.add_view_derivation('deriv2', deriv2)
         self.config.add_view(view, deriv1='test1', deriv2='test2')
         self.config.commit()
 
@@ -1341,32 +1308,6 @@ class TestDerivationIntegration(unittest.TestCase):
         request.method = 'GET'
         self.assertEqual(wrapper(None, request), response)
         self.assertEqual(['test1', 'test2'], response.deriv)
-
-    def test_view_options_default_or_not(self):
-        response = DummyResponse()
-        view = lambda *arg: response
-        response.deriv = []
-
-        def deriv1(view, value, **kw):
-            response.deriv.append(value)
-            response.deriv.append(kw['options'].get('deriv1', None))
-            return view
-
-        def deriv2(view, value, **kw):
-            response.deriv.append(value)
-            response.deriv.append(kw['options'].get('deriv2', None))
-            return view
-
-        self.config.add_view_derivation('deriv1', deriv1, default=None)
-        self.config.add_view_derivation('deriv2', deriv2, default='test2')
-        self.config.add_view(view, deriv1='test1')
-        self.config.commit()
-
-        wrapper = self._getViewCallable(self.config)
-        request = self._makeRequest(self.config)
-        request.method = 'GET'
-        self.assertEqual(wrapper(None, request), response)
-        self.assertEqual(['test1', 'test1', 'test2', None], response.deriv)
 
 
 from zope.interface import implementer


### PR DESCRIPTION
I put some work into #2021 tonight and here's what I've come up with:

- New api for view derivers is `deriver(view, info)` where info is a new `IViewDeriverInfo` object with attributes including `package`, `registry`, `orig_view`, `predicates` and `options`.
- Define `options` as almost everything that was passed to `config.add_view` and a few other bonuses like `phash`, `order`, etc. We'll need to document this.
- Removed all default values from view derivers.

TODO

- Add a new `add_view_option` API that supports setting default values. View options will be the way to provide default values for options passed to `config.add_view`. This could be used for predicates values or view deriver values so it would then be possible to have a predicate default to on as well. Envision `config.add_view_option('require_csrf', default=True)`.