### PR TITLE
fix the wiki2 tutorial to set the password as unicode

### DIFF
--- a/docs/tutorials/wiki2/src/authentication/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/models/user.py
@@ -19,11 +19,10 @@ class User(Base):
 
     def set_password(self, pw):
         pwhash = bcrypt.hashpw(pw.encode('utf8'), bcrypt.gensalt())
-        self.password_hash = pwhash
+        self.password_hash = pwhash.decode('utf8')
 
     def check_password(self, pw):
         if self.password_hash is not None:
             expected_hash = self.password_hash.encode('utf8')
-            actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
-            return expected_hash == actual_hash
+            return bcrypt.checkpw(pw.encode('utf8'), expected_hash)
         return False

--- a/docs/tutorials/wiki2/src/authorization/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/models/user.py
@@ -19,11 +19,10 @@ class User(Base):
 
     def set_password(self, pw):
         pwhash = bcrypt.hashpw(pw.encode('utf8'), bcrypt.gensalt())
-        self.password_hash = pwhash
+        self.password_hash = pwhash.decode('utf8')
 
     def check_password(self, pw):
         if self.password_hash is not None:
             expected_hash = self.password_hash.encode('utf8')
-            actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
-            return expected_hash == actual_hash
+            return bcrypt.checkpw(pw.encode('utf8'), expected_hash)
         return False

--- a/docs/tutorials/wiki2/src/models/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/models/tutorial/models/user.py
@@ -19,11 +19,10 @@ class User(Base):
 
     def set_password(self, pw):
         pwhash = bcrypt.hashpw(pw.encode('utf8'), bcrypt.gensalt())
-        self.password_hash = pwhash
+        self.password_hash = pwhash.decode('utf8')
 
     def check_password(self, pw):
         if self.password_hash is not None:
             expected_hash = self.password_hash.encode('utf8')
-            actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
-            return expected_hash == actual_hash
+            return bcrypt.checkpw(pw.encode('utf8'), expected_hash)
         return False

--- a/docs/tutorials/wiki2/src/tests/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/models/user.py
@@ -19,11 +19,10 @@ class User(Base):
 
     def set_password(self, pw):
         pwhash = bcrypt.hashpw(pw.encode('utf8'), bcrypt.gensalt())
-        self.password_hash = pwhash
+        self.password_hash = pwhash.decode('utf8')
 
     def check_password(self, pw):
         if self.password_hash is not None:
             expected_hash = self.password_hash.encode('utf8')
-            actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
-            return expected_hash == actual_hash
+            return bcrypt.checkpw(pw.encode('utf8'), expected_hash)
         return False

--- a/docs/tutorials/wiki2/src/views/tutorial/models/user.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/models/user.py
@@ -19,11 +19,10 @@ class User(Base):
 
     def set_password(self, pw):
         pwhash = bcrypt.hashpw(pw.encode('utf8'), bcrypt.gensalt())
-        self.password_hash = pwhash
+        self.password_hash = pwhash.decode('utf8')
 
     def check_password(self, pw):
         if self.password_hash is not None:
             expected_hash = self.password_hash.encode('utf8')
-            actual_hash = bcrypt.hashpw(pw.encode('utf8'), expected_hash)
-            return expected_hash == actual_hash
+            return bcrypt.checkpw(pw.encode('utf8'), expected_hash)
         return False


### PR DESCRIPTION
Something really weird is happening but this fixes it. SQLAlchemy is
returning the "password_hash" from queries as the type that it was
inserted as. Not consistently unicode or bytes. If I insert bytes, then
I get bytes back out. If I insert unicode then I get unicode back out.
It's unclear why, as the type is Text, the data we're storing is
unambiguously US-ASCII and the connection is using a consistent
text_factory for unicode conversions of "str" on Python 3.

Here, we ensure that we always insert the value as unicode which appears
to fix downstream issues like those mentioned in #2605. I was able to
reproduce that bug and confirm this fixes it if the original database is
initialized using this fix.

Obsoletes #2623.