### PR TITLE
remove essentially duplicate "note" section

### DIFF
--- a/docs/tutorials/wiki2/installation.rst
+++ b/docs/tutorials/wiki2/installation.rst
@@ -402,13 +402,6 @@ initialize our database.
    already have a database, you should delete it before running
    ``initialize_tutorial_db`` again.
 
-.. note::
-
-   The ``initialize_tutorial_db`` command is not performing a migration but
-   rather simply creating missing tables and adding some dummy data. If you
-   already have a database, you should delete it before running
-   ``initialize_tutorial_db`` again.
-
 Type the following command, making sure you are still in the ``tutorial``
 directory (the directory with a ``development.ini`` in it):
 


### PR DESCRIPTION
The note section/paragraph under "initializing the database" was entered twice, identical except differing verb tenses. I removed one of the dupes.