### PR TITLE
Fix flake8's noqa directive in documentation and scaffolds

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -276,3 +276,5 @@ Contributors
 - Marco Martinez, 2016/06/02
 
 - Cris Ewing, 2016/06/03
+
+- Jean-Christophe Bohin, 2016/06/13

--- a/docs/quick_tour/sqla_demo/sqla_demo/models/__init__.py
+++ b/docs/quick_tour/sqla_demo/sqla_demo/models/__init__.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import configure_mappers
 # import all models classes here for sqlalchemy mappers
 # to pick up
-from .mymodel import MyModel # flake8: noqa
+from .mymodel import MyModel  # noqa
 
 # run configure mappers to ensure we avoid any race conditions
 configure_mappers()

--- a/docs/tutorials/wiki2/src/authentication/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/models/__init__.py
@@ -5,8 +5,8 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .page import Page # flake8: noqa
-from .user import User # flake8: noqa
+from .page import Page  # noqa
+from .user import User  # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/docs/tutorials/wiki2/src/authorization/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/models/__init__.py
@@ -5,8 +5,8 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .page import Page # flake8: noqa
-from .user import User # flake8: noqa
+from .page import Page  # noqa
+from .user import User  # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/docs/tutorials/wiki2/src/basiclayout/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/basiclayout/tutorial/models/__init__.py
@@ -5,7 +5,7 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .mymodel import MyModel # flake8: noqa
+from .mymodel import MyModel  # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/docs/tutorials/wiki2/src/installation/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/installation/tutorial/models/__init__.py
@@ -5,7 +5,7 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .mymodel import MyModel # flake8: noqa
+from .mymodel import MyModel  # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/docs/tutorials/wiki2/src/models/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/models/tutorial/models/__init__.py
@@ -5,8 +5,8 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .page import Page # flake8: noqa
-from .user import User # flake8: noqa
+from .page import Page  # noqa
+from .user import User  # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/docs/tutorials/wiki2/src/tests/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/models/__init__.py
@@ -5,8 +5,8 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .page import Page # flake8: noqa
-from .user import User # flake8: noqa
+from .page import Page # noqa
+from .user import User # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/docs/tutorials/wiki2/src/tests/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/models/__init__.py
@@ -5,8 +5,8 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .page import Page # noqa
-from .user import User # noqa
+from .page import Page  # noqa
+from .user import User  # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/docs/tutorials/wiki2/src/views/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/models/__init__.py
@@ -5,8 +5,8 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .page import Page # flake8: noqa
-from .user import User # flake8: noqa
+from .page import Page # noqa
+from .user import User # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/docs/tutorials/wiki2/src/views/tutorial/models/__init__.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/models/__init__.py
@@ -5,8 +5,8 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .page import Page # noqa
-from .user import User # noqa
+from .page import Page  # noqa
+from .user import User  # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup

--- a/pyramid/scaffolds/alchemy/+package+/models/__init__.py_tmpl
+++ b/pyramid/scaffolds/alchemy/+package+/models/__init__.py_tmpl
@@ -5,7 +5,7 @@ import zope.sqlalchemy
 
 # import or define all models here to ensure they are attached to the
 # Base.metadata prior to any initialization routines
-from .mymodel import MyModel # flake8: noqa
+from .mymodel import MyModel  # noqa
 
 # run configure_mappers after defining all of the models to ensure
 # all relationships can be setup


### PR DESCRIPTION
They are a [few (9 as of today)](https://github.com/Pylons/pyramid/search?utf8=✓&q=%22flake8%3A+noqa%22&type=Code) occurrences of the following snippet in docs and scaffolds:

```python
from .a import b  # flake8: noqa
```
*(replace `from .a import b` with any line of code)*

As mentioned in [Flake8 documentation](http://flake8.pycqa.org/en/stable/):

> files that contain this line are skipped:
> `# flake8: noqa`
> lines that contain a `# noqa` comment at the end will not issue warnings.

So the example above should be written
```python
from .a import b  # noqa
```
to only ignore the line instead of the whole file.