### PR TITLE
link to hacking and contributing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,9 +50,10 @@ for documentation, reporting bugs, and getting support.
 Developing and Contributing
 ---------------------------
 
-See ``HACKING.txt`` and ``contributing.md`` for guidelines for running tests,
-adding features, coding style, and updating documentation when developing in or
-contributing to Pyramid.
+See `HACKING.txt <https://github.com/Pylons/pyramid/blob/master/HACKING.txt>`_ and
+`contributing.md <https://github.com/Pylons/pyramid/blob/master/contributing.md>`_
+for guidelines on running tests, adding features, coding style, and updating
+documentation when developing in or contributing to Pyramid.
 
 License
 -------


### PR DESCRIPTION
(cherry picked from commit 2b8c7d5)

Although this links to master, I think it is best to point to that branch as the canonical version instead of each branch's version.