### PR TITLE
Adding an invalid UTF-8 sequence in the URL make the server to crash.

### DIFF
--- a/pyramid/tests/test_request.py
+++ b/pyramid/tests/test_request.py
@@ -78,12 +78,20 @@ class TestRequest(unittest.TestCase):
 
     def test_params_decoded_from_utf_8_by_default(self):
         environ = {
-            'PATH_INFO':'/',
-            'QUERY_STRING':'la=La%20Pe%C3%B1a'
-            }
+            'PATH_INFO': '/',
+            'QUERY_STRING': 'la=La%20Pe%C3%B1a'
+        }
         request = self._makeOne(environ)
         request.charset = None
         self.assertEqual(request.GET['la'], text_(b'La Pe\xf1a'))
+
+    def test_params_handle_wrong_utf_8_parameters(self):
+        environ = {
+            'PATH_INFO': '/\x80',
+        }
+        request = self._makeOne(environ)
+        request.charset = None
+        self.assertEqual(request.path, text_(b'/\\x80'))
 
     def test_tmpl_context(self):
         from pyramid.request import TemplateContext


### PR DESCRIPTION
I've got a few website done using Pyramid, Cornice and lately Kinto (the two last ones helps to make great HTTP API's on top of Pyramid)

One of them has got pentested using OpenVAD and we found an error that can make any Pyramid website to crash.

It is not a security exploit except that it can ease DDoS.

**How to reproduce?**

Add the string '%82%AC' in the URL of your Pyramid project and see it fails.