### PR TITLE
Pass vars to logging.config.fileConfig

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,12 @@ unreleased
   where you may need more control over the request.
   See https://github.com/Pylons/pyramid/pull/2393
 
+- Allow using variable substitutions like ``%(LOGGING_LOGGER_ROOT_LEVEL)s``
+  for logging sections of the .ini file and populate these variables from
+  the ``pserve`` command line -- e.g.:
+  ``pserve development.ini LOGGING_LOGGER_ROOT_LEVEL=DEBUG``
+  See https://github.com/Pylons/pyramid/pull/2399
+
 1.6 (2015-04-14)
 ================
 

--- a/docs/api/paster.rst
+++ b/docs/api/paster.rst
@@ -11,4 +11,4 @@
 
     .. autofunction:: get_appsettings(config_uri, name=None, options=None)
 
-    .. autofunction:: setup_logging(config_uri)
+    .. autofunction:: setup_logging(config_uri, global_conf=None)

--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -52,7 +52,8 @@ def get_appsettings(config_uri, name=None, options=None, appconfig=appconfig):
         relative_to=here_dir,
         global_conf=options)
 
-def setup_logging(config_uri, fileConfig=fileConfig,
+def setup_logging(config_uri, global_conf=None,
+                  fileConfig=fileConfig,
                   configparser=configparser):
     """
     Set up logging via the logging module's fileConfig function with the
@@ -61,16 +62,22 @@ def setup_logging(config_uri, fileConfig=fileConfig,
 
     ConfigParser defaults are specified for the special ``__file__``
     and ``here`` variables, similar to PasteDeploy config loading.
+    Extra defaults can optionally be specified as a dict in ``global_conf``.
     """
     path, _ = _getpathsec(config_uri, None)
     parser = configparser.ConfigParser()
     parser.read([path])
     if parser.has_section('loggers'):
         config_file = os.path.abspath(path)
-        return fileConfig(
-            config_file,
-            dict(__file__=config_file, here=os.path.dirname(config_file))
-            )
+        if global_conf:
+            # Copy to avoid side effects
+            global_conf = dict(global_conf)
+        else:
+            global_conf = {}
+        global_conf.update(
+            __file__=config_file,
+            here=os.path.dirname(config_file))
+        return fileConfig(config_file, global_conf)
 
 def _getpathsec(config_uri, name):
     if '#' in config_uri:

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -362,7 +362,7 @@ a real process manager for your processes like Systemd, Circus, or Supervisor.
             log_fn = None
         if log_fn:
             log_fn = os.path.join(base, log_fn)
-            setup_logging(log_fn)
+            setup_logging(log_fn, global_conf=vars)
 
         server = self.loadserver(server_spec, name=server_name,
                                  relative_to=base, global_conf=vars)

--- a/pyramid/tests/test_paster.py
+++ b/pyramid/tests/test_paster.py
@@ -105,17 +105,37 @@ class Test_get_appsettings(unittest.TestCase):
         self.assertEqual(result['foo'], 'baz')
 
 class Test_setup_logging(unittest.TestCase):
-    def _callFUT(self, config_file):
+    def _callFUT(self, config_file, global_conf=None):
         from pyramid.paster import setup_logging
         dummy_cp = DummyConfigParserModule
-        return setup_logging(config_file, self.fileConfig, dummy_cp)
+        return setup_logging(
+            config_uri=config_file,
+            global_conf=global_conf,
+            fileConfig=self.fileConfig,
+            configparser=dummy_cp,
+            )
 
-    def test_it(self):
+    def test_it_no_global_conf(self):
         config_file, dict = self._callFUT('/abc')
         # os.path.abspath is a sop to Windows
         self.assertEqual(config_file, os.path.abspath('/abc'))
         self.assertEqual(dict['__file__'], os.path.abspath('/abc'))
         self.assertEqual(dict['here'], os.path.abspath('/'))
+
+    def test_it_global_conf_empty(self):
+        config_file, dict = self._callFUT('/abc', global_conf={})
+        # os.path.abspath is a sop to Windows
+        self.assertEqual(config_file, os.path.abspath('/abc'))
+        self.assertEqual(dict['__file__'], os.path.abspath('/abc'))
+        self.assertEqual(dict['here'], os.path.abspath('/'))
+
+    def test_it_global_conf_not_empty(self):
+        config_file, dict = self._callFUT('/abc', global_conf={'key': 'val'})
+        # os.path.abspath is a sop to Windows
+        self.assertEqual(config_file, os.path.abspath('/abc'))
+        self.assertEqual(dict['__file__'], os.path.abspath('/abc'))
+        self.assertEqual(dict['here'], os.path.abspath('/'))
+        self.assertEqual(dict['key'], 'val')
 
     def fileConfig(self, config_file, dict):
         return config_file, dict


### PR DESCRIPTION
This allows one to set up a logging configuration that is parameterized based on variables specified on the command-line.

e.g.: the application .ini file could have:

```ini
[logger_root]
level = %(LOGGING_LOGGER_ROOT_LEVEL)s
handlers = console

[handler_console]
class = StreamHandler
args = (sys.stderr,)
level = %(LOGGING_HANDLER_CONSOLE_LEVEL)s
formatter = generic
```

This app could be launched with:

```
pserve development.ini LOGGING_LOGGER_ROOT_LEVEL=DEBUG LOGGING_HANDLER_CONSOLE_LEVEL=DEBUG
```

Cc: @mmerickel, @sontek, @sudarkoff, @sseg, @aconrad 