### PR TITLE
Fix typo in docstring for check_csrf_token

### DIFF
--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -215,7 +215,7 @@ def check_csrf_token(request,
     supplied by ``request.session.get_csrf_token()``, and ``raises`` is
     ``True``, this function will raise an
     :exc:`pyramid.exceptions.BadCSRFToken` exception.
-    If the check does succeed and ``raises`` is ``False``, this
+    If the check does not succeed and ``raises`` is ``False``, this
     function will return ``False``.  If the CSRF check is successful, this
     function will return ``True`` unconditionally.
 


### PR DESCRIPTION
This same typo appears to exist in all branches from 1.4 onward
