### PR TITLE
Update user.py to prevent attribute error in check_password function

### DIFF
--- a/docs/tutorials/wiki2/src/models/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/models/tutorial/models/user.py
@@ -23,7 +23,7 @@ class User(Base):
 
     def check_password(self, pw):
         if self.password_hash is not None:
-            expected_hash = self.password_hash.encode('utf8')
+            expected_hash = self.password_hash
             actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
             return expected_hash == actual_hash
         return False


### PR DESCRIPTION
The original file is throwing Attribute Error in check_password function with python 3 interpreter. (didn't check with python 2)
password_hash is of type bytes, bytes object doesn't have attribute encode.
The error is evaded by removing the encoding function.