### PR TITLE
Add one-way password hash to security example in Wiki Tutorial.

### DIFF
--- a/docs/tutorials/wiki/authorization.rst
+++ b/docs/tutorials/wiki/authorization.rst
@@ -59,7 +59,9 @@ For example, ``groupfinder('editor', request )`` returns ``['group:editor']``,
 ``groupfinder('viewer', request)`` returns ``[]``, and ``groupfinder('admin',
 request)`` returns ``None``.  We will use ``groupfinder()`` as an
 :term:`authentication policy` "callback" that will provide the
-:term:`principal` or principals for a user.
+:term:`principal` or principals for a user. One-way hash function
+``hash_password_with_salt`` is used to avoid user's password stored in plain
+text.
 
 In a production system, user and group data will most often come from a
 database, but here we use "dummy" data to represent user and groups sources.

--- a/docs/tutorials/wiki/src/authorization/tutorial/security.py
+++ b/docs/tutorials/wiki/src/authorization/tutorial/security.py
@@ -1,6 +1,24 @@
-USERS = {'editor':'editor',
-          'viewer':'viewer'}
-GROUPS = {'editor':['group:editors']}
+import hashlib
+import os
+import binascii
+
+SALT_LENGTH = 16
+
+
+def hash_password_with_salt(password, salt=None):
+    salt = salt or os.urandom(SALT_LENGTH)
+    dk = hashlib.pbkdf2_hmac('sha512', password.encode('utf-8'), salt, 100000)
+    return binascii.hexlify(dk + salt).decode('utf-8')
+
+def check_password(password, salted_password):
+    salt = binascii.unhexlify(salted_password[-2 * SALT_LENGTH:])
+    return hash_password_with_salt(password, salt) == salted_password
+
+
+USERS = {'editor': hash_password_with_salt('editor'),
+         'viewer': hash_password_with_salt('viewer')}
+GROUPS = {'editor': ['group:editors']}
+
 
 def groupfinder(userid, request):
     if userid in USERS:

--- a/docs/tutorials/wiki/src/authorization/tutorial/views.py
+++ b/docs/tutorials/wiki/src/authorization/tutorial/views.py
@@ -14,7 +14,10 @@ from pyramid.security import (
     )
 
 
-from .security import USERS
+from .security import (
+    USERS,
+    check_password,
+)
 from .models import Page
 
 # regular expression used to find WikiWords
@@ -94,7 +97,7 @@ def login(request):
     if 'form.submitted' in request.params:
         login = request.params['login']
         password = request.params['password']
-        if USERS.get(login) == password:
+        if check_password(password, USERS.get(login)):
             headers = remember(request, login)
             return HTTPFound(location=came_from,
                              headers=headers)


### PR DESCRIPTION
This pull-request is aiding #2204.
The usage of hashlib for one-way hash is from the discussion of #2590.