### PR TITLE
re.split() requires non-empty match

### DIFF
--- a/pyramid/scripts/proutes.py
+++ b/pyramid/scripts/proutes.py
@@ -296,7 +296,7 @@ class PRoutesCommand(object):
             items = config.items('proutes')
             for k, v in items:
                 if 'format' == k:
-                    cols = re.split(r'[,|\s|\n]*', v)
+                    cols = re.split(r'[,|\s\n]+', v)
                     self.column_format = [x.strip() for x in cols]
 
         except configparser.NoSectionError:


### PR DESCRIPTION
Change from a * to a +, so long as there is something to split on, it
will split.

Fixes this warning:

```
FutureWarning: split() requires a non-empty pattern match.
  return _compile(pattern, flags).split(string, maxsplit)
```