### PR TITLE
drop support for python 3.3 and error on 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     include:
         - python: 2.7
           env: TOXENV=py27
-        - python: 3.3
-          env: TOXENV=py33
         - python: 3.4
           env: TOXENV=py34
         - python: 3.5

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -124,10 +124,10 @@ In order to add a feature to Pyramid:
 - The feature must be documented in both the API and narrative
   documentation (in ``docs/``).
 
-- The feature must work fully on the following CPython versions: 2.6, 2.7, 3.2,
-  3.3, 3.4, and 3.5 on both UNIX and Windows.
+- The feature must work fully on the following CPython versions: 2.7, 3.2,
+  3.4, and 3.5 on both UNIX and Windows.
 
-- The feature must work on the latest version of PyPy and PyPy3.
+- The feature must work on the latest version of PyPy.
 
 - The feature must not cause installation or runtime failure on App Engine.
   If it doesn't cause installation or runtime failure, but doesn't actually

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -124,8 +124,8 @@ In order to add a feature to Pyramid:
 - The feature must be documented in both the API and narrative
   documentation (in ``docs/``).
 
-- The feature must work fully on the following CPython versions: 2.7, 3.2,
-  3.4, and 3.5 on both UNIX and Windows.
+- The feature must work fully on the following CPython versions: 2.7, 3.4,
+  and 3.5 on both UNIX and Windows.
 
 - The feature must work on the latest version of PyPy.
 
@@ -199,7 +199,7 @@ Running Tests
 
   Alternately::
 
-   $ tox -e{py26,py27,py32,py33,py34,py35,pypy,pypy3}-scaffolds,
+   $ tox -e{py27,py34,py35,pypy}-scaffolds,
 
 Test Coverage
 -------------

--- a/RELEASING.txt
+++ b/RELEASING.txt
@@ -33,8 +33,8 @@ Prepare new release branch
 
 - Run tests on Windows if feasible.
 
-- Make sure all scaffold tests pass (Py 2.7, 3.3, 3.4, 3.5, and pypy on UNIX;
-  this doesn't work on Windows):
+- Make sure all scaffold tests pass (CPython 2.7, 3.4, and 3.5, and PyPy on
+  UNIX; this doesn't work on Windows):
 
   $ ./scaffoldtests.sh
 

--- a/docs/narr/install.rst
+++ b/docs/narr/install.rst
@@ -21,9 +21,8 @@ the following sections.
 
 .. sidebar:: Python Versions
 
-    As of this writing, :app:`Pyramid` has been tested under Python 2.7,
-    Python 3.3, Python 3.4, Python 3.5, PyPy, and PyPy3. :app:`Pyramid` does
-    not run under any version of Python before 2.7.
+    As of this writing, :app:`Pyramid` is tested against Python 2.7,
+    Python 3.4, Python 3.5, PyPy.
 
 :app:`Pyramid` is known to run on all popular UNIX-like systems such as Linux,
 Mac OS X, and FreeBSD, as well as on Windows platforms.  It is also known to

--- a/docs/narr/introduction.rst
+++ b/docs/narr/introduction.rst
@@ -860,7 +860,7 @@ Every release of Pyramid has 100% statement coverage via unit and integration
 tests, as measured by the ``coverage`` tool available on PyPI.  It also has
 greater than 95% decision/condition coverage as measured by the
 ``instrumental`` tool available on PyPI. It is automatically tested by Travis,
-and Jenkins on Python 2.7, Python 3.3, Python 3.4, Python 3.5, PyPy, and PyPy3
+and Jenkins on Python 2.7, Python 3.4, Python 3.5, and PyPy
 after each commit to its GitHub repository. Official Pyramid add-ons are held
 to a similar testing standard.  We still find bugs in Pyramid and its official
 add-ons, but we've noticed we find a lot more of them while working on other

--- a/docs/quick_tour.rst
+++ b/docs/quick_tour.rst
@@ -52,7 +52,7 @@ For Windows:
     # or for a specific released version
     c:\\> %VENV%\\Scripts\\pip install "pyramid==\ |release|\ "
 
-Of course Pyramid runs fine on Python 2.6+, as do the examples in this *Quick
+Of course Pyramid runs fine on Python 2.7+, as do the examples in this *Quick
 Tour*. We're showing Python 3 for simplicity. (Pyramid had production support
 for Python 3 in October 2011.) Also for simplicity, the remaining examples will
 show only UNIX commands.

--- a/docs/quick_tutorial/requirements.rst
+++ b/docs/quick_tutorial/requirements.rst
@@ -19,7 +19,7 @@ virtual environment.)
 
 This *Quick Tutorial* is based on:
 
-* **Python 3.5**. Pyramid fully supports Python 3.3+ and Python 2.7+. This
+* **Python 3.5**. Pyramid fully supports Python 3.4+ and Python 2.7+. This
   tutorial uses **Python 3.5** but runs fine under Python 2.7.
 
 * **venv**. We believe in virtual environments. For this tutorial, we use

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,15 @@ import sys
 from setuptools import setup, find_packages
 
 py_version = sys.version_info[:2]
-is_pypy = '__pypy__' in sys.builtin_module_names
 
 PY3 = py_version[0] == 3
 
 if PY3:
-    if py_version < (3, 3) and not is_pypy: # PyPy3 masquerades as Python 3.2...
-        raise RuntimeError('On Python 3, Pyramid requires Python 3.3 or better')
+    if py_version < (3, 4):
+        raise RuntimeError('On Python 3, Pyramid requires Python 3.4 or better')
 else:
-    if py_version < (2, 6):
-        raise RuntimeError('On Python 2, Pyramid requires Python 2.6 or better')
+    if py_version < (2, 7):
+        raise RuntimeError('On Python 2, Pyramid requires Python 2.7 or better')
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:
@@ -81,7 +80,6 @@ setup(name='pyramid',
           "Programming Language :: Python",
           "Programming Language :: Python :: 2.7",
           "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.3",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: Implementation :: CPython",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,py36,pypy,
+    py27,py34,py35,py36,pypy,
     docs,pep8,
     {py2,py3}-cover,coverage,
 skip-missing-interpreters = True
@@ -10,7 +10,6 @@ skip-missing-interpreters = True
 # to defaults for others.
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -24,12 +23,6 @@ commands =
 
 [testenv:py27-scaffolds]
 basepython = python2.7
-commands =
-    python pyramid/scaffolds/tests.py
-deps = virtualenv
-
-[testenv:py33-scaffolds]
-basepython = python3.3
 commands =
     python pyramid/scaffolds/tests.py
 deps = virtualenv


### PR DESCRIPTION
closes #2476

I updated setup.py to error on py26 as well since our codebase officially uses some 2.7-only features now.