### PR TITLE
make --interactive the default for pcreate

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,12 @@ Backward Incompatibilities
 
    See https://github.com/Pylons/pyramid/pull/2615
 
+- ``pcreate`` is now interactive by default. You will be prompted if it
+  a file already exists with different content. Previously if there were
+  similar files it would silently skip them unless you specified
+  ``--interactive`` or ``--overwrite``.
+  See https://github.com/Pylons/pyramid/pull/2775
+
 Features
 --------
 

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -56,7 +56,9 @@ class PCreateCommand(object):
     parser.add_option('--interactive',
                       dest='interactive',
                       action='store_true',
-                      help='When a file would be overwritten, interrogate')
+                      help='When a file would be overwritten, interrogate '
+                           '(this is the default, but you may specify it to '
+                           'override --overwrite)')
     parser.add_option('--ignore-conflicting-name',
                       dest='force_bad_name',
                       action='store_true',
@@ -70,6 +72,8 @@ class PCreateCommand(object):
     def __init__(self, argv, quiet=False):
         self.quiet = quiet
         self.options, self.args = self.parser.parse_args(argv[1:])
+        if not self.options.interactive and not self.options.overwrite:
+            self.options.interactive = True
         self.scaffolds = self.all_scaffolds()
 
     def run(self):


### PR DESCRIPTION
The current default is to just skip conflicting files. I think this is a better default, and if you want the old behavior you have to type it in at the prompt (`all n`). Instead of skipping I think most people either want interactive or ``--overwrite``.

fixes #1225