### PR TITLE
Fix flake8 failures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,10 @@ ignore =
     E302,
     # E303: too many blank lines (3)
     E303,
+    # E305: expected 2 blank lines after class or function definition, found 1
+    E305,
+    # E306: expected 1 blank line before a nested definition, found 0
+    E306,
     # E501: line too long (82 > 79 characters)
     E501,
     # E731: do not assign a lambda expression, use a def

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,48 @@ docs = develop easy_install pyramid[docs]
 universal = 1
 
 [flake8]
-ignore = E301,E302,E731,E261,E123,E121,E128,E129,E125,W291,E501,W293,E303,W391,E266,E231,E201,E202,E127,E262,E265
+ignore =
+    # E121: continuation line under-indented for hanging indent
+    E121,
+    # E123: closing bracket does not match indentation of opening bracket's line
+    E123,
+    # E125: continuation line with same indent as next logical line
+    E125,
+    # E127: continuation line over-indented for visual indent
+    E127,
+    # E128: continuation line under-indented for visual indent
+    E128,
+    # E129: visually indented line with same indent as next logical line
+    E129,
+    # E201: whitespace after ‘(‘
+    E201,
+    # E202: whitespace before ‘)’
+    E202,
+    # E231: missing whitespace after ‘,’, ‘;’, or ‘:’
+    E231,
+    # E261: at least two spaces before inline comment
+    E261,
+    # E262: inline comment should start with ‘# ‘
+    E262,
+    # E265: block comment should start with ‘# ‘
+    E265,
+    # E266: too many leading ‘#’ for block comment
+    E266,
+    # E301: expected 1 blank line, found 0
+    E301,
+    # E302: expected 2 blank lines, found 0
+    E302,
+    # E303: too many blank lines (3)
+    E303,
+    # E501: line too long (82 > 79 characters)
+    E501,
+    # E731: do not assign a lambda expression, use a def
+    E731,
+    # W291: trailing whitespace
+    W291,
+    # W293: blank line contains whitespace
+    W293,
+    # W391: blank line at end of file
+    W391
 exclude = pyramid/tests/,pyramid/compat.py,pyramid/resource.py
 show-source = True


### PR DESCRIPTION
Flake 3.1, released today, caused previously-overlooked E305 and E306 errors to trip.  This PR annotates the excluded codes, and adds those two explicitly.