### PR TITLE
updated old link to Alembic naming convention

### DIFF
--- a/pyramid/scaffolds/alchemy/+package+/models/meta.py
+++ b/pyramid/scaffolds/alchemy/+package+/models/meta.py
@@ -3,7 +3,7 @@ from sqlalchemy.schema import MetaData
 
 # Recommended naming convention used by Alembic, as various different database
 # providers will autogenerate vastly different names making migrations more
-# difficult. See: http://alembic.readthedocs.org/en/latest/naming.html
+# difficult. See: http://alembic.zzzcomputing.com/en/latest/naming.html
 NAMING_CONVENTION = {
     "ix": 'ix_%(column_0_label)s',
     "uq": "uq_%(table_name)s_%(column_0_name)s",


### PR DESCRIPTION
All docs now live on alembic.zzzcomputing.com, but for some reason link http://alembic.readthedocs.org/en/latest/naming.html redirects to wrong domain.