### PR TITLE
Don't fail CSRF check with subdomains

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -266,3 +266,5 @@ Contributors
 - Marcin Raczyński, 2016/01/26
 
 - Arian Maykon de A. Diógenes, 2016/04/13
+
+- Dustin Ingram, 2016/04/18

--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -182,10 +182,7 @@ def check_csrf_origin(request, trusted_origins=None, raises=True):
                     "pyramid.csrf_trusted_origins", [])
             )
 
-        if request.host_port not in set(["80", "443"]):
-            trusted_origins.append("{0.domain}:{0.host_port}".format(request))
-        else:
-            trusted_origins.append(request.domain)
+        trusted_origins.append(request.host)
 
         # Actually check to see if the request's origin matches any of our
         # trusted origins.

--- a/pyramid/tests/test_session.py
+++ b/pyramid/tests/test_session.py
@@ -756,6 +756,15 @@ class Test_check_csrf_origin(unittest.TestCase):
         request.registry.settings = {}
         self.assertTrue(self._callFUT(request))
 
+    def test_success_with_subdomain(self):
+        request = testing.DummyRequest()
+        request.scheme = "https"
+        request.host = "sub.example.com"
+        request.host_port = "443"
+        request.referrer = "https://sub.example.com/"
+        request.registry.settings = {}
+        self.assertTrue(self._callFUT(request))
+
     def test_fails_with_wrong_host(self):
         from pyramid.exceptions import BadCSRFOrigin
         request = testing.DummyRequest()

--- a/pyramid/tests/test_viewderivers.py
+++ b/pyramid/tests/test_viewderivers.py
@@ -1147,7 +1147,7 @@ class TestDeriveView(unittest.TestCase):
             return response
         request = self._makeRequest()
         request.scheme = "https"
-        request.domain = "example.com"
+        request.host = "example.com"
         request.host_port = "443"
         request.referrer = "https://example.com/login/"
         request.method = 'POST'
@@ -1209,7 +1209,7 @@ class TestDeriveView(unittest.TestCase):
         request.method = "POST"
         request.scheme = "https"
         request.host_port = "443"
-        request.domain = "example.com"
+        request.host = "example.com"
         request.referrer = "https://not-example.com/evil/"
         request.registry.settings = {}
         view = self.config._derive_view(inner_view, require_csrf='DUMMY')
@@ -1222,7 +1222,7 @@ class TestDeriveView(unittest.TestCase):
         request.method = "POST"
         request.scheme = "https"
         request.host_port = "443"
-        request.domain = "example.com"
+        request.host = "example.com"
         request.headers = {"Origin": "https://not-example.com/evil/"}
         request.registry.settings = {}
         view = self.config._derive_view(inner_view, require_csrf='DUMMY')


### PR DESCRIPTION
This fixes a bug introduced in #2501 which fails the CSRF origin check due to incorrectly using `request.domain` instead of `request.host`.