### PR TITLE
Strip allegedly-smart quotes in comments.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,19 +27,19 @@ ignore =
     E128,
     # E129: visually indented line with same indent as next logical line
     E129,
-    # E201: whitespace after ‘(‘
+    # E201: whitespace after '('
     E201,
-    # E202: whitespace before ‘)’
+    # E202: whitespace before ')'
     E202,
-    # E231: missing whitespace after ‘,’, ‘;’, or ‘:’
+    # E231: missing whitespace after ',', ';', or ':'
     E231,
     # E261: at least two spaces before inline comment
     E261,
-    # E262: inline comment should start with ‘# ‘
+    # E262: inline comment should start with '# '
     E262,
-    # E265: block comment should start with ‘# ‘
+    # E265: block comment should start with '# '
     E265,
-    # E266: too many leading ‘#’ for block comment
+    # E266: too many leading '#' for block comment
     E266,
     # E301: expected 1 blank line, found 0
     E301,


### PR DESCRIPTION
They break installing on a `LANG=C` system.