### PR TITLE
Avoid silent dismissal of __acl__ AttributeErrors

### DIFF
--- a/pyramid/authorization.py
+++ b/pyramid/authorization.py
@@ -75,12 +75,12 @@ class ACLAuthorizationPolicy(object):
         acl = '<No ACL found on any object in resource lineage>'
 
         for location in lineage(context):
-            try:
-                acl = location.__acl__
-            except AttributeError:
+            if not hasattr(location, '__acl__'):
                 continue
+            
+            acl = location.__acl__
 
-            if acl and callable(acl):
+            if callable(acl):
                 acl = acl()
 
             for ace in acl:
@@ -114,15 +114,15 @@ class ACLAuthorizationPolicy(object):
 
         for location in reversed(list(lineage(context))):
             # NB: we're walking *up* the object graph from the root
-            try:
-                acl = location.__acl__
-            except AttributeError:
+            if not hasattr(location, '__acl__'):
                 continue
+            
+            acl = location.__acl__
 
             allowed_here = set()
             denied_here = set()
 
-            if acl and callable(acl):
+            if callable(acl):
                 acl = acl()
 
             for ace_action, ace_principal, ace_permissions in acl:


### PR DESCRIPTION
With current code, an AttributeError raised in an __acl__ property will be silently dismissed, making code debug harder: what looks like a permission problem can actually be a bug. Instead, here we check if the location has the __acl__ attribute, and if not we keep looking.

I have run the test suite for this modification and it passed but I'd be happy to write whatever checks seem necessary to make this change acceptable as I think this part of the Pyramid code can lead to costly debug sessions :)