### PR TITLE
Do not use a set for accept dedup in MultiView.add

### DIFF
--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -568,9 +568,8 @@ class MultiView(object):
             else:
                 subset.append((order, view, phash))
                 subset.sort(key=operator.itemgetter(0))
-            accepts = set(self.accepts)
-            accepts.add(accept)
-            self.accepts = list(accepts) # dedupe
+            if accept not in self.accepts:
+                self.accepts.append(accept)
 
     def get_views(self, request):
         if self.accepts and hasattr(request, 'accept'):


### PR DESCRIPTION
Starting python3.3, string hash are randomised by default. Meaning the self.accept list order was random.

In case of a MultiView accepting multiple types, the first matching type of that list is used.

The result was that the method actually used was random based on the initial seed.

Example bellow. When using GET without an accept header (or */*), the method called was randomly get_json or get_text

```python
@view_defaults(route_name='example')
class ExampleView(object):
    def __init__(self, request):
        self.request = request

    @view_config(renderer='json', accept='application/json')
    def get_json(self):
        print('GET JSON')
        return 'json'

    @view_config(renderer='string', accept='text/plain')
    def get_text(self):
        print('GET TEXT')
        return 'text'
```