### PR TITLE
Change column `Page.data` to `Text` in wiki2 tutorial

### DIFF
--- a/docs/tutorials/wiki2/src/authentication/tutorial/models/page.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/models/page.py
@@ -14,7 +14,7 @@ class Page(Base):
     __tablename__ = 'pages'
     id = Column(Integer, primary_key=True)
     name = Column(Text, nullable=False, unique=True)
-    data = Column(Integer, nullable=False)
+    data = Column(Text, nullable=False)
 
     creator_id = Column(ForeignKey('users.id'), nullable=False)
     creator = relationship('User', backref='created_pages')

--- a/docs/tutorials/wiki2/src/authorization/tutorial/models/page.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/models/page.py
@@ -14,7 +14,7 @@ class Page(Base):
     __tablename__ = 'pages'
     id = Column(Integer, primary_key=True)
     name = Column(Text, nullable=False, unique=True)
-    data = Column(Integer, nullable=False)
+    data = Column(Text, nullable=False)
 
     creator_id = Column(ForeignKey('users.id'), nullable=False)
     creator = relationship('User', backref='created_pages')

--- a/docs/tutorials/wiki2/src/models/tutorial/models/page.py
+++ b/docs/tutorials/wiki2/src/models/tutorial/models/page.py
@@ -14,7 +14,7 @@ class Page(Base):
     __tablename__ = 'pages'
     id = Column(Integer, primary_key=True)
     name = Column(Text, nullable=False, unique=True)
-    data = Column(Integer, nullable=False)
+    data = Column(Text, nullable=False)
 
     creator_id = Column(ForeignKey('users.id'), nullable=False)
     creator = relationship('User', backref='created_pages')

--- a/docs/tutorials/wiki2/src/tests/tutorial/models/page.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/models/page.py
@@ -14,7 +14,7 @@ class Page(Base):
     __tablename__ = 'pages'
     id = Column(Integer, primary_key=True)
     name = Column(Text, nullable=False, unique=True)
-    data = Column(Integer, nullable=False)
+    data = Column(Text, nullable=False)
 
     creator_id = Column(ForeignKey('users.id'), nullable=False)
     creator = relationship('User', backref='created_pages')

--- a/docs/tutorials/wiki2/src/views/tutorial/models/page.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/models/page.py
@@ -14,7 +14,7 @@ class Page(Base):
     __tablename__ = 'pages'
     id = Column(Integer, primary_key=True)
     name = Column(Text, nullable=False, unique=True)
-    data = Column(Integer, nullable=False)
+    data = Column(Text, nullable=False)
 
     creator_id = Column(ForeignKey('users.id'), nullable=False)
     creator = relationship('User', backref='created_pages')


### PR DESCRIPTION
Column `data` in `Page` class is `Integer` but should be `Text` in wiki2 tutorial.