### PR TITLE
Avoid setting Content-Encoding header for static view responses.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -97,6 +97,11 @@ Bug Fixes
   from previous orders have executed.
   See https://github.com/Pylons/pyramid/pull/2757
 
+- Fix static view to avoid setting the ``Content-Encoding`` response header
+  to an encoding guessed using Python's ``mimetypes`` module.
+  This was causing clients to decode the content of gzipped files
+  when downloading them.
+
 Deprecations
 ------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -101,6 +101,7 @@ Bug Fixes
   to an encoding guessed using Python's ``mimetypes`` module.
   This was causing clients to decode the content of gzipped files
   when downloading them.
+  See https://github.com/Pylons/pyramid/pull/2810
 
 Deprecations
 ------------

--- a/pyramid/response.py
+++ b/pyramid/response.py
@@ -54,16 +54,7 @@ class FileResponse(Response):
     def __init__(self, path, request=None, cache_max_age=None,
                  content_type=None, content_encoding=None):
         if content_type is None:
-            content_type, content_encoding = mimetypes.guess_type(
-                path,
-                strict=False
-                )
-            if content_type is None:
-                content_type = 'application/octet-stream'
-            # str-ifying content_type is a workaround for a bug in Python 2.7.7
-            # on Windows where mimetypes.guess_type returns unicode for the
-            # content_type.
-            content_type = str(content_type)
+            content_type, content_encoding = _guess_type(path)
         super(FileResponse, self).__init__(
             conditional_response=True,
             content_type=content_type,
@@ -180,3 +171,17 @@ def _get_response_factory(registry):
     )
 
     return response_factory
+
+
+def _guess_type(path):
+    content_type, content_encoding = mimetypes.guess_type(
+        path,
+        strict=False
+        )
+    if content_type is None:
+        content_type = 'application/octet-stream'
+    # str-ifying content_type is a workaround for a bug in Python 2.7.7
+    # on Windows where mimetypes.guess_type returns unicode for the
+    # content_type.
+    content_type = str(content_type)
+    return content_type, content_encoding

--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -32,7 +32,12 @@ from pyramid.httpexceptions import (
     )
 
 from pyramid.path import caller_package
-from pyramid.response import FileResponse
+
+from pyramid.response import (
+    _guess_type,
+    FileResponse,
+)
+
 from pyramid.traversal import traversal_path_info
 
 slash = text_('/')
@@ -134,7 +139,10 @@ class static_view(object):
             if not exists(filepath):
                 raise HTTPNotFound(request.url)
 
-        return FileResponse(filepath, request, self.cache_max_age)
+        content_type, content_encoding = _guess_type(filepath)
+        return FileResponse(
+            filepath, request, self.cache_max_age,
+            content_type, content_encoding=None)
 
     def add_slash_redirect(self, request):
         url = request.path_url + '/'

--- a/pyramid/tests/test_static.py
+++ b/pyramid/tests/test_static.py
@@ -186,14 +186,14 @@ class Test_static_view_use_subpath_False(unittest.TestCase):
         from pyramid.httpexceptions import HTTPNotFound
         self.assertRaises(HTTPNotFound, inst, context, request)
 
-    def test_resource_with_content_encoding(self):
+    def test_gz_resource_no_content_encoding(self):
         inst = self._makeOne('pyramid.tests:fixtures/static')
         request = self._makeRequest({'PATH_INFO':'/arcs.svg.tgz'})
         context = DummyContext()
         response = inst(context, request)
         self.assertEqual(response.status, '200 OK')
         self.assertEqual(response.content_type, 'application/x-tar')
-        self.assertEqual(response.content_encoding, 'gzip')
+        self.assertEqual(response.content_encoding, None)
         response.app_iter.close()
 
     def test_resource_no_content_encoding(self):


### PR DESCRIPTION
This was causing clients to decode the content of gzipped files when downloading them.

We discussed this on IRC and @mmerickel pointed out that it may be a goal in some cases to serve gzipped precompiled assets (i.e. CSS/Javascript) with this header. But that's a new feature that would require thought about how to specify which files to serve that way. And it can already be
implemented for a project using a tween. This just aims to fix the existing use case of serving files for download.