### PR TITLE
Warning: view derivers only take effect for view configured afterwards

### DIFF
--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -1772,6 +1772,11 @@ View derivers are unique in that they have access to most of the options
 passed to :meth:`pyramid.config.Configurator.add_view` in order to decide what
 to do, and they have a chance to affect every view in the application.
 
+.. warning::
+
+Only views which are added to the configuration *after* a view deriver has been
+added will be derived by it.
+
 .. _exception_view_derivers:
 
 Exception Views and View Derivers

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -1774,8 +1774,8 @@ to do, and they have a chance to affect every view in the application.
 
 .. warning::
 
-Only views which are added to the configuration *after* a view deriver has been
-added will be derived by it.
+    Only views which are added to the configuration *after* a view deriver has been
+    added will be derived by it.
 
 .. _exception_view_derivers:
 


### PR DESCRIPTION
I ran into this because I had assumed Pyramid maintains a chain of view derivers in its config that is applied whenever a view is called. Actually, the chain is made and configured to be used by a view at the time that this view is added to the config - with whatever view derivers are known at that time.