### PR TITLE
request.host_port is a str not an int

### DIFF
--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -182,7 +182,7 @@ def check_csrf_origin(request, trusted_origins=None, raises=True):
                     "pyramid.csrf_trusted_origins", [])
             )
 
-        if request.host_port not in set([80, 443]):
+        if request.host_port not in set(["80", "443"]):
             trusted_origins.append("{0.domain}:{0.host_port}".format(request))
         else:
             trusted_origins.append(request.domain)

--- a/pyramid/tests/test_session.py
+++ b/pyramid/tests/test_session.py
@@ -721,7 +721,7 @@ class Test_check_csrf_origin(unittest.TestCase):
         request = testing.DummyRequest()
         request.scheme = "https"
         request.host = "example.com"
-        request.host_port = 443
+        request.host_port = "443"
         request.referrer = "https://example.com/login/"
         request.registry.settings = {}
         self.assertTrue(self._callFUT(request))
@@ -730,7 +730,7 @@ class Test_check_csrf_origin(unittest.TestCase):
         request = testing.DummyRequest()
         request.scheme = "https"
         request.host = "example.com"
-        request.host_port = 443
+        request.host_port = "443"
         request.headers = {"Origin": "https://example.com/"}
         request.referrer = "https://not-example.com/"
         request.registry.settings = {}
@@ -740,7 +740,7 @@ class Test_check_csrf_origin(unittest.TestCase):
         request = testing.DummyRequest()
         request.scheme = "https"
         request.host = "example.com"
-        request.host_port = 443
+        request.host_port = "443"
         request.referrer = "https://not-example.com/login/"
         request.registry.settings = {
             "pyramid.csrf_trusted_origins": ["not-example.com"],
@@ -751,7 +751,7 @@ class Test_check_csrf_origin(unittest.TestCase):
         request = testing.DummyRequest()
         request.scheme = "https"
         request.host = "example.com:8080"
-        request.host_port = 8080
+        request.host_port = "8080"
         request.referrer = "https://example.com:8080/login/"
         request.registry.settings = {}
         self.assertTrue(self._callFUT(request))
@@ -761,7 +761,7 @@ class Test_check_csrf_origin(unittest.TestCase):
         request = testing.DummyRequest()
         request.scheme = "https"
         request.host = "example.com"
-        request.host_port = 443
+        request.host_port = "443"
         request.referrer = "https://not-example.com/login/"
         request.registry.settings = {}
         self.assertRaises(BadCSRFOrigin, self._callFUT, request)
@@ -780,7 +780,7 @@ class Test_check_csrf_origin(unittest.TestCase):
         request = testing.DummyRequest()
         request.scheme = "https"
         request.host = "example.com"
-        request.host_port = 443
+        request.host_port = "443"
         request.referrer = "http://example.com/evil/"
         request.registry.settings = {}
         self.assertRaises(BadCSRFOrigin, self._callFUT, request)
@@ -791,7 +791,7 @@ class Test_check_csrf_origin(unittest.TestCase):
         request = testing.DummyRequest()
         request.scheme = "https"
         request.host = "example.com:8080"
-        request.host_port = 8080
+        request.host_port = "8080"
         request.referrer = "https://example.com/login/"
         request.registry.settings = {}
         self.assertRaises(BadCSRFOrigin, self._callFUT, request)

--- a/pyramid/tests/test_viewderivers.py
+++ b/pyramid/tests/test_viewderivers.py
@@ -1148,7 +1148,7 @@ class TestDeriveView(unittest.TestCase):
         request = self._makeRequest()
         request.scheme = "https"
         request.domain = "example.com"
-        request.host_port = 443
+        request.host_port = "443"
         request.referrer = "https://example.com/login/"
         request.method = 'POST'
         request.session = DummySession({'csrf_token': 'foo'})
@@ -1208,7 +1208,7 @@ class TestDeriveView(unittest.TestCase):
         request = self._makeRequest()
         request.method = "POST"
         request.scheme = "https"
-        request.host_port = 443
+        request.host_port = "443"
         request.domain = "example.com"
         request.referrer = "https://not-example.com/evil/"
         request.registry.settings = {}
@@ -1221,7 +1221,7 @@ class TestDeriveView(unittest.TestCase):
         request = self._makeRequest()
         request.method = "POST"
         request.scheme = "https"
-        request.host_port = 443
+        request.host_port = "443"
         request.domain = "example.com"
         request.headers = {"Origin": "https://not-example.com/evil/"}
         request.registry.settings = {}


### PR DESCRIPTION
This fixes a logic error in #2501 where I accidentally treated ``request.host_port`` as an ``int`` when in reality it is a ``str``. This wasn't exposed in my own testing because I was only using non-standard ports so I expected this to evaluate to ``False`` anyways.