### PR TITLE
setup_logging: global_conf => extra_global_conf

### DIFF
--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -69,15 +69,12 @@ def setup_logging(config_uri, global_conf=None,
     parser.read([path])
     if parser.has_section('loggers'):
         config_file = os.path.abspath(path)
-        if global_conf:
-            # Copy to avoid side effects
-            global_conf = dict(global_conf)
-        else:
-            global_conf = {}
-        global_conf.update(
+        full_global_conf = dict(
             __file__=config_file,
             here=os.path.dirname(config_file))
-        return fileConfig(config_file, global_conf)
+        if global_conf:
+            full_global_conf.update(global_conf)
+        return fileConfig(config_file, full_global_conf)
 
 def _getpathsec(config_uri, name):
     if '#' in config_uri:


### PR DESCRIPTION
In `setup_logging` function, rename the argument `global_conf` to `extra_global_conf`.

This lets us have a somewhat simpler and nicer implementation than what I had in https://github.com/Pylons/pyramid/pull/2399.

Cc: @mmerickel 