### PR TITLE
sanitize the url printed on the 404 Not Found to fix a XSS flaw

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -258,3 +258,5 @@ Contributors
 - Rami Chousein, 2015/10/28
 
 - Sri Sanketh Uppalapati, 2015/12/12
+
+- Bastien Gérard, 2016/11/23

--- a/pyramid/router.py
+++ b/pyramid/router.py
@@ -22,6 +22,7 @@ from pyramid.events import (
     NewResponse,
     )
 
+from pyramid.encode import url_quote
 from pyramid.httpexceptions import HTTPNotFound
 from pyramid.request import Request
 from pyramid.view import _call_view
@@ -34,6 +35,7 @@ from pyramid.traversal import (
     )
 
 from pyramid.tweens import excview_tween_factory
+
 
 @implementer(IRouter)
 class Router(object):
@@ -158,7 +160,7 @@ class Router(object):
                     )
                 logger and logger.debug(msg)
             else:
-                msg = request.path_info
+                msg = url_quote(request.path_info, safe='/')
             raise HTTPNotFound(msg)
 
         return response
@@ -172,18 +174,18 @@ class Router(object):
         :term:`tween` in the tween stack closest to the request ingress.  If
         ``use_tweens`` is ``False``, the request will be sent to the main
         router handler, and no tweens will be invoked.
-        
+
         See the API for pyramid.request for complete documentation.
         """
         registry = self.registry
         has_listeners = self.registry.has_listeners
         notify = self.registry.notify
-        threadlocals = {'registry':registry, 'request':request}
+        threadlocals = {'registry': registry, 'request': request}
         manager = self.threadlocal_manager
         manager.push(threadlocals)
         request.registry = registry
         request.invoke_subrequest = self.invoke_subrequest
-        
+
         if use_tweens:
             handle_request = self.handle_request
         else:
@@ -201,7 +203,7 @@ class Router(object):
                     request._process_response_callbacks(response)
 
                 has_listeners and notify(NewResponse(request, response))
-                
+
                 return response
 
             finally:

--- a/pyramid/tests/test_router.py
+++ b/pyramid/tests/test_router.py
@@ -281,6 +281,17 @@ class TestRouter(unittest.TestCase):
         self.assertTrue("view_name: ''" in message)
         self.assertTrue("subpath: []" in message)
 
+    def test_call_no_view_registered_debug_notfound_false_quote_url(self):
+        from pyramid.httpexceptions import HTTPNotFound
+        environ = self._makeEnviron(PATH_INFO="/<script>alert('hello world')</script>")
+        context = DummyContext()
+        self._registerTraverserFactory(context)
+        self._registerSettings(debug_notfound=False)
+        router = self._makeOne()
+        start_response = DummyStartResponse()
+        why = exc_raised(HTTPNotFound, router, environ, start_response)
+        self.assertEqual('/%3Cscript%3Ealert%28%27hello%20world%27%29%3C/script%3E', why.args[0])
+
     def test_call_view_returns_non_iresponse(self):
         from pyramid.interfaces import IViewClassifier
         context = DummyContext()
@@ -852,7 +863,7 @@ class TestRouter(unittest.TestCase):
         # https://github.com/Pylons/pyramid/issues/1223)
         self.assertEqual(request.exception, error)
         self.assertEqual(request.exc_info[:2], (RuntimeError, error,))
-        
+
     def test_call_view_raises_exception_view(self):
         from pyramid.interfaces import IViewClassifier
         from pyramid.interfaces import IExceptionViewClassifier
@@ -978,7 +989,7 @@ class TestRouter(unittest.TestCase):
         environ = self._makeEnviron()
         response = DummyResponse()
         view = DummyView(response, raise_exception=RuntimeError)
-        
+
         self._registerView(self.config.derive_view(view), '',
                            IViewClassifier, IRequest, None)
         exception_view = DummyView(None)
@@ -1317,7 +1328,7 @@ class DummyResponse(object):
         self.environ = environ
         start_response(self.status, self.headerlist)
         return self.app_iter
-    
+
 class DummyThreadLocalManager:
     def __init__(self):
         self.pushed = []
@@ -1328,7 +1339,7 @@ class DummyThreadLocalManager:
 
     def pop(self):
         self.popped.append(True)
-    
+
 class DummyAuthenticationPolicy:
     pass
 
@@ -1348,4 +1359,4 @@ def exc_raised(exc, func, *arg, **kw):
     else:
         raise AssertionError('%s not raised' % exc) # pragma: no cover
 
-    
+


### PR DESCRIPTION
A recent vulnerability scan (qualys) detected that the default 404 page returned by pyramid when a request is done on an unknown route is printing the url provided in input in the html.

E.g: calling /<script>alert('hello')</script>
returns:
```
404 Not Found
The resource could not be found.
/<script>alert('hello')</script>
```
This represents an xss flaw, my suggestion is to sanitize the url before returning it, by using urllib.quote to sanitize the url