### PR TITLE
Pass os.environ to logging.config.fileConfig

### DIFF
--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -67,10 +67,12 @@ def setup_logging(config_uri, fileConfig=fileConfig,
     parser.read([path])
     if parser.has_section('loggers'):
         config_file = os.path.abspath(path)
-        return fileConfig(
-            config_file,
-            dict(__file__=config_file, here=os.path.dirname(config_file))
+        vars = dict(
+            __file__=config_file,
+            here=os.path.dirname(config_file)
             )
+        vars.update(os.environ)
+        return fileConfig(config_file, vars)
 
 def _getpathsec(config_uri, name):
     if '#' in config_uri:


### PR DESCRIPTION
This allows one to set up a logging configuration that is parameterized based on environment variables, and thus in the spirit of http://12factor.net/config

e.g.: the application .ini file could have:

```ini
[logger_root]
level = %(LOGGING_LOGGER_ROOT_LEVEL)s
handlers = console

[handler_console]
class = StreamHandler
args = (sys.stderr,)
level = %(LOGGING_HANDLER_CONSOLE_LEVEL)s
formatter = generic
```

Log levels are one of the main things that differ in a `development.ini` vs. a `production.ini`. I am working towards the goal of having only one config file for a Pyramid app, because having two configs is error-prone and implies that there are only two possible configurations for an app, which is somewhat limiting. Again, this is inspired largely by http://12factor.net/config

Cc: @mmerickel, @sontek, @sudarkoff, @sseg, @aconrad 