### PR TITLE
Extra colon in docs breaks code block highlighting.

### DIFF
--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -229,7 +229,7 @@ class ManifestCacheBuster(object):
 
     By default, it is a JSON-serialized dictionary where the keys are the
     source asset paths used in calls to
-    :meth:`~pyramid.request.Request.static_url`. For example::
+    :meth:`~pyramid.request.Request.static_url`. For example:
 
     .. code-block:: python
 


### PR DESCRIPTION
2cc0710ecf9b47e5a6f41caf6b1c56b29bab2db0