### PR TITLE
convert response callbacks into a tween

### DIFF
--- a/docs/api/tweens.rst
+++ b/docs/api/tweens.rst
@@ -7,6 +7,8 @@
 
    .. autofunction:: excview_tween_factory
 
+   .. autofunction:: response_callbacks_tween_factory
+
    .. attribute:: MAIN
 
       Constant representing the main Pyramid handling function, for use in
@@ -21,5 +23,9 @@
    .. attribute:: EXCVIEW
 
       Constant representing the exception view tween, for use in ``under``
-      and ``over`` arguments to
-      :meth:`pyramid.config.Configurator.add_tween`.
+      and ``over`` arguments to :meth:`pyramid.config.Configurator.add_tween`.
+
+   .. attribute:: RESPONSE_CALLBACKS
+
+      Constant representing the response callbacks tween for use in ``under``
+      and ``over`` arguments to :meth:`pyramid.config.Configurator.add_tween`.

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -1249,6 +1249,7 @@ very last tween factory added) as its request handler function.  For example:
 The above example will generate an implicit tween chain that looks like this::
 
     INGRESS (implicit)
+    pyramid.tweens.response_callbacks_tween_factory (implicit)
     myapp.tween_factory2
     myapp.tween_factory1
     pyramid.tweens.excview_tween_factory (implicit)
@@ -1276,6 +1277,7 @@ Allowable values for ``under`` or ``over`` (or both) are:
 
 - one of the constants :attr:`pyramid.tweens.MAIN`,
   :attr:`pyramid.tweens.INGRESS`, or :attr:`pyramid.tweens.EXCVIEW`, or
+  :attr:`pyramid.tweens.RESPONSE_CALLBACKS`, or
 
 - an iterable of any combination of the above. This allows the user to specify
   fallbacks if the desired tween is not included, as well as compatibility
@@ -1296,7 +1298,8 @@ order) the main Pyramid request handler.
 
    import pyramid.tweens
 
-   config.add_tween('myapp.tween_factory', over=pyramid.tweens.MAIN)
+   config.add_tween('myapp.tween_factory',
+                    under=pyramid.tweens.EXCVIEW, over=pyramid.tweens.MAIN)
 
 The above example will generate an implicit tween chain that looks like this::
 
@@ -1315,7 +1318,7 @@ factory "above" the main handler but "below" a separately added tween factory:
    import pyramid.tweens
 
    config.add_tween('myapp.tween_factory1',
-                    over=pyramid.tweens.MAIN)
+                    under=pyramid.tweens.EXCVIEW, over=pyramid.tweens.MAIN)
    config.add_tween('myapp.tween_factory2',
                     over=pyramid.tweens.MAIN,
                     under='myapp.tween_factory1')
@@ -1328,8 +1331,12 @@ The above example will generate an implicit tween chain that looks like this::
     myapp.tween_factory2
     MAIN (implicit)
 
-Specifying neither ``over`` nor ``under`` is equivalent to specifying
-``under=INGRESS``.
+The default value for ``over`` is :attr:`pyramid.tweens.EXCVIEW` and ``under``
+is :attr:`pyramid.tweens.RESPONSE_CALLBACKS`. This places the tween somewhere
+between the two in the tween ordering. If the tween should be placed elsewhere,
+such as under ``EXCVIEW``, then you MUST also specify ``over`` to
+something later in the order (such as ``MAIN``), or a ``CyclicDependencyError``
+will be raised when trying to sort the tweens.
 
 If all options for ``under`` (or ``over``) cannot be found in the current
 configuration, it is an error. If some options are specified purely for

--- a/pyramid/config/util.py
+++ b/pyramid/config/util.py
@@ -4,7 +4,7 @@ import inspect
 from pyramid.compat import (
     bytes_,
     getargspec,
-    is_nonstr_iter
+    is_nonstr_iter,
     )
 
 from pyramid.compat import im_func
@@ -22,6 +22,12 @@ ActionInfo = ActionInfo # support bw compat imports
 
 MAX_ORDER = 1 << 30
 DEFAULT_PHASH = md5().hexdigest()
+
+def as_sorted_tuple(val):
+    if not is_nonstr_iter(val):
+        val = (val,)
+    val = tuple(sorted(val))
+    return val
 
 class not_(object):
     """

--- a/pyramid/request.py
+++ b/pyramid/request.py
@@ -20,6 +20,7 @@ from pyramid.compat import (
     iteritems_,
     )
 
+from pyramid.events import NewResponse
 from pyramid.decorator import reify
 from pyramid.i18n import LocalizerRequestMixin
 from pyramid.response import Response, _get_response_factory
@@ -332,3 +333,12 @@ def apply_request_extensions(request, extensions=None):
 
         InstancePropertyHelper.apply_properties(
             request, extensions.descriptors)
+
+def _execute_response_callbacks(request, response):
+    """ Execute response callbacks and emit a NewResponse event."""
+    registry = request.registry
+    if getattr(request, 'response_callbacks', False):
+        request._process_response_callbacks(response)
+
+    if registry.has_listeners:
+        registry.notify(NewResponse(request, response))

--- a/pyramid/tests/test_config/test_tweens.py
+++ b/pyramid/tests/test_config/test_tweens.py
@@ -14,6 +14,7 @@ class TestTweensConfiguratorMixin(unittest.TestCase):
     def test_add_tweens_names_distinct(self):
         from pyramid.interfaces import ITweens
         from pyramid.tweens import excview_tween_factory
+        from pyramid.tweens import response_callbacks_tween_factory
         def factory1(handler, registry): return handler
         def factory2(handler, registry): return handler
         config = self._makeOne()
@@ -27,6 +28,8 @@ class TestTweensConfiguratorMixin(unittest.TestCase):
         self.assertEqual(
             implicit,
             [
+                ('pyramid.tweens.response_callbacks_tween_factory',
+                 response_callbacks_tween_factory),
                 ('pyramid.tests.test_config.dummy_tween_factory2',
                  dummy_tween_factory2),
                 ('pyramid.tests.test_config.dummy_tween_factory',
@@ -39,6 +42,7 @@ class TestTweensConfiguratorMixin(unittest.TestCase):
     def test_add_tweens_names_with_underover(self):
         from pyramid.interfaces import ITweens
         from pyramid.tweens import excview_tween_factory
+        from pyramid.tweens import response_callbacks_tween_factory
         from pyramid.tweens import MAIN
         config = self._makeOne()
         config.add_tween(
@@ -50,16 +54,39 @@ class TestTweensConfiguratorMixin(unittest.TestCase):
             under='pyramid.tests.test_config.dummy_tween_factory')
         config.commit()
         tweens = config.registry.queryUtility(ITweens)
-        implicit = tweens.implicit()
         self.assertEqual(
-            implicit,
+            tweens.implicit(),
             [
-                ('pyramid.tweens.excview_tween_factory', excview_tween_factory),
+                ('pyramid.tweens.response_callbacks_tween_factory',
+                 response_callbacks_tween_factory),
                 ('pyramid.tests.test_config.dummy_tween_factory',
                  dummy_tween_factory),
                 ('pyramid.tests.test_config.dummy_tween_factory2',
                  dummy_tween_factory2),
-             ])
+                ('pyramid.tweens.excview_tween_factory', excview_tween_factory),
+            ])
+
+    def test_add_tween_default_order(self):
+        from pyramid.interfaces import ITweens
+        from pyramid.tweens import excview_tween_factory
+        from pyramid.tweens import response_callbacks_tween_factory
+        config = self._makeOne()
+        config.add_tween('pyramid.tests.test_config.dummy_tween_factory')
+        config.add_tween('pyramid.tests.test_config.dummy_tween_factory2',
+                         under='pyramid.tests.test_config.dummy_tween_factory')
+        config.commit()
+        tweens = config.registry.queryUtility(ITweens)
+        self.assertEqual(
+            tweens.implicit(),
+            [
+                ('pyramid.tweens.response_callbacks_tween_factory',
+                 response_callbacks_tween_factory),
+                ('pyramid.tests.test_config.dummy_tween_factory',
+                 dummy_tween_factory),
+                ('pyramid.tests.test_config.dummy_tween_factory2',
+                 dummy_tween_factory2),
+                ('pyramid.tweens.excview_tween_factory', excview_tween_factory),
+            ])
 
     def test_add_tweens_names_with_under_nonstringoriter(self):
         from pyramid.exceptions import ConfigurationError
@@ -77,9 +104,30 @@ class TestTweensConfiguratorMixin(unittest.TestCase):
             'pyramid.tests.test_config.dummy_tween_factory',
             over=False)
 
+    def test_add_tweens_names_with_over_nonstriter(self):
+        from pyramid.exceptions import ConfigurationError
+        from pyramid.tweens import MAIN
+        config = self._makeOne()
+        self.assertRaises(
+            ConfigurationError,
+            config.add_tween,
+            'pyramid.tests.test_config.dummy_tween_factory',
+            over=[MAIN, object()])
+
+    def test_add_tweens_names_with_under_nonstriter(self):
+        from pyramid.exceptions import ConfigurationError
+        from pyramid.tweens import INGRESS
+        config = self._makeOne()
+        self.assertRaises(
+            ConfigurationError,
+            config.add_tween,
+            'pyramid.tests.test_config.dummy_tween_factory',
+            under=[INGRESS, object()])
+
     def test_add_tween_dottedname(self):
         from pyramid.interfaces import ITweens
         from pyramid.tweens import excview_tween_factory
+        from pyramid.tweens import response_callbacks_tween_factory
         config = self._makeOne()
         config.add_tween('pyramid.tests.test_config.dummy_tween_factory')
         config.commit()
@@ -87,6 +135,8 @@ class TestTweensConfiguratorMixin(unittest.TestCase):
         self.assertEqual(
             tweens.implicit(),
             [
+                ('pyramid.tweens.response_callbacks_tween_factory',
+                 response_callbacks_tween_factory),
                 ('pyramid.tests.test_config.dummy_tween_factory',
                  dummy_tween_factory),
                 ('pyramid.tweens.excview_tween_factory',

--- a/pyramid/tweens.py
+++ b/pyramid/tweens.py
@@ -6,6 +6,7 @@ from pyramid.interfaces import (
     IExceptionViewClassifier,
     IRequest,
     )
+from pyramid.request import _execute_response_callbacks
 
 from zope.interface import providedBy
 from pyramid.view import _call_view
@@ -65,6 +66,19 @@ def excview_tween_factory(handler, registry):
 
     return excview_tween
 
+def response_callbacks_tween_factory(handler, registry):
+    """ A :term:`tween` factory which produces a tween that processes
+    any response callbacks registered using
+    :meth:`pyramid.request.Request.add_response_callback`.
+
+    """
+    def response_callbacks_tween(request):
+        response = handler(request)
+        _execute_response_callbacks(request, response)
+        return response
+    return response_callbacks_tween
+
 MAIN = 'MAIN'
 INGRESS = 'INGRESS'
 EXCVIEW = 'pyramid.tweens.excview_tween_factory'
+RESPONSE_CALLBACKS = 'pyramid.tweens.response_callbacks_tween_factory'

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -35,12 +35,6 @@ class DottedNameResolver(_DottedNameResolver):
     def __init__(self, package=None): # default to package = None for bw compat
         _DottedNameResolver.__init__(self, package)
 
-def is_string_or_iterable(v):
-    if isinstance(v, string_types):
-        return True
-    if hasattr(v, '__iter__'):
-        return True
-
 def as_sorted_tuple(val):
     if not is_nonstr_iter(val):
         val = (val,)


### PR DESCRIPTION
There is a backward incompatibility here in how tweens are defined. This
is consistent with the new view deriver API but may present some
frustration for anyone currently defining a tween **under** the EXCVIEW
as all tweens now default to **over** the EXCVIEW.

This incompatibility is not strictly required to implement this feature,
but if we don't then:

1) Tween ordering is almost completely dependent on the user's
   environment and sorting behavior. If they add another tween then the
   addon tween (if left unspecified) may be shifted to a bad place.
   This is an issue unrelated to this feature... just a lingering issue with
   tweens.

2) Another incompatibility may surface in which a user's tween would
   show up OVER the response callbacks tween, which would lead to
   inconsistent behavior versus the previous pipeline where callbacks
   were always executed after tweens.

This patch shifts tweens to be more fully specified which should be
generally considered a good thing.

Side note, the response callbacks and excview tweens are defined
with fallbacks incase one of them is overridden or unavailable for some
reason by using a list of dependencies. We should apply this pattern to
the view derivers as well to make them easier to override.

Closes #2622.
