### PR TITLE
Add --package-name option to pcreate. 

### DIFF
--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -49,8 +49,9 @@ class PCreateCommand(object):
                       dest='package_name',
                       action='store',
                       type='string',
-                      help='Package name to use. Has to be a valid python '
-                           'package name. (By default package name is derived '
+                      help='Package name to use. Named provided is assumed to '
+                           'be a valid python package name and will not be '
+                           'validated. (By default package name is derived '
                            'from output_directory base folder name)')
     parser.add_option('--simulate',
                       dest='simulate',

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -45,6 +45,13 @@ class PCreateCommand(object):
                       action='store_true',
                       help=("A backwards compatibility alias for -l/--list.  "
                             "List all available scaffold names."))
+    parser.add_option('--package-name',
+                      dest='package_name',
+                      action='store',
+                      type='string',
+                      help='Package name to use. Has to be a valid python '
+                           'package name. (By default package name is derived '
+                           'from output_directory base folder name)')
     parser.add_option('--simulate',
                       dest='simulate',
                       action='store_true',
@@ -99,9 +106,13 @@ class PCreateCommand(object):
     def project_vars(self):
         output_dir = self.output_path
         project_name = os.path.basename(os.path.split(output_dir)[1])
-        pkg_name = _bad_chars_re.sub(
-            '', project_name.lower().replace('-', '_'))
-        safe_name = pkg_resources.safe_name(project_name)
+        if self.options.package_name is None:
+            pkg_name = _bad_chars_re.sub(
+                '', project_name.lower().replace('-', '_'))
+            safe_name = pkg_resources.safe_name(project_name)
+        else:
+            pkg_name = self.options.package_name
+            safe_name = pkg_name
         egg_name = pkg_resources.to_filename(safe_name)
 
         # get pyramid package version

--- a/pyramid/tests/test_scripts/test_pcreate.py
+++ b/pyramid/tests/test_scripts/test_pcreate.py
@@ -80,6 +80,27 @@ class TestPCreateCommand(unittest.TestCase):
             {'project': 'Distro', 'egg': 'Distro', 'package': 'distro',
              'pyramid_version': '0.1', 'pyramid_docs_branch':'0.1-branch'})
 
+    def test_scaffold_with_package_name(self):
+        import os
+        cmd = self._makeOne('-s', 'dummy', '--package-name', 'dummy_package',
+                            'Distro')
+        scaffold = DummyScaffold('dummy')
+        cmd.scaffolds = [scaffold]
+        cmd.pyramid_dist = DummyDist("0.1")
+        result = cmd.run()
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            scaffold.output_dir,
+            os.path.normpath(os.path.join(os.getcwd(), 'Distro'))
+            )
+        self.assertEqual(
+            scaffold.vars,
+            {'project': 'Distro', 'egg': 'dummy_package',
+             'package': 'dummy_package', 'pyramid_version': '0.1',
+             'pyramid_docs_branch':'0.1-branch'})
+
+
     def test_scaffold_with_hyphen_in_project_name(self):
         import os
         cmd = self._makeOne('-s', 'dummy', 'Distro-')


### PR DESCRIPTION
This solves the problem of scaffold creating an existing directory where the package created should not be named after the base folder. For example if I am in I run pcreate in ~/code/trypyramid.com and
would like to create package called tpc this is currently impossible. This solves the issues by allowing me to specify the package name on the command line.

Note: I'll add changelog changes post review