### PR TITLE
Issue #2493: Fixing Quick Tutorial Step 18 - CSS/JS Paths

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -264,3 +264,5 @@ Contributors
 - Sri Sanketh Uppalapati, 2015/12/12
 
 - Marcin Raczyński, 2016/01/26
+
+- Arian Maykon de A. Diógenes, 2016/04/13

--- a/docs/quick_tutorial/databases/tutorial/wikipage_addedit.pt
+++ b/docs/quick_tutorial/databases/tutorial/wikipage_addedit.pt
@@ -4,12 +4,10 @@
     <title>WikiPage: Add/Edit</title>
     <tal:block tal:repeat="reqt view.reqts['css']">
         <link rel="stylesheet" type="text/css"
-                href="${request.static_url(reqt)}">
+              href="${request.static_url('deform:static/' + reqt)}"/>
     </tal:block>
-    <script type="text/javascript"
-          src="${request.static_url('deform:static/scripts/jquery-2.0.3.min.js')}"></script>
     <tal:block tal:repeat="reqt view.reqts['js']">
-        <script src="${request.static_url(reqt)}"
+        <script src="${request.static_url('deform:static/' + reqt)}"
                 type="text/javascript"></script>
     </tal:block>
 </head>

--- a/docs/quick_tutorial/forms/tutorial/wikipage_addedit.pt
+++ b/docs/quick_tutorial/forms/tutorial/wikipage_addedit.pt
@@ -4,12 +4,10 @@
     <title>WikiPage: Add/Edit</title>
     <tal:block tal:repeat="reqt view.reqts['css']">
         <link rel="stylesheet" type="text/css"
-              href="${request.static_url(reqt)}"/>
+              href="${request.static_url('deform:static/' + reqt)}"/>
     </tal:block>
-    <script src="${request.static_url('deform:static/scripts/jquery-2.0.3.min.js')}"
-        type="text/javascript"></script>
     <tal:block tal:repeat="reqt view.reqts['js']">
-        <script src="${request.static_url(reqt)}"
+        <script src="${request.static_url('deform:static/' + reqt)}"
                 type="text/javascript"></script>
     </tal:block>
 </head>


### PR DESCRIPTION
Fixed CSS and JS paths, and removed JQuery (already included by Deform).