### PR TITLE
Adding a warning discouraging use of __acl__ properties attributes

### DIFF
--- a/docs/narr/security.rst
+++ b/docs/narr/security.rst
@@ -290,6 +290,13 @@ properties of the instance.
        def __init__(self, owner):
            self.owner = owner
 
+.. warning::
+
+   Writing ``__acl__`` as properties is discouraged, as AttributeErrors
+   occuring in ``fget`` or ``fset`` will be silently dismissed (this is consistent
+   with Python ``getattr`` and ``hasattr`` behaviors). For dynamic ACLs, simply use
+   callables, as documented above.
+
 .. index::
    single: ACE
    single: access control entry


### PR DESCRIPTION
As discussed in #2613, it might not be possible or easy to fix silent dismissal of AttributeErrors in the authorization.py code dealing with `__acl__` properties, so instead I'm proposing this warning, in the documentation file explaining ACLs.