### PR TITLE
Show testsetup code in rendered docs.

### DIFF
--- a/pyramid/decorator.py
+++ b/pyramid/decorator.py
@@ -8,6 +8,16 @@ class reify(object):
     replacing the function it decorates with an instance variable.  It is, in
     Python parlance, a non-data descriptor.  An example:
 
+    .. code-block:: python
+
+        from pyramid.decorator import reify
+
+        class Foo(object):
+            @reify
+            def jammy(self):
+                print('jammy called')
+                return 1
+
     .. testsetup::
 
         from pyramid.decorator import reify


### PR DESCRIPTION
For `testsetup`, Sphinx does not show code in the output: http://www.sphinx-doc.org/en/stable/ext/doctest.html#directive-testsetup This commit fixes that issue, although duplicates code. I'll submit a feature request to https://github.com/sphinx-doc/sphinx/ Fixes #2670