### PR TITLE
password_hash is unicode, needs to be encoded

### DIFF
--- a/docs/tutorials/wiki2/src/authentication/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash
+            expected_hash = self.password_hash.encode('utf8')
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False

--- a/docs/tutorials/wiki2/src/models/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/models/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash
+            expected_hash = self.password_hash.encode('utf8')
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False

--- a/docs/tutorials/wiki2/src/tests/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash
+            expected_hash = self.password_hash.encode('utf8')
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False

--- a/docs/tutorials/wiki2/src/views/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash
+            expected_hash = self.password_hash.encode('utf8')
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False


### PR DESCRIPTION
I think SQLAlchemy must have changed its behavior. Maybe someone could confirm this is an issue but it was failing for me while trying to reproduce https://github.com/Pylons/pyramid_debugtoolbar/issues/261