### PR TITLE
Fix AttributeError: tm inactive for request or accessed above tm tween

### DIFF
--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -119,6 +119,11 @@ class PShellCommand(object):
         # bootstrap the environ
         env = self.bootstrap[0](config_uri, options=parse_vars(self.args[1:]))
 
+        # override environ if needed
+        env['request'].environ.update({
+            'tm.active': True
+        })
+
         # remove the closer from the env
         self.closer = env.pop('closer')
 


### PR DESCRIPTION
Fix the following issue:

```
~/code/projects/amnesia/ pshell development.ini
Python 3.4.5 (default, Jun 29 2016, 19:14:11) 
[GCC 4.2.1 Compatible FreeBSD Clang 3.4.1 (tags/RELEASE_34/dot1-final 208032)] on freebsd10
Type "help" for more information.

Environment:
  app          The WSGI application.
  registry     Active Pyramid registry.
  request      Active request object.
  root         Root of the default resource tree.
  root_factory Default root factory used to create `root`.

>>> from amnesia.modules import folder
>>> request.dbsession.query(folder.Folder).get(1)
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/home/jcigar/code/venvs/amnesia/lib/python3.4/site-packages/pyramid/decorator.py", line 42, in __get__
    val = self.wrapped(inst)
  File "/usr/home/jcigar/code/venvs/amnesia/lib/python3.4/site-packages/pyramid/util.py", line 67, in <lambda>
    fn = lambda this: callable(this)
  File "/usr/home/jcigar/code/projects/amnesia/amnesia/db/__init__.py", line 88, in <lambda>
    lambda r: get_tm_session(session_factory, r.tm),
  File "/usr/home/jcigar/code/venvs/amnesia/lib/python3.4/site-packages/pyramid/decorator.py", line 42, in __get__
    val = self.wrapped(inst)
  File "/usr/home/jcigar/code/venvs/amnesia/lib/python3.4/site-packages/pyramid/util.py", line 67, in <lambda>
    fn = lambda this: callable(this)
  File "/usr/home/jcigar/code/venvs/amnesia/lib/python3.4/site-packages/pyramid_tm/__init__.py", line 118, in create_tm
    raise AttributeError('tm inactive for request or accessed above tm '
AttributeError: tm inactive for request or accessed above tm tween
```