### PR TITLE
Add route name to view deriver options. Closes: #2609

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -270,3 +270,5 @@ Contributors
 - Vincent Férotin, 2016/05/08
 
 - Berker Peksag, 2016/05/16
+
+- Marco Martinez, 2016/06/02

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -885,6 +885,7 @@ class ViewsConfiguratorMixin(object):
             # __no_permission_required__ handled by _secure_view
             derived_view = self._derive_view(
                 view,
+                route_name=route_name,
                 permission=permission,
                 predicates=preds,
                 attr=attr,
@@ -1331,7 +1332,7 @@ class ViewsConfiguratorMixin(object):
     def _derive_view(self, view, permission=None, predicates=(),
                      attr=None, renderer=None, wrapper_viewname=None,
                      viewname=None, accept=None, order=MAX_ORDER,
-                     phash=DEFAULT_PHASH, decorator=None,
+                     phash=DEFAULT_PHASH, decorator=None, route_name=None,
                      mapper=None, http_cache=None, context=None,
                      require_csrf=None, extra_options=None):
         view = self.maybe_dotted(view)
@@ -1361,6 +1362,7 @@ class ViewsConfiguratorMixin(object):
             decorator=decorator,
             http_cache=http_cache,
             require_csrf=require_csrf,
+            route_name=route_name
         )
         if extra_options:
             options.update(extra_options)


### PR DESCRIPTION
Passed `route_name` to `_derive_view` method so that it can be added to the `DerivedViewInfo` options.