### PR TITLE
Exception-only option when registering views

### DIFF
--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -1639,7 +1639,8 @@ the user-defined :term:`view callable`:
   Enforce the ``permission`` defined on the view. This element is a no-op if no
   permission is defined. Note there will always be a permission defined if a
   default permission was assigned via
-  :meth:`pyramid.config.Configurator.set_default_permission`.
+  :meth:`pyramid.config.Configurator.set_default_permission` unless the
+  view is an :term:`exception view`.
 
   This element will also output useful debugging information when
   ``pyramid.debug_authorization`` is enabled.
@@ -1649,7 +1650,8 @@ the user-defined :term:`view callable`:
   Used to check the CSRF token provided in the request. This element is a
   no-op if ``require_csrf`` view option is not ``True``. Note there will
   always be a ``require_csrf`` option if a default value was assigned via
-  :meth:`pyramid.config.Configurator.set_default_csrf_options`.
+  :meth:`pyramid.config.Configurator.set_default_csrf_options` unless
+  the view is an :term:`exception view`.
 
 ``owrapped_view``
 
@@ -1695,6 +1697,8 @@ around monitoring and security. In order to register a custom :term:`view
 deriver`, you should create a callable that conforms to the
 :class:`pyramid.interfaces.IViewDeriver` interface, and then register it with
 your application using :meth:`pyramid.config.Configurator.add_view_deriver`.
+The callable should accept the ``view`` to be wrapped and the ``info`` object
+which is an instance of :class:`pyramid.interfaces.IViewDeriverInfo`.
 For example, below is a callable that can provide timing information for the
 view pipeline:
 
@@ -1744,6 +1748,21 @@ But this view *will* have timing information added to the response headers:
 View derivers are unique in that they have access to most of the options
 passed to :meth:`pyramid.config.Configurator.add_view` in order to decide what
 to do, and they have a chance to affect every view in the application.
+
+.. _exception_view_derivers:
+
+Exception Views and View Derivers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A :term:`view deriver` has the opportunity to wrap any view, including
+an :term:`exception view`. In general this is fine, but certain view derivers
+may wish to avoid doing certain things when handling exceptions. For example,
+the ``csrf_view`` and ``secured_view`` built-in view derivers will not perform
+security checks on exception views unless explicitly told to do so.
+
+You can check for ``info.exception_only`` on the
+:class:`pyramid.interfaces.IViewDeriverInfo` object when wrapping the view
+to determine whether you are wrapping an exception view or a normal view.
 
 Ordering View Derivers
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/narr/viewconfig.rst
+++ b/docs/narr/viewconfig.rst
@@ -34,7 +34,7 @@ determine the set of circumstances which must be true for the view callable to
 be invoked.
 
 A view configuration statement is made about information present in the
-:term:`context` resource and the :term:`request`.
+:term:`context` resource (or exception) and the :term:`request`.
 
 View configuration is performed in one of two ways:
 
@@ -306,8 +306,25 @@ configured view.
   represented class or if the :term:`context` resource provides the represented
   interface; it is otherwise false.
 
+  It is possible to pass an exception class as the context if your context may
+  subclass an exception. In this case **two** views will be registered. One
+  will match normal incoming requests and the other will match as an
+  :term:`exception view` which only occurs when an exception is raised during
+  the normal request processing pipeline.
+
   If ``context`` is not supplied, the value ``None``, which matches any
   resource, is used.
+
+``exception_only``
+
+  When this value is ``True`` the ``context`` argument must be a subclass of
+  ``Exception``. This flag indicates that only an :term:`exception view` should
+  be created and that this view should not match if the traversal
+  :term:`context` matches the ``context`` argument. If the ``context`` is a
+  subclass of ``Exception`` and this value is ``False`` (the default) then a
+  view will be registered to match the traversal :term:`context` as well.
+
+  .. versionadded:: 1.8
 
 ``route_name``
   If ``route_name`` is supplied, the view callable will be invoked only when

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -1613,6 +1613,71 @@ class ViewsConfiguratorMixin(object):
 
     set_notfound_view = add_notfound_view # deprecated sorta-bw-compat alias
 
+    @viewdefaults
+    @action_method
+    def add_exception_view(
+        self,
+        view=None,
+        context=None,
+        attr=None,
+        renderer=None,
+        wrapper=None,
+        route_name=None,
+        request_type=None,
+        request_method=None,
+        request_param=None,
+        containment=None,
+        xhr=None,
+        accept=None,
+        header=None,
+        path_info=None,
+        custom_predicates=(),
+        decorator=None,
+        mapper=None,
+        match_param=None,
+        **view_options
+            ):
+        """ Add a view for an exception to the current configuration state.
+        The view will be called when Pyramid or application code raises an
+        the given exception.
+
+        .. versionadded:: 1.8
+        """
+        for arg in (
+            'name', 'permission', 'for_', 'http_cache',
+            'require_csrf', 'exception_only',
+        ):
+            if arg in view_options:
+                raise ConfigurationError(
+                    '%s may not be used as an argument to add_exception_view'
+                    % arg
+                    )
+        if context is None:
+            raise ConfigurationError('context exception must be specified')
+        settings = dict(
+            view=view,
+            context=context,
+            wrapper=wrapper,
+            renderer=renderer,
+            request_type=request_type,
+            request_method=request_method,
+            request_param=request_param,
+            containment=containment,
+            xhr=xhr,
+            accept=accept,
+            header=header,
+            path_info=path_info,
+            custom_predicates=custom_predicates,
+            decorator=decorator,
+            mapper=mapper,
+            match_param=match_param,
+            route_name=route_name,
+            permission=NO_PERMISSION_REQUIRED,
+            require_csrf=False,
+            exception_only=True,
+            )
+        return self.add_view(**settings)
+
     @action_method
     def set_view_mapper(self, mapper):
         """

--- a/pyramid/exceptions.py
+++ b/pyramid/exceptions.py
@@ -109,6 +109,7 @@ class ConfigurationExecutionError(ConfigurationError):
     def __str__(self):
         return "%s: %s\n  in:\n  %s" % (self.etype, self.evalue, self.info)
 
+
 class CyclicDependencyError(Exception):
     """ The exception raised when the Pyramid topological sorter detects a
     cyclic dependency."""

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -1234,6 +1234,7 @@ class IViewDeriverInfo(Interface):
                         'default values that were not overriden')
     predicates = Attribute('The list of predicates active on the view')
     original_view = Attribute('The original view object being wrapped')
+    exception_only = Attribute('The view will only be invoked for exceptions')
 
 class IViewDerivers(Interface):
     """ Interface for view derivers list """

--- a/pyramid/tests/test_config/test_views.py
+++ b/pyramid/tests/test_config/test_views.py
@@ -20,15 +20,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config = Configurator(*arg, **kw)
         return config
 
-    def _getViewCallable(self, config, ctx_iface=None, request_iface=None,
-                         name='', exception_view=False):
+    def _getViewCallable(self, config, ctx_iface=None, exc_iface=None,
+                         request_iface=None, name=''):
         from zope.interface import Interface
         from pyramid.interfaces import IRequest
         from pyramid.interfaces import IView
         from pyramid.interfaces import IViewClassifier
         from pyramid.interfaces import IExceptionViewClassifier
-        if exception_view:
+        if exc_iface:
             classifier = IExceptionViewClassifier
+            ctx_iface = exc_iface
         else:
             classifier = IViewClassifier
         if ctx_iface is None:
@@ -489,7 +490,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_view(view=newview, xhr=True, context=RuntimeError,
                         renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError), exception_view=True)
+            config, exc_iface=implementedBy(RuntimeError))
         self.assertFalse(IMultiView.providedBy(wrapper))
         request = DummyRequest()
         request.is_xhr = True
@@ -533,7 +534,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_view(view=newview, context=RuntimeError,
                         renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError), exception_view=True)
+            config, exc_iface=implementedBy(RuntimeError))
         self.assertFalse(IMultiView.providedBy(wrapper))
         request = DummyRequest()
         request.is_xhr = True
@@ -581,7 +582,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_view(view=newview, context=RuntimeError,
                         renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError), exception_view=True)
+            config, exc_iface=implementedBy(RuntimeError))
         self.assertFalse(IMultiView.providedBy(wrapper))
         request = DummyRequest()
         request.is_xhr = True
@@ -626,7 +627,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_view(view=view, context=RuntimeError,
                         renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError), exception_view=True)
+            config, exc_iface=implementedBy(RuntimeError))
         self.assertTrue(IMultiView.providedBy(wrapper))
         self.assertEqual(wrapper(None, None), 'OK')
 
@@ -669,7 +670,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             ISecuredView, name='')
         config.add_view(view=view, context=RuntimeError, renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError), exception_view=True)
+            config, exc_iface=implementedBy(RuntimeError))
         self.assertTrue(IMultiView.providedBy(wrapper))
         self.assertEqual(wrapper(None, None), 'OK')
 
@@ -755,7 +756,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_view(view=view2, accept='text/html', context=RuntimeError,
                         renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError), exception_view=True)
+            config, exc_iface=implementedBy(RuntimeError))
         self.assertTrue(IMultiView.providedBy(wrapper))
         self.assertEqual(len(wrapper.views), 1)
         self.assertEqual(len(wrapper.media_views), 1)
@@ -816,7 +817,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_view(view=view2, context=RuntimeError,
                         renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError), exception_view=True)
+            config, exc_iface=implementedBy(RuntimeError))
         self.assertTrue(IMultiView.providedBy(wrapper))
         self.assertEqual(len(wrapper.views), 1)
         self.assertEqual(len(wrapper.media_views), 1)
@@ -843,31 +844,71 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual([x[:2] for x in wrapper.views], [(view2, None)])
         self.assertEqual(wrapper(None, None), 'OK1')
 
-    def test_add_view_exc_multiview_replaces_multiview(self):
+    def test_add_view_exc_multiview_replaces_multiviews(self):
         from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
         from pyramid.interfaces import IRequest
         from pyramid.interfaces import IMultiView
         from pyramid.interfaces import IViewClassifier
         from pyramid.interfaces import IExceptionViewClassifier
-        view = DummyMultiView()
+        hot_view = DummyMultiView()
+        exc_view = DummyMultiView()
         config = self._makeOne(autocommit=True)
         config.registry.registerAdapter(
-            view,
+            hot_view,
             (IViewClassifier, IRequest, implementedBy(RuntimeError)),
             IMultiView, name='')
         config.registry.registerAdapter(
-            view,
+            exc_view,
             (IExceptionViewClassifier, IRequest, implementedBy(RuntimeError)),
             IMultiView, name='')
         view2 = lambda *arg: 'OK2'
         config.add_view(view=view2, context=RuntimeError,
                         renderer=null_renderer)
-        wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError), exception_view=True)
-        self.assertTrue(IMultiView.providedBy(wrapper))
-        self.assertEqual([x[:2] for x in wrapper.views], [(view2, None)])
-        self.assertEqual(wrapper(None, None), 'OK1')
+        hot_wrapper = self._getViewCallable(
+            config, ctx_iface=implementedBy(RuntimeError))
+        self.assertTrue(IMultiView.providedBy(hot_wrapper))
+        self.assertEqual([x[:2] for x in hot_wrapper.views], [(view2, None)])
+        self.assertEqual(hot_wrapper(None, None), 'OK1')
+
+        exc_wrapper = self._getViewCallable(
+            config, exc_iface=implementedBy(RuntimeError))
+        self.assertTrue(IMultiView.providedBy(exc_wrapper))
+        self.assertEqual([x[:2] for x in exc_wrapper.views], [(view2, None)])
+        self.assertEqual(exc_wrapper(None, None), 'OK1')
+
+    def test_add_view_exc_multiview_replaces_only_exc_multiview(self):
+        from pyramid.renderers import null_renderer
+        from zope.interface import implementedBy
+        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import IMultiView
+        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IExceptionViewClassifier
+        hot_view = DummyMultiView()
+        exc_view = DummyMultiView()
+        config = self._makeOne(autocommit=True)
+        config.registry.registerAdapter(
+            hot_view,
+            (IViewClassifier, IRequest, implementedBy(RuntimeError)),
+            IMultiView, name='')
+        config.registry.registerAdapter(
+            exc_view,
+            (IExceptionViewClassifier, IRequest, implementedBy(RuntimeError)),
+            IMultiView, name='')
+        view2 = lambda *arg: 'OK2'
+        config.add_view(view=view2, context=RuntimeError, exception_only=True,
+                        renderer=null_renderer)
+        hot_wrapper = self._getViewCallable(
+            config, ctx_iface=implementedBy(RuntimeError))
+        self.assertTrue(IMultiView.providedBy(hot_wrapper))
+        self.assertEqual(len(hot_wrapper.views), 0)
+        self.assertEqual(hot_wrapper(None, None), 'OK1')
+
+        exc_wrapper = self._getViewCallable(
+            config, exc_iface=implementedBy(RuntimeError))
+        self.assertTrue(IMultiView.providedBy(exc_wrapper))
+        self.assertEqual([x[:2] for x in exc_wrapper.views], [(view2, None)])
+        self.assertEqual(exc_wrapper(None, None), 'OK1')
 
     def test_add_view_multiview_context_superclass_then_subclass(self):
         from pyramid.renderers import null_renderer
@@ -886,10 +927,12 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.registry.registerAdapter(
             view, (IViewClassifier, IRequest, ISuper), IView, name='')
         config.add_view(view=view2, for_=ISub, renderer=null_renderer)
-        wrapper = self._getViewCallable(config, ISuper, IRequest)
+        wrapper = self._getViewCallable(config, ctx_iface=ISuper,
+                                        request_iface=IRequest)
         self.assertFalse(IMultiView.providedBy(wrapper))
         self.assertEqual(wrapper(None, None), 'OK')
-        wrapper = self._getViewCallable(config, ISub, IRequest)
+        wrapper = self._getViewCallable(config, ctx_iface=ISub,
+                                        request_iface=IRequest)
         self.assertFalse(IMultiView.providedBy(wrapper))
         self.assertEqual(wrapper(None, None), 'OK2')
 
@@ -914,16 +957,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             view, (IExceptionViewClassifier, IRequest, Super), IView, name='')
         config.add_view(view=view2, for_=Sub, renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, implementedBy(Super), IRequest)
+            config, ctx_iface=implementedBy(Super), request_iface=IRequest)
         wrapper_exc_view = self._getViewCallable(
-            config, implementedBy(Super), IRequest, exception_view=True)
+            config, exc_iface=implementedBy(Super), request_iface=IRequest)
         self.assertEqual(wrapper_exc_view, wrapper)
         self.assertFalse(IMultiView.providedBy(wrapper_exc_view))
         self.assertEqual(wrapper_exc_view(None, None), 'OK')
         wrapper = self._getViewCallable(
-            config, implementedBy(Sub), IRequest)
+            config, ctx_iface=implementedBy(Sub), request_iface=IRequest)
         wrapper_exc_view = self._getViewCallable(
-            config, implementedBy(Sub), IRequest, exception_view=True)
+            config, exc_iface=implementedBy(Sub), request_iface=IRequest)
         self.assertEqual(wrapper_exc_view, wrapper)
         self.assertFalse(IMultiView.providedBy(wrapper_exc_view))
         self.assertEqual(wrapper_exc_view(None, None), 'OK2')
@@ -1233,8 +1276,8 @@ class TestViewsConfigurationMixin(unittest.TestCase):
                         renderer=null_renderer)
         request_iface = self._getRouteRequestIface(config, 'foo')
         wrapper_exc_view = self._getViewCallable(
-            config, ctx_iface=implementedBy(RuntimeError),
-            request_iface=request_iface, exception_view=True)
+            config, exc_iface=implementedBy(RuntimeError),
+            request_iface=request_iface)
         self.assertNotEqual(wrapper_exc_view, None)
         wrapper = self._getViewCallable(
             config, ctx_iface=implementedBy(RuntimeError),
@@ -1820,8 +1863,8 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from pyramid.renderers import null_renderer
         view1 = lambda *arg: 'OK'
         config = self._makeOne(autocommit=True)
-        config.add_view(view=view1, context=Exception, renderer=null_renderer,
-                        exception_only=True)
+        config.add_view(view=view1, context=Exception, exception_only=True,
+                        renderer=null_renderer)
         view = self._getViewCallable(config, ctx_iface=implementedBy(Exception))
         self.assertTrue(view is None)
 
@@ -1830,11 +1873,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from pyramid.renderers import null_renderer
         view1 = lambda *arg: 'OK'
         config = self._makeOne(autocommit=True)
-        config.add_view(view=view1, context=Exception, renderer=null_renderer,
-                        exception_only=True)
+        config.add_view(view=view1, context=Exception, exception_only=True,
+                        renderer=null_renderer)
         view = self._getViewCallable(
-            config, ctx_iface=implementedBy(Exception), exception_view=True
-            )
+            config, exc_iface=implementedBy(Exception))
         self.assertEqual(view1, view)
 
     def test_add_view_exception_only_misconfiguration(self):
@@ -1844,20 +1886,30 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             pass
         self.assertRaises(
             ConfigurationError,
-            config.add_view, view, context=NotAnException, exception_only=True
-            )
+            config.add_view, view, context=NotAnException, exception_only=True)
 
     def test_add_exception_view(self):
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
         from pyramid.renderers import null_renderer
         view1 = lambda *arg: 'OK'
         config = self._makeOne(autocommit=True)
-        config.add_exception_view(view=view1, context=Exception, renderer=null_renderer)
+        config.add_exception_view(view=view1, renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(Exception), exception_view=True,
-            )
+            config, exc_iface=implementedBy(Exception))
         context = Exception()
+        request = self._makeRequest(config)
+        self.assertEqual(wrapper(context, request), 'OK')
+
+    def test_add_exception_view_with_subclass(self):
+        from zope.interface import implementedBy
+        from pyramid.renderers import null_renderer
+        view1 = lambda *arg: 'OK'
+        config = self._makeOne(autocommit=True)
+        config.add_exception_view(view=view1, context=ValueError,
+                                  renderer=null_renderer)
+        wrapper = self._getViewCallable(
+            config, exc_iface=implementedBy(ValueError))
+        context = ValueError()
         request = self._makeRequest(config)
         self.assertEqual(wrapper(context, request), 'OK')
 
@@ -1875,19 +1927,19 @@ class TestViewsConfigurationMixin(unittest.TestCase):
                           context=Exception(),
                           permission='foo')
 
+    def test_add_exception_view_disallows_require_csrf(self):
+        config = self._makeOne(autocommit=True)
+        self.assertRaises(ConfigurationError,
+                          config.add_exception_view,
+                          context=Exception(),
+                          require_csrf=True)
+
     def test_add_exception_view_disallows_for_(self):
         config = self._makeOne(autocommit=True)
         self.assertRaises(ConfigurationError,
                           config.add_exception_view,
                           context=Exception(),
                           for_='foo')
-
-    def test_add_exception_view_disallows_http_cache(self):
-        config = self._makeOne(autocommit=True)
-        self.assertRaises(ConfigurationError,
-                          config.add_exception_view,
-                          context=Exception(),
-                          http_cache='foo')
 
     def test_add_exception_view_disallows_exception_only(self):
         config = self._makeOne(autocommit=True)
@@ -1896,21 +1948,14 @@ class TestViewsConfigurationMixin(unittest.TestCase):
                           context=Exception(),
                           exception_only=True)
 
-    def test_add_exception_view_requires_context(self):
-        config = self._makeOne(autocommit=True)
-        view = lambda *a: 'OK'
-        self.assertRaises(ConfigurationError,
-                          config.add_exception_view, view=view)
-
     def test_add_exception_view_with_view_defaults(self):
         from pyramid.renderers import null_renderer
         from pyramid.exceptions import PredicateMismatch
-        from pyramid.httpexceptions import HTTPNotFound
         from zope.interface import directlyProvides
         from zope.interface import implementedBy
         class view(object):
             __view_defaults__ = {
-                'containment':'pyramid.tests.test_config.IDummy'
+                'containment': 'pyramid.tests.test_config.IDummy'
                 }
             def __init__(self, request):
                 pass
@@ -1922,7 +1967,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             context=Exception,
             renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(Exception), exception_view=True)
+            config, exc_iface=implementedBy(Exception))
         context = DummyContext()
         directlyProvides(context, IDummy)
         request = self._makeRequest(config)
@@ -2043,7 +2088,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_forbidden_view(view, renderer=null_renderer)
         request = self._makeRequest(config)
         view = self._getViewCallable(config,
-                                     ctx_iface=implementedBy(HTTPForbidden),
+                                     exc_iface=implementedBy(HTTPForbidden),
                                      request_iface=IRequest)
         result = view(None, request)
         self.assertEqual(result, 'OK')
@@ -2057,7 +2102,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_forbidden_view()
         request = self._makeRequest(config)
         view = self._getViewCallable(config,
-                                     ctx_iface=implementedBy(HTTPForbidden),
+                                     exc_iface=implementedBy(HTTPForbidden),
                                      request_iface=IRequest)
         context = HTTPForbidden()
         result = view(context, request)
@@ -2080,6 +2125,11 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertRaises(ConfigurationError,
                           config.add_forbidden_view, permission='foo')
 
+    def test_add_forbidden_view_disallows_require_csrf(self):
+        config = self._makeOne(autocommit=True)
+        self.assertRaises(ConfigurationError,
+                          config.add_forbidden_view, require_csrf=True)
+
     def test_add_forbidden_view_disallows_context(self):
         config = self._makeOne(autocommit=True)
         self.assertRaises(ConfigurationError,
@@ -2089,11 +2139,6 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config = self._makeOne(autocommit=True)
         self.assertRaises(ConfigurationError,
                           config.add_forbidden_view, for_='foo')
-
-    def test_add_forbidden_view_disallows_http_cache(self):
-        config = self._makeOne(autocommit=True)
-        self.assertRaises(ConfigurationError,
-                          config.add_forbidden_view, http_cache='foo')
 
     def test_add_forbidden_view_with_view_defaults(self):
         from pyramid.interfaces import IRequest
@@ -2115,7 +2160,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             view=view,
             renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(HTTPForbidden),
+            config, exc_iface=implementedBy(HTTPForbidden),
             request_iface=IRequest)
         context = DummyContext()
         directlyProvides(context, IDummy)
@@ -2135,7 +2180,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_notfound_view(view, renderer=null_renderer)
         request = self._makeRequest(config)
         view = self._getViewCallable(config,
-                                     ctx_iface=implementedBy(HTTPNotFound),
+                                     exc_iface=implementedBy(HTTPNotFound),
                                      request_iface=IRequest)
         result = view(None, request)
         self.assertEqual(result, (None, request))
@@ -2149,7 +2194,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config.add_notfound_view()
         request = self._makeRequest(config)
         view = self._getViewCallable(config,
-                                     ctx_iface=implementedBy(HTTPNotFound),
+                                     exc_iface=implementedBy(HTTPNotFound),
                                      request_iface=IRequest)
         context = HTTPNotFound()
         result = view(context, request)
@@ -2172,6 +2217,11 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertRaises(ConfigurationError,
                           config.add_notfound_view, permission='foo')
 
+    def test_add_notfound_view_disallows_require_csrf(self):
+        config = self._makeOne(autocommit=True)
+        self.assertRaises(ConfigurationError,
+                          config.add_notfound_view, require_csrf=True)
+
     def test_add_notfound_view_disallows_context(self):
         config = self._makeOne(autocommit=True)
         self.assertRaises(ConfigurationError,
@@ -2181,11 +2231,6 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         config = self._makeOne(autocommit=True)
         self.assertRaises(ConfigurationError,
                           config.add_notfound_view, for_='foo')
-
-    def test_add_notfound_view_disallows_http_cache(self):
-        config = self._makeOne(autocommit=True)
-        self.assertRaises(ConfigurationError,
-                          config.add_notfound_view, http_cache='foo')
 
     def test_add_notfound_view_append_slash(self):
         from pyramid.response import Response
@@ -2202,7 +2247,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         request.query_string = 'a=1&b=2'
         request.path = '/scriptname/foo'
         view = self._getViewCallable(config,
-                                     ctx_iface=implementedBy(HTTPNotFound),
+                                     exc_iface=implementedBy(HTTPNotFound),
                                      request_iface=IRequest)
         result = view(None, request)
         self.assertTrue(isinstance(result, HTTPFound))
@@ -2225,7 +2270,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         request.query_string = 'a=1&b=2'
         request.path = '/scriptname/foo'
         view = self._getViewCallable(config,
-                                     ctx_iface=implementedBy(HTTPNotFound),
+                                     exc_iface=implementedBy(HTTPNotFound),
                                      request_iface=IRequest)
         result = view(None, request)
         self.assertTrue(isinstance(result, HTTPMovedPermanently))
@@ -2251,7 +2296,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             view=view,
             renderer=null_renderer)
         wrapper = self._getViewCallable(
-            config, ctx_iface=implementedBy(HTTPNotFound),
+            config, exc_iface=implementedBy(HTTPNotFound),
             request_iface=IRequest)
         context = DummyContext()
         directlyProvides(context, IDummy)
@@ -2281,7 +2326,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             renderer='json')
         request = self._makeRequest(config)
         view = self._getViewCallable(config,
-                                     ctx_iface=implementedBy(HTTPNotFound),
+                                     exc_iface=implementedBy(HTTPNotFound),
                                      request_iface=IRequest)
         result = view(None, request)
         self._assertBody(result, '{}')
@@ -2298,7 +2343,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             renderer='json')
         request = self._makeRequest(config)
         view = self._getViewCallable(config,
-                                     ctx_iface=implementedBy(HTTPForbidden),
+                                     exc_iface=implementedBy(HTTPForbidden),
                                      request_iface=IRequest)
         result = view(None, request)
         self._assertBody(result, '{}')
@@ -2318,6 +2363,75 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         result = config.registry.getUtility(IViewMapperFactory)
         from pyramid.tests import test_config
         self.assertEqual(result, test_config)
+
+    def test_add_normal_and_exception_view_intr_derived_callable(self):
+        from pyramid.renderers import null_renderer
+        from pyramid.exceptions import BadCSRFToken
+        config = self._makeOne(autocommit=True)
+        introspector = DummyIntrospector()
+        config.introspector = introspector
+        view = lambda r: 'OK'
+        config.set_default_csrf_options(require_csrf=True)
+        config.add_view(view, context=Exception, renderer=null_renderer)
+        view_intr = introspector.introspectables[1]
+        self.assertTrue(view_intr.type_name, 'view')
+        self.assertEqual(view_intr['callable'], view)
+        derived_view = view_intr['derived_callable']
+
+        request = self._makeRequest(config)
+        request.method = 'POST'
+        request.scheme = 'http'
+        request.POST = {}
+        request.headers = {}
+        request.session = DummySession({'csrf_token': 'foo'})
+        self.assertRaises(BadCSRFToken, lambda: derived_view(None, request))
+        request.exception = Exception()
+        self.assertEqual(derived_view(None, request), 'OK')
+
+class Test_runtime_exc_view(unittest.TestCase):
+    def _makeOne(self, view1, view2):
+        from pyramid.config.views import runtime_exc_view
+        return runtime_exc_view(view1, view2)
+
+    def test_call(self):
+        def view1(context, request): return 'OK'
+        def view2(context, request): raise AssertionError
+        result_view = self._makeOne(view1, view2)
+        request = DummyRequest()
+        result = result_view(None, request)
+        self.assertEqual(result, 'OK')
+
+    def test_call_dispatches_on_exception(self):
+        def view1(context, request): raise AssertionError
+        def view2(context, request): return 'OK'
+        result_view = self._makeOne(view1, view2)
+        request = DummyRequest()
+        request.exception = Exception()
+        result = result_view(None, request)
+        self.assertEqual(result, 'OK')
+
+    def test_permitted(self):
+        def errfn(context, request): raise AssertionError
+        def view1(context, request): raise AssertionError
+        view1.__permitted__ = lambda c, r: 'OK'
+        def view2(context, request): raise AssertionError
+        view2.__permitted__ = errfn
+        result_view = self._makeOne(view1, view2)
+        request = DummyRequest()
+        result = result_view.__permitted__(None, request)
+        self.assertEqual(result, 'OK')
+
+    def test_permitted_dispatches_on_exception(self):
+        def errfn(context, request): raise AssertionError
+        def view1(context, request): raise AssertionError
+        view1.__permitted__ = errfn
+        def view2(context, request): raise AssertionError
+        view2.__permitted__ = lambda c, r: 'OK'
+        result_view = self._makeOne(view1, view2)
+        request = DummyRequest()
+        request.exception = Exception()
+        result = result_view.__permitted__(None, request)
+        self.assertEqual(result, 'OK')
 
 class Test_requestonly(unittest.TestCase):
     def _callFUT(self, view, attr=None):

--- a/pyramid/tests/test_config/test_views.py
+++ b/pyramid/tests/test_config/test_views.py
@@ -1815,6 +1815,38 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
         self.assertRaises(ConfigurationError, configure_view)
 
+    def test_add_view_exception_only_no_regular_view(self):
+        from zope.interface import implementedBy
+        from pyramid.renderers import null_renderer
+        view1 = lambda *arg: 'OK'
+        config = self._makeOne(autocommit=True)
+        config.add_view(view=view1, context=Exception, renderer=null_renderer,
+                        exception_only=True)
+        view = self._getViewCallable(config, ctx_iface=implementedBy(Exception))
+        self.assertTrue(view is None)
+
+    def test_add_view_exception_only(self):
+        from zope.interface import implementedBy
+        from pyramid.renderers import null_renderer
+        view1 = lambda *arg: 'OK'
+        config = self._makeOne(autocommit=True)
+        config.add_view(view=view1, context=Exception, renderer=null_renderer,
+                        exception_only=True)
+        view = self._getViewCallable(
+            config, ctx_iface=implementedBy(Exception), exception_view=True
+            )
+        self.assertEqual(view1, view)
+
+    def test_add_view_exception_only_misconfiguration(self):
+        view = lambda *arg: 'OK'
+        config = self._makeOne(autocommit=True)
+        class NotAnException(object):
+            pass
+        self.assertRaises(
+            ConfigurationError,
+            config.add_view, view, context=NotAnException, exception_only=True
+            )
+
     def test_derive_view_function(self):
         from pyramid.renderers import null_renderer
         def view(request):

--- a/pyramid/tests/test_exceptions.py
+++ b/pyramid/tests/test_exceptions.py
@@ -90,5 +90,3 @@ class TestCyclicDependencyError(unittest.TestCase):
         result = str(exc)
         self.assertTrue("'a' sorts before ['c', 'd']" in result)
         self.assertTrue("'c' sorts before ['a']" in result)
-
-

--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -132,7 +132,49 @@ class Test_forbidden_view_config(BaseTest, unittest.TestCase):
         self.assertEqual(settings[0]['view'], None) # comes from call_venusian
         self.assertEqual(settings[0]['attr'], 'view')
         self.assertEqual(settings[0]['_info'], 'codeinfo')
-        
+
+class Test_exception_view_config(BaseTest, unittest.TestCase):
+    def _makeOne(self, **kw):
+        from pyramid.view import exception_view_config
+        return exception_view_config(**kw)
+
+    def test_ctor(self):
+        inst = self._makeOne(context=Exception, path_info='path_info')
+        self.assertEqual(inst.__dict__,
+                         {'context':Exception, 'path_info':'path_info'})
+
+    def test_it_function(self):
+        def view(request): pass
+        decorator = self._makeOne(context=Exception, renderer='renderer')
+        venusian = DummyVenusian()
+        decorator.venusian = venusian
+        wrapped = decorator(view)
+        self.assertTrue(wrapped is view)
+        config = call_venusian(venusian)
+        settings = config.settings
+        self.assertEqual(
+            settings,
+            [{'venusian': venusian, 'context': Exception,
+              'renderer': 'renderer', '_info': 'codeinfo', 'view': None}]
+            )
+
+    def test_it_class(self):
+        decorator = self._makeOne()
+        venusian = DummyVenusian()
+        decorator.venusian = venusian
+        decorator.venusian.info.scope = 'class'
+        class view(object): pass
+        wrapped = decorator(view)
+        self.assertTrue(wrapped is view)
+        config = call_venusian(venusian)
+        settings = config.settings
+        self.assertEqual(len(settings), 1)
+        self.assertEqual(len(settings[0]), 4)
+        self.assertEqual(settings[0]['venusian'], venusian)
+        self.assertEqual(settings[0]['view'], None) # comes from call_venusian
+        self.assertEqual(settings[0]['attr'], 'view')
+        self.assertEqual(settings[0]['_info'], 'codeinfo')
+
 class RenderViewToResponseTests(BaseTest, unittest.TestCase):
     def _callFUT(self, *arg, **kw):
         from pyramid.view import render_view_to_response
@@ -898,7 +940,7 @@ class DummyConfig(object):
     def add_view(self, **kw):
         self.settings.append(kw)
 
-    add_notfound_view = add_forbidden_view = add_view
+    add_notfound_view = add_forbidden_view = add_exception_view = add_view
 
     def with_package(self, pkg):
         self.pkg = pkg

--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -134,14 +134,23 @@ class Test_forbidden_view_config(BaseTest, unittest.TestCase):
         self.assertEqual(settings[0]['_info'], 'codeinfo')
 
 class Test_exception_view_config(BaseTest, unittest.TestCase):
-    def _makeOne(self, **kw):
+    def _makeOne(self, *args, **kw):
         from pyramid.view import exception_view_config
-        return exception_view_config(**kw)
+        return exception_view_config(*args, **kw)
 
     def test_ctor(self):
         inst = self._makeOne(context=Exception, path_info='path_info')
         self.assertEqual(inst.__dict__,
                          {'context':Exception, 'path_info':'path_info'})
+
+    def test_ctor_positional_exception(self):
+        inst = self._makeOne(Exception, path_info='path_info')
+        self.assertEqual(inst.__dict__,
+                         {'context':Exception, 'path_info':'path_info'})
+
+    def test_ctor_positional_extras(self):
+        from pyramid.exceptions import ConfigurationError
+        self.assertRaises(ConfigurationError, lambda: self._makeOne(Exception, True))
 
     def test_it_function(self):
         def view(request): pass

--- a/pyramid/tests/test_viewderivers.py
+++ b/pyramid/tests/test_viewderivers.py
@@ -551,6 +551,28 @@ class TestDeriveView(unittest.TestCase):
                          "'view_name' against context None): "
                          "Allowed (NO_PERMISSION_REQUIRED)")
 
+    def test_debug_auth_permission_authpol_permitted_excview(self):
+        response = DummyResponse()
+        view = lambda *arg: response
+        self.config.registry.settings = dict(
+            debug_authorization=True, reload_templates=True)
+        logger = self._registerLogger()
+        self._registerSecurityPolicy(True)
+        result = self.config._derive_view(
+            view, context=Exception, permission='view')
+        self.assertEqual(view.__module__, result.__module__)
+        self.assertEqual(view.__doc__, result.__doc__)
+        self.assertEqual(view.__name__, result.__name__)
+        self.assertEqual(result.__call_permissive__.__wraps__, view)
+        request = self._makeRequest()
+        request.view_name = 'view_name'
+        request.url = 'url'
+        self.assertEqual(result(Exception(), request), response)
+        self.assertEqual(len(logger.messages), 1)
+        self.assertEqual(logger.messages[0],
+                         "debug_authorization of url url (view name "
+                         "'view_name' against context Exception()): True")
+
     def test_secured_view_authn_policy_no_authz_policy(self):
         response = DummyResponse()
         view = lambda *arg: response

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -491,6 +491,7 @@ class exception_view_config(object):
     :meth:`pyramid.view.view_config` and each predicate argument restricts
     the set of circumstances under which this exception view will be invoked.
     """
+    venusian = venusian
 
     def __init__(self, **settings):
         self.__dict__.update(settings)

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -17,7 +17,10 @@ from pyramid.interfaces import (
 
 from pyramid.compat import decode_path_info
 
-from pyramid.exceptions import PredicateMismatch
+from pyramid.exceptions import (
+    ConfigurationError,
+    PredicateMismatch,
+)
 
 from pyramid.httpexceptions import (
     HTTPFound,
@@ -166,7 +169,7 @@ class view_config(object):
              :class:`pyramid.view.bfg_view`.
 
     :class:`pyramid.view.view_config` supports the following keyword
-    arguments: ``context``, ``permission``, ``name``,
+    arguments: ``context``, ``exception``, ``permission``, ``name``,
     ``request_type``, ``route_name``, ``request_method``, ``request_param``,
     ``containment``, ``xhr``, ``accept``, ``header``, ``path_info``,
     ``custom_predicates``, ``decorator``, ``mapper``, ``http_cache``,
@@ -325,7 +328,8 @@ class notfound_view_config(object):
     .. versionadded:: 1.3
 
     An analogue of :class:`pyramid.view.view_config` which registers a
-    :term:`Not Found View`.
+    :term:`Not Found View` using
+    :meth:`pyramid.config.Configurator.add_notfound_view`.
 
     The ``notfound_view_config`` constructor accepts most of the same arguments
     as the constructor of :class:`pyramid.view.view_config`.  It can be used
@@ -413,7 +417,8 @@ class forbidden_view_config(object):
     .. versionadded:: 1.3
 
     An analogue of :class:`pyramid.view.view_config` which registers a
-    :term:`forbidden view`.
+    :term:`forbidden view` using
+    :meth:`pyramid.config.Configurator.add_forbidden_view`.
 
     The forbidden_view_config constructor accepts most of the same arguments
     as the constructor of :class:`pyramid.view.view_config`.  It can be used
@@ -468,13 +473,15 @@ class exception_view_config(object):
     .. versionadded:: 1.8
 
     An analogue of :class:`pyramid.view.view_config` which registers an
-    exception view.
+    :term:`exception view` using
+    :meth:`pyramid.config.Configurator.add_exception_view`.
 
-    The exception_view_config constructor requires an exception context, and
-    additionally accepts most of the same arguments as the constructor of
+    The ``exception_view_config`` constructor requires an exception context,
+    and additionally accepts most of the same arguments as the constructor of
     :class:`pyramid.view.view_config`.  It can be used in the same places,
-    and behaves in largely the same way, except it always registers an exception
-    view instead of a 'normal' view.
+    and behaves in largely the same way, except it always registers an
+    exception view instead of a 'normal' view that dispatches on the request
+    :term:`context`.
 
     Example:
 
@@ -483,17 +490,23 @@ class exception_view_config(object):
         from pyramid.view import exception_view_config
         from pyramid.response import Response
 
-        @exception_view_config(context=ValueError, renderer='json')
-        def error_view(context, request):
-            return {'error': str(context)}
+        @exception_view_config(ValueError, renderer='json')
+        def error_view(request):
+            return {'error': str(request.exception)}
 
     All arguments passed to this function have the same meaning as
     :meth:`pyramid.view.view_config` and each predicate argument restricts
     the set of circumstances under which this exception view will be invoked.
+
     """
     venusian = venusian
 
-    def __init__(self, **settings):
+    def __init__(self, *args, **settings):
+        if 'context' not in settings and len(args) > 0:
+            exception, args = args[0], args[1:]
+            settings['context'] = exception
+        if len(args) > 0:
+            raise ConfigurationError('unknown positional arguments')
         self.__dict__.update(settings)
 
     def __call__(self, wrapped):

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -471,7 +471,7 @@ class exception_view_config(object):
     exception view.
 
     The exception_view_config constructor requires an exception context, and
-    additionally accepts most of the same argumenta as the constructor of
+    additionally accepts most of the same arguments as the constructor of
     :class:`pyramid.view.view_config`.  It can be used in the same places,
     and behaves in largely the same way, except it always registers an exception
     view instead of a 'normal' view.
@@ -483,9 +483,9 @@ class exception_view_config(object):
         from pyramid.view import exception_view_config
         from pyramid.response import Response
 
-        @exception_view_config(context=ValueError)
-        def error_view(request):
-            return Response('A value error ocurred')
+        @exception_view_config(context=ValueError, renderer='json')
+        def error_view(context, request):
+            return {'error': str(context)}
 
     All arguments passed to this function have the same meaning as
     :meth:`pyramid.view.view_config` and each predicate argument restricts


### PR DESCRIPTION
I don't think that this work is fully done yet, but I'm creating a PR to start collaboration and discussion.

I think that code could use some re-factoring. I think that there's too much shared between the exception view registration and the not-found view and forbidden view registration. Probably it could be changed to have less repeated code between those three.

I have some time to work on this going forward, but unfortunately a lot less than I'd like.

Discussion that started this work here: https://github.com/Pylons/pyramid/issues/1646
