### PR TITLE
fix pserve to work with gevent workers

### DIFF
--- a/pyramid/paster.py
+++ b/pyramid/paster.py
@@ -5,9 +5,8 @@ from paste.deploy import (
     appconfig,
     )
 
-from pyramid.compat import configparser
-from logging.config import fileConfig
 from pyramid.scripting import prepare
+from pyramid.scripts.common import setup_logging  # noqa, api
 
 def get_app(config_uri, name=None, options=None, loadapp=loadapp):
     """ Return the WSGI application named ``name`` in the PasteDeploy
@@ -51,30 +50,6 @@ def get_appsettings(config_uri, name=None, options=None, appconfig=appconfig):
         name=section,
         relative_to=here_dir,
         global_conf=options)
-
-def setup_logging(config_uri, global_conf=None,
-                  fileConfig=fileConfig,
-                  configparser=configparser):
-    """
-    Set up logging via :func:`logging.config.fileConfig` with the filename
-    specified via ``config_uri`` (a string in the form
-    ``filename#sectionname``).
-
-    ConfigParser defaults are specified for the special ``__file__``
-    and ``here`` variables, similar to PasteDeploy config loading.
-    Extra defaults can optionally be specified as a dict in ``global_conf``.
-    """
-    path, _ = _getpathsec(config_uri, None)
-    parser = configparser.ConfigParser()
-    parser.read([path])
-    if parser.has_section('loggers'):
-        config_file = os.path.abspath(path)
-        full_global_conf = dict(
-            __file__=config_file,
-            here=os.path.dirname(config_file))
-        if global_conf:
-            full_global_conf.update(global_conf)
-        return fileConfig(config_file, full_global_conf)
 
 def _getpathsec(config_uri, name):
     if '#' in config_uri:

--- a/pyramid/scripts/common.py
+++ b/pyramid/scripts/common.py
@@ -17,20 +17,26 @@ def parse_vars(args):
         result[name] = value
     return result
 
-def logging_file_config(config_file, fileConfig=fileConfig,
-                        configparser=configparser):
+def setup_logging(config_uri, global_conf=None,
+                  fileConfig=fileConfig,
+                  configparser=configparser):
     """
-    Setup logging via the logging module's fileConfig function with the
-    specified ``config_file``, if applicable.
+    Set up logging via :func:`logging.config.fileConfig` with the filename
+    specified via ``config_uri`` (a string in the form
+    ``filename#sectionname``).
 
     ConfigParser defaults are specified for the special ``__file__``
     and ``here`` variables, similar to PasteDeploy config loading.
+    Extra defaults can optionally be specified as a dict in ``global_conf``.
     """
+    path = config_uri.split('#', 1)[0]
     parser = configparser.ConfigParser()
-    parser.read([config_file])
+    parser.read([path])
     if parser.has_section('loggers'):
-        config_file = os.path.abspath(config_file)
-        return fileConfig(
-            config_file,
-            dict(__file__=config_file, here=os.path.dirname(config_file))
-            )
+        config_file = os.path.abspath(path)
+        full_global_conf = dict(
+            __file__=config_file,
+            here=os.path.dirname(config_file))
+        if global_conf:
+            full_global_conf.update(global_conf)
+        return fileConfig(config_file, full_global_conf)

--- a/pyramid/scripts/prequest.py
+++ b/pyramid/scripts/prequest.py
@@ -5,8 +5,9 @@ import textwrap
 
 from pyramid.compat import url_unquote
 from pyramid.request import Request
-from pyramid.paster import get_app, setup_logging
+from pyramid.paster import get_app
 from pyramid.scripts.common import parse_vars
+from pyramid.scripts.common import setup_logging
 
 def main(argv=sys.argv, quiet=False):
     command = PRequestCommand(argv, quiet)

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -30,9 +30,8 @@ from paste.deploy.loadwsgi import loadcontext, SERVER
 from pyramid.compat import PY2
 from pyramid.compat import WIN
 
-from pyramid.paster import setup_logging
-
 from pyramid.scripts.common import parse_vars
+from pyramid.scripts.common import setup_logging
 
 MAXFD = 1024
 

--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -10,11 +10,10 @@ from pyramid.compat import exec_
 from pyramid.util import DottedNameResolver
 from pyramid.paster import bootstrap
 
-from pyramid.paster import setup_logging
-
 from pyramid.settings import aslist
 
 from pyramid.scripts.common import parse_vars
+from pyramid.scripts.common import setup_logging
 
 def main(argv=sys.argv, quiet=False):
     command = PShellCommand(argv, quiet)

--- a/pyramid/tests/test_scripts/test_common.py
+++ b/pyramid/tests/test_scripts/test_common.py
@@ -1,21 +1,4 @@
-import os
 import unittest
-
-class Test_logging_file_config(unittest.TestCase):
-    def _callFUT(self, config_file):
-        from pyramid.scripts.common import logging_file_config
-        dummy_cp = DummyConfigParserModule
-        return logging_file_config(config_file, self.fileConfig, dummy_cp)
-
-    def test_it(self):
-        config_file, dict = self._callFUT('/abc')
-        # use of os.path.abspath here is a sop to Windows
-        self.assertEqual(config_file, os.path.abspath('/abc'))
-        self.assertEqual(dict['__file__'], os.path.abspath('/abc'))
-        self.assertEqual(dict['here'], os.path.abspath('/'))
-
-    def fileConfig(self, config_file, dict):
-        return config_file, dict
 
 class TestParseVars(unittest.TestCase):
     def test_parse_vars_good(self):
@@ -28,16 +11,3 @@ class TestParseVars(unittest.TestCase):
         from pyramid.scripts.common import parse_vars
         vars = ['a']
         self.assertRaises(ValueError, parse_vars, vars)
-
-
-class DummyConfigParser(object):
-    def read(self, x):
-        pass
-
-    def has_section(self, name):
-        return True
-
-class DummyConfigParserModule(object):
-    ConfigParser = DummyConfigParser
-
-


### PR DESCRIPTION
- refactored code to remove ``pyramid.threadlocal`` from pserve's import
  tree. It was coming from the ``pyramid.paster`` module which imports
  ``pyramid.scripting`` which imports ``pyramid.threadlocal``.

- dropped ``pyramid.scripts.common.logging_file_config`` as it appears
  to be unused and almost identical to ``setup_logging`` except
  without ``global_conf`` support.

It's super finicky but basically when using a `[server:main]` with `use = egg:gunicorn` with a worker of gevent, it's necessary to monkeypatch threading modules, etc. Before this patch, the import tree caused `pyramid.threadlocal` to be imported into other modules which triggers configuring the threadlocal manager using the current threading module **before** the server/app have an opportunity to patch the threading module.

Without this patch people who have been using greenlet-based workers from `[server:main]` have probably been broken in any code that uses `get_current_request` or `get_current_registry`.

related https://github.com/Pylons/pyramid/issues/1125 https://github.com/benoitc/gunicorn/issues/737