### PR TITLE
Fix AuthTktCookieHelper so that it doesn't create bad cookies

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -5,6 +5,7 @@ import hashlib
 import base64
 import re
 import time as time_mod
+import warnings
 
 from zope.interface import implementer
 
@@ -947,8 +948,19 @@ class AuthTktCookieHelper(object):
 
         if encoding_data:
             encoding, encoder = encoding_data
-            userid = encoder(userid)
-            user_data = 'userid_type:%s' % encoding
+        else:
+            warnings.warn(
+                "userid is of type {}, and is not supported by the "
+                "AuthTktAuthenticationPolicy. Explicitly converting to string "
+                "and storing as base64. Subsequent requests will receive a "
+                "string as the userid, it will not be decoded back to the type "
+                "provided.".format(type(userid)), RuntimeWarning
+            )
+            encoding, encoder = self.userid_type_encoders.get(text_type)
+            userid = str(userid)
+
+        userid = encoder(userid)
+        user_data = 'userid_type:%s' % encoding
 
         new_tokens = []
         for token in tokens:


### PR DESCRIPTION
The AuthTktCookieHelper when provided a type it didn't knoww what to do
with would simply pass it through unchanged, this would lead to things
like object() being serialised by just having str() called on it, which
may included spaces and other characters that are not allowed in cookie
values.

WebOb would send a RuntimeWarning:

RuntimeWarning: Cookie value contains invalid bytes: (b'   '). Future
versions will raise ValueError upon encountering invalid bytes.

This fix warns the user of the library directly, and makes sure to
call str() on the provided userid, AND then encode it as base64. The
user won't get back the original object after decoding on a
request/response round-trip, but at least no cookies are being generated
that are invalid.

-----

<details>
<summary>Stack trace from py.test when setting PYTHONWARNINGS=error</summary>
```
=================================================================================================== FAILURES ====================================================================================================
______________________________________________________________________________ TestAuthTktCookieHelper.test_remember_insane_userid ______________________________________________________________________________

self = <pyramid.tests.test_authentication.TestAuthTktCookieHelper testMethod=test_remember_insane_userid>

    def test_remember_insane_userid(self):
        helper = self._makeOne('secret')
        request = self._makeRequest()
        userid = object()
>       result = helper.remember(request, userid)

pyramid/tests/test_authentication.py:1092: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pyramid/authentication.py:980: in remember
    return self._get_cookies(request, cookie_value, max_age)
pyramid/authentication.py:843: in _get_cookies
    headers = profile.get_headers(value, **kw)
../../.ve/pyramid/lib/python3.5/site-packages/webob/cookies.py:745: in get_headers
    httponly=httponly
../../.ve/pyramid/lib/python3.5/site-packages/webob/cookies.py:808: in _get_cookies
    secure=secure,
../../.ve/pyramid/lib/python3.5/site-packages/webob/cookies.py:475: in make_cookie
    return morsel.serialize()
../../.ve/pyramid/lib/python3.5/site-packages/webob/cookies.py:264: in serialize
    add(self.name + b'=' + _value_quote(self.value))
../../.ve/pyramid/lib/python3.5/site-packages/webob/cookies.py:398: in _value_quote
    RuntimeWarning, ValueError, 'Invalid characters in cookie value'
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

text = "Cookie value contains invalid bytes: (b'   '). Future versions will raise ValueError upon encountering invalid bytes.", warn_class = <class 'RuntimeWarning'>, to_raise = <class 'ValueError'>
raise_reason = 'Invalid characters in cookie value'

    def __warn_or_raise(text, warn_class, to_raise, raise_reason):
        if _should_raise:
            raise to_raise(raise_reason)
    
        else:
>           warnings.warn(text, warn_class, stacklevel=2)
E           RuntimeWarning: Cookie value contains invalid bytes: (b'   '). Future versions will raise ValueError upon encountering invalid bytes.

../../.ve/pyramid/lib/python3.5/site-packages/webob/cookies.py:384: RuntimeWarning
```
</details>