### PR TITLE
setup_logging: Intersphinx link to fileConfig

### DIFF
--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -55,8 +55,8 @@ def get_appsettings(config_uri, name=None, options=None, appconfig=appconfig):
 def setup_logging(config_uri, fileConfig=fileConfig,
                   configparser=configparser):
     """
-    Set up logging via the logging module's fileConfig function with the
-    filename specified via ``config_uri`` (a string in the form
+    Set up logging via :func:`logging.config.fileConfig` with the filename
+    specified via ``config_uri`` (a string in the form
     ``filename#sectionname``).
 
     ConfigParser defaults are specified for the special ``__file__``


### PR DESCRIPTION
So Sphinx docs have a clickable link to `logging.config.fileConfig`.

<img width="673" alt="screen shot 2016-04-06 at 11 11 26 am" src="https://cloud.githubusercontent.com/assets/305268/14327714/5abeee22-fbe8-11e5-954b-46ec100d5ff6.png">

Cc: @mmerickel, @stevepiercy 