### PR TITLE
Fixed bug in `pcreate` such that it now shows the correct view when a class and `attr` is involved

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+unreleased
+==========
+
+- Fixed bug in `pcreate` such that it now shows the correct view when a class
+  and `attr` is involved.
+  See: https://github.com/Pylons/pyramid/pull/2687
+
+
 .. _changes_1.6.1:
 
 1.6.1 (2016-02-02)

--- a/pyramid/scripts/proutes.py
+++ b/pyramid/scripts/proutes.py
@@ -184,8 +184,15 @@ def get_route_data(route, registry):
                 request_method = view.get('request_methods')
 
                 if request_method is not None:
-                    view_callable = view['callable']
-                    view_module = _get_view_module(view_callable)
+                    if view.get('attr') is not None:
+                        view_callable = getattr(view['callable'], view['attr'])
+                        view_module = '%s.%s' % (
+                            _get_view_module(view['callable']),
+                            view['attr']
+                        )
+                    else:
+                        view_callable = view['callable']
+                        view_module = _get_view_module(view_callable)
 
                     if view_module not in view_request_methods:
                         view_request_methods[view_module] = []

--- a/pyramid/tests/test_scripts/dummy.py
+++ b/pyramid/tests/test_scripts/dummy.py
@@ -70,6 +70,9 @@ class DummyView(object):
     def __init__(self, **attrs):
         self.__request_attrs__ = attrs
 
+    def view(context, request):
+        return 'view1'
+
 from zope.interface import implementer
 from pyramid.interfaces import IMultiView
 @implementer(IMultiView)

--- a/pyramid/tests/test_scripts/dummy.py
+++ b/pyramid/tests/test_scripts/dummy.py
@@ -70,8 +70,7 @@ class DummyView(object):
     def __init__(self, **attrs):
         self.__request_attrs__ = attrs
 
-    def view(context, request):
-        return 'view1'
+    def view(context, request): pass
 
 from zope.interface import implementer
 from pyramid.interfaces import IMultiView

--- a/pyramid/tests/test_scripts/test_proutes.py
+++ b/pyramid/tests/test_scripts/test_proutes.py
@@ -199,6 +199,33 @@ class TestPRoutesCommand(unittest.TestCase):
              'pyramid.tests.test_scripts.test_proutes.view']
         )
 
+    def test_class_view(self):
+        from pyramid.renderers import null_renderer as nr
+
+        config = self._makeConfig(autocommit=True)
+        config.add_route('foo', '/a/b')
+        config.add_view(
+            route_name='foo',
+            view=dummy.DummyView,
+            attr='view',
+            renderer=nr,
+            request_method='POST'
+        )
+
+        command = self._makeOne()
+        L = []
+        command.out = L.append
+        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        result = command.run()
+        self.assertEqual(result, 0)
+        self.assertEqual(len(L), 3)
+        compare_to = L[-1].split()
+        expected = [
+            'foo', '/a/b',
+            'pyramid.tests.test_scripts.dummy.DummyView.view', 'POST'
+        ]
+        self.assertEqual(compare_to, expected)
+
     def test_single_route_one_view_registered_with_factory(self):
         from zope.interface import Interface
         from pyramid.interfaces import IRouteRequest


### PR DESCRIPTION
Backport from master
See: https://github.com/Pylons/pyramid/pull/2687