### PR TITLE
Add one-way password hash to security example in Quick Tutorial.

### DIFF
--- a/docs/quick_tutorial/authentication.rst
+++ b/docs/quick_tutorial/authentication.rst
@@ -50,7 +50,9 @@ Steps
     :linenos:
 
 #. Create an ``authentication/tutorial/security.py`` module that can find our
-   user information by providing an *authentication policy callback*:
+   user information by providing an *authentication policy callback*.
+   One-way hash function ``hash_password_with_salt`` is used to avoid user's
+   password stored in plain text:
 
    .. literalinclude:: authentication/tutorial/security.py
     :linenos:

--- a/docs/quick_tutorial/authentication/tutorial/security.py
+++ b/docs/quick_tutorial/authentication/tutorial/security.py
@@ -1,5 +1,21 @@
-USERS = {'editor': 'editor',
-         'viewer': 'viewer'}
+import os
+import hashlib
+import binascii
+
+SALT_LENGTH = 16
+
+def hash_password_with_salt(password, salt=None):
+    salt = salt or os.urandom(SALT_LENGTH)
+    dk = hashlib.pbkdf2_hmac('sha512', password.encode('utf-8'), salt, 100000)
+    return binascii.hexlify(dk + salt).decode('utf-8')
+
+def check_password(password, salted_password):
+    salt = binascii.unhexlify(salted_password[-2 * SALT_LENGTH:])
+    return hash_password_with_salt(password, salt) == salted_password
+
+
+USERS = {'editor': hash_password_with_salt('editor'),
+         'viewer': hash_password_with_salt('viewer')}
 GROUPS = {'editor': ['group:editors']}
 
 

--- a/docs/quick_tutorial/authentication/tutorial/views.py
+++ b/docs/quick_tutorial/authentication/tutorial/views.py
@@ -9,7 +9,10 @@ from pyramid.view import (
     view_defaults
     )
 
-from .security import USERS
+from .security import (
+    USERS,
+    check_password
+)
 
 
 @view_defaults(renderer='home.pt')
@@ -40,7 +43,7 @@ class TutorialViews:
         if 'form.submitted' in request.params:
             login = request.params['login']
             password = request.params['password']
-            if USERS.get(login) == password:
+            if check_password(password, USERS.get(login)):
                 headers = remember(request, login)
                 return HTTPFound(location=came_from,
                                  headers=headers)

--- a/docs/quick_tutorial/authorization/tutorial/security.py
+++ b/docs/quick_tutorial/authorization/tutorial/security.py
@@ -1,3 +1,19 @@
+import os
+import hashlib
+import binascii
+
+SALT_LENGTH = 16
+
+def hash_password_with_salt(password, salt=None):
+    salt = salt or os.urandom(SALT_LENGTH)
+    dk = hashlib.pbkdf2_hmac('sha512', password.encode('utf-8'), salt, 100000)
+    return binascii.hexlify(dk + salt).decode('utf-8')
+
+def check_password(password, salted_password):
+    salt = binascii.unhexlify(salted_password[-2 * SALT_LENGTH:])
+    return hash_password_with_salt(password, salt) == salted_password
+
+
 USERS = {'editor': 'editor',
          'viewer': 'viewer'}
 GROUPS = {'editor': ['group:editors']}

--- a/docs/quick_tutorial/authorization/tutorial/views.py
+++ b/docs/quick_tutorial/authorization/tutorial/views.py
@@ -10,7 +10,10 @@ from pyramid.view import (
     forbidden_view_config
     )
 
-from .security import USERS
+from .security import (
+    USERS,
+    check_password
+)
 
 
 @view_defaults(renderer='home.pt')
@@ -42,7 +45,7 @@ class TutorialViews:
         if 'form.submitted' in request.params:
             login = request.params['login']
             password = request.params['password']
-            if USERS.get(login) == password:
+            if check_password(password, USERS.get(login)):
                 headers = remember(request, login)
                 return HTTPFound(location=came_from,
                                  headers=headers)


### PR DESCRIPTION
This pull-request is aiding #2204.
The usage of hashlib for one-way hash is from the discussion of #2590.