### PR TITLE
setup_logging: Read logging_defaults section

### DIFF
--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -72,8 +72,10 @@ def setup_logging(config_uri, global_conf=None,
         full_global_conf = dict(
             __file__=config_file,
             here=os.path.dirname(config_file))
+        full_global_conf.update(parser.items('logging_defaults'))
         if global_conf:
-            full_global_conf.update(global_conf)
+            for key, val in global_conf.items():
+                full_global_conf[key.lower()] = val
         return fileConfig(config_file, full_global_conf)
 
 def _getpathsec(config_uri, name):

--- a/pyramid/tests/test_paster.py
+++ b/pyramid/tests/test_paster.py
@@ -222,5 +222,8 @@ class DummyConfigParser(object):
     def has_section(self, name):
         return True
 
+    def items(self, section):
+        return {}
+
 class DummyConfigParserModule(object):
     ConfigParser = DummyConfigParser


### PR DESCRIPTION
This allows one to have an ini file that specifies defaults that one can override from the command line.

E.g.:

```ini
# app.ini

[logging_defaults]
logging_logger_root_level = WARN
...
[logger_root]
level = %(logging_logger_root_level)s
handlers = console
```

Invoked normally, the defaults get used and logging level defaults to `WARN`:

```
$ pserve app.ini
2016-04-06 14:19:58,895 WARNI [fakeproject:28][MainThread] warn msg
2016-04-06 14:19:58,895 ERROR [fakeproject:29][MainThread] error msg
root_logger.level = 30; logging.WARN = 30; logging.DEBUG = 10
Starting server in PID 92994.
serving on http://127.0.0.1:6543
```

Invoked with command line args, the defaults can be overidden, so that the logging level is `DEBUG`:

```
$ pserve app.ini logging_logger_root_level=DEBUG
2016-04-06 14:21:40,111 DEBUG [fakeproject:26][MainThread] debug msg
2016-04-06 14:21:40,111 INFO  [fakeproject:27][MainThread] info msg
2016-04-06 14:21:40,111 WARNI [fakeproject:28][MainThread] warn msg
2016-04-06 14:21:40,112 ERROR [fakeproject:29][MainThread] error msg
root_logger.level = 10; logging.WARN = 30; logging.DEBUG = 10
Starting server in PID 93159.
serving on http://127.0.0.1:6543
```

Note that the configparser module in Python has a built-in concept of a
`[DEFAULT]` section, but it acts more like an override; values in that
section take precedence over values specified in the `ConfigParser`
constructor. This makes it not so useful and that's why I created a new
`[logging_defaults]` section instead of using the existing `[DEFAULT]`
mechanism.

This would need more documentation to explain how it works, but I'm going to hold off on that and see if folks even think it's a good idea first.