### PR TITLE
Remove: py26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 
 matrix:
     include:
-        - python: 2.6
-          env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27
         - python: 3.3

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,9 @@
 unreleased
 ==========
 
+- Python 2.6 is no longer supported by Pyramid. See
+  https://github.com/Pylons/pyramid/issues/2368
+
 - A complete overhaul of the docs:
 
   - Use pip instead of easy_install.

--- a/docs/narr/install.rst
+++ b/docs/narr/install.rst
@@ -21,9 +21,9 @@ the following sections.
 
 .. sidebar:: Python Versions
 
-    As of this writing, :app:`Pyramid` has been tested under Python 2.6, Python
-    2.7, Python 3.3, Python 3.4, Python 3.5, PyPy, and PyPy3. :app:`Pyramid`
-    does not run under any version of Python before 2.6.
+    As of this writing, :app:`Pyramid` has been tested under Python 2.7,
+    Python 3.3, Python 3.4, Python 3.5, PyPy, and PyPy3. :app:`Pyramid` does
+    not run under any version of Python before 2.7.
 
 :app:`Pyramid` is known to run on all popular UNIX-like systems such as Linux,
 Mac OS X, and FreeBSD, as well as on Windows platforms.  It is also known to

--- a/docs/narr/introduction.rst
+++ b/docs/narr/introduction.rst
@@ -859,14 +859,15 @@ Testing
 Every release of Pyramid has 100% statement coverage via unit and integration
 tests, as measured by the ``coverage`` tool available on PyPI.  It also has
 greater than 95% decision/condition coverage as measured by the
-``instrumental`` tool available on PyPI.  It is automatically tested by the
-Jenkins tool on Python 2.6, Python 2.7, Python 3.3, Python 3.4, Python 3.5,
-PyPy, and PyPy3 after each commit to its GitHub repository. Official Pyramid
-add-ons are held to a similar testing standard.  We still find bugs in Pyramid
-and its official add-ons, but we've noticed we find a lot more of them while
-working on other projects that don't have a good testing regime.
+``instrumental`` tool available on PyPI. It is automatically tested by Travis,
+and Jenkins on Python 2.7, Python 3.3, Python 3.4, Python 3.5, PyPy, and PyPy3
+after each commit to its GitHub repository. Official Pyramid add-ons are held
+to a similar testing standard.  We still find bugs in Pyramid and its official
+add-ons, but we've noticed we find a lot more of them while working on other
+projects that don't have a good testing regime.
 
-Example: http://jenkins.pylonsproject.org/
+Travis: https://travis-ci.org/Pylons/pyramid
+Jenkins: http://jenkins.pylonsproject.org/job/pyramid/
 
 Support
 ~~~~~~~

--- a/docs/narr/upgrading.rst
+++ b/docs/narr/upgrading.rst
@@ -127,8 +127,6 @@ you can see DeprecationWarnings printed to the console when the tests run.
    $ python -Wd setup.py test -q
 
 The ``-Wd`` argument tells Python to print deprecation warnings to the console.
-Note that the ``-Wd`` flag is only required for Python 2.7 and better: Python
-versions 2.6 and older print deprecation warnings to the console by default.
 See `the Python -W flag documentation
 <http://docs.python.org/using/cmdline.html#cmdoption-W>`_ for more information.
 

--- a/docs/tutorials/modwsgi/index.rst
+++ b/docs/tutorials/modwsgi/index.rst
@@ -101,7 +101,7 @@ specific path information for commands and files.
        WSGIApplicationGroup %{GLOBAL}
        WSGIPassAuthorization On
        WSGIDaemonProcess pyramid user=chrism group=staff threads=4 \
-          python-path=/Users/chrism/modwsgi/env/lib/python2.6/site-packages
+          python-path=/Users/chrism/modwsgi/env/lib/python2.7/site-packages
        WSGIScriptAlias /myapp /Users/chrism/modwsgi/env/pyramid.wsgi
 
        <Directory /Users/chrism/modwsgi/env>

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ if PY3:
     if py_version < (3, 3) and not is_pypy: # PyPy3 masquerades as Python 3.2...
         raise RuntimeError('On Python 3, Pyramid requires Python 3.3 or better')
 else:
-    if py_version < (2, 7):
-        raise RuntimeError('On Python 2, Pyramid requires Python 2.7 or better')
+    if py_version < (2, 6):
+        raise RuntimeError('On Python 2, Pyramid requires Python 2.6 or better')
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ if PY3:
     if py_version < (3, 3) and not is_pypy: # PyPy3 masquerades as Python 3.2...
         raise RuntimeError('On Python 3, Pyramid requires Python 3.3 or better')
 else:
-    if py_version < (2, 6):
-        raise RuntimeError('On Python 2, Pyramid requires Python 2.6 or better')
+    if py_version < (2, 7):
+        raise RuntimeError('On Python 2, Pyramid requires Python 2.7 or better')
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:
@@ -38,7 +38,7 @@ try:
 except IOError:
     README = CHANGES = ''
 
-install_requires=[
+install_requires = [
     'setuptools',
     'WebOb >= 1.3.1', # request.domain and CookieProfile
     'repoze.lru >= 0.4', # py3 compat
@@ -74,24 +74,23 @@ testing_extras = tests_require + [
 setup(name='pyramid',
       version='1.7.dev0',
       description='The Pyramid Web Framework, a Pylons project',
-      long_description=README + '\n\n' +  CHANGES,
+      long_description=README + '\n\n' + CHANGES,
       classifiers=[
-        "Development Status :: 6 - Mature",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Framework :: Pyramid",
-        "Topic :: Internet :: WWW/HTTP",
-        "Topic :: Internet :: WWW/HTTP :: WSGI",
-        "License :: Repoze Public License",
-        ],
+          "Development Status :: 6 - Mature",
+          "Intended Audience :: Developers",
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.3",
+          "Programming Language :: Python :: 3.4",
+          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: Implementation :: CPython",
+          "Programming Language :: Python :: Implementation :: PyPy",
+          "Framework :: Pyramid",
+          "Topic :: Internet :: WWW/HTTP",
+          "Topic :: Internet :: WWW/HTTP :: WSGI",
+          "License :: Repoze Public License",
+      ],
       keywords='web wsgi pylons pyramid',
       author="Chris McDonough, Agendaless Consulting",
       author_email="pylons-discuss@googlegroups.com",
@@ -100,14 +99,14 @@ setup(name='pyramid',
       packages=find_packages(),
       include_package_data=True,
       zip_safe=False,
-      install_requires = install_requires,
-      extras_require = {
-          'testing':testing_extras,
-          'docs':docs_extras,
+      install_requires=install_requires,
+      extras_require={
+          'testing': testing_extras,
+          'docs': docs_extras,
           },
-      tests_require = tests_require,
+      tests_require=tests_require,
       test_suite="pyramid.tests",
-      entry_points = """\
+      entry_points="""\
         [pyramid.scaffold]
         starter=pyramid.scaffolds:StarterProjectTemplate
         zodb=pyramid.scaffolds:ZODBProjectTemplate
@@ -128,4 +127,3 @@ setup(name='pyramid',
         cherrypy = pyramid.scripts.pserve:cherrypy_server_runner
       """
       )
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py26,py27,py33,py34,py35,pypy,pypy3,
+    py27,py33,py34,py35,pypy,pypy3,
     docs,pep8,
     {py2,py3}-cover,coverage,
 
@@ -8,7 +8,6 @@ envlist =
 # Most of these are defaults but if you specify any you can't fall back
 # to defaults for others.
 basepython =
-    py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4
@@ -22,14 +21,8 @@ commands =
     pip install pyramid[testing]
     nosetests --with-xunit --xunit-file=nosetests-{envname}.xml {posargs:}
 
-[testenv:py26-scaffolds]
-basepython = python2.6
-commands =
-    python pyramid/scaffolds/tests.py
-deps = virtualenv
-
 [testenv:py27-scaffolds]
-basepython = python2.6
+basepython = python2.7
 commands =
     python pyramid/scaffolds/tests.py
 deps = virtualenv


### PR DESCRIPTION
In accordance with this: https://github.com/Pylons/pyramid/issues/2368

Here's a PR that removes Python 2.6 support. If we want to drop Python 3.3 support I can modify this PR as necessary.