### PR TITLE
refactor tween initialization to occur at config-time

### DIFF
--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -379,6 +379,7 @@ class Configurator(
         self.add_default_view_predicates()
         self.add_default_view_derivers()
         self.add_default_route_predicates()
+        self.add_default_tweens()
 
         if exceptionresponse_view is not None:
             exceptionresponse_view = self.maybe_dotted(exceptionresponse_view)

--- a/pyramid/config/tweens.py
+++ b/pyramid/config/tweens.py
@@ -10,7 +10,6 @@ from pyramid.compat import (
 from pyramid.exceptions import ConfigurationError
 
 from pyramid.tweens import (
-    excview_tween_factory,
     MAIN,
     INGRESS,
     EXCVIEW,
@@ -107,6 +106,9 @@ class TweensConfiguratorMixin(object):
         return self._add_tween(tween_factory, under=under, over=over,
                                explicit=False)
 
+    def add_default_tweens(self):
+        self.add_tween(EXCVIEW)
+
     @action_method
     def _add_tween(self, tween_factory, under=None, over=None, explicit=False):
 
@@ -142,17 +144,6 @@ class TweensConfiguratorMixin(object):
         if tweens is None:
             tweens = Tweens()
             registry.registerUtility(tweens, ITweens)
-            ex_intr = self.introspectable('tweens',
-                                          ('tween', EXCVIEW, False),
-                                          EXCVIEW,
-                                          'implicit tween')
-            ex_intr['name'] = EXCVIEW
-            ex_intr['factory'] = excview_tween_factory
-            ex_intr['type'] = 'implicit'
-            ex_intr['under'] = None
-            ex_intr['over'] = MAIN
-            introspectables.append(ex_intr)
-            tweens.add_implicit(EXCVIEW, excview_tween_factory, over=MAIN)
 
         def register():
             if explicit:

--- a/pyramid/router.py
+++ b/pyramid/router.py
@@ -34,8 +34,6 @@ from pyramid.traversal import (
     ResourceTreeTraverser,
     )
 
-from pyramid.tweens import excview_tween_factory
-
 @implementer(IRouter)
 class Router(object):
 
@@ -51,11 +49,10 @@ class Router(object):
         self.routes_mapper = q(IRoutesMapper)
         self.request_factory = q(IRequestFactory, default=Request)
         self.request_extensions = q(IRequestExtensions)
-        tweens = q(ITweens)
-        if tweens is None:
-            tweens = excview_tween_factory
         self.orig_handle_request = self.handle_request
-        self.handle_request = tweens(self.handle_request, registry)
+        tweens = q(ITweens)
+        if tweens is not None:
+            self.handle_request = tweens(self.handle_request, registry)
         self.root_policy = self.root_factory # b/w compat
         self.registry = registry
         settings = registry.settings

--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -478,6 +478,7 @@ def setUp(registry=None, request=None, hook_zca=True, autocommit=True,
         config.add_default_view_predicates()
         config.add_default_view_derivers()
         config.add_default_route_predicates()
+        config.add_default_tweens()
     config.commit()
     global have_zca
     try:


### PR DESCRIPTION
previously the EXCVIEW tween was only created in the router OR when
another tween is added. Now the EXCVIEW tween is just added at startup
similar to how view derivers and many other things operate.