### PR TITLE
only warn about py33, do not error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,19 +14,21 @@
 
 import os
 import sys
+import warnings
 
 from setuptools import setup, find_packages
 
 py_version = sys.version_info[:2]
 
-PY3 = py_version[0] == 3
+PY2 = py_version[0] == 2
 
-if PY3:
-    if py_version < (3, 4):
-        raise RuntimeError('On Python 3, Pyramid requires Python 3.4 or better')
-else:
-    if py_version < (2, 7):
-        raise RuntimeError('On Python 2, Pyramid requires Python 2.7 or better')
+if (3, 0) <= py_version < (3, 4):
+    warnings.warn(
+        'On Python 3, Pyramid only supports Python 3.4 or better',
+        UserWarning,
+    )
+elif py_version < (2, 7):
+    raise RuntimeError('On Python 2, Pyramid requires Python 2.7 or better')
 
 here = os.path.abspath(os.path.dirname(__file__))
 try:
@@ -53,7 +55,7 @@ tests_require = [
     'WebTest >= 1.3.1', # py3 compat
     ]
 
-if not PY3:
+if PY2:
     tests_require.append('zope.component>=3.11.0')
 
 docs_extras = [


### PR DESCRIPTION
This is squashed by pip unfortunately but it's better than a hard error since we aren't currently using any py34-specific features that break py33.

There are some alternatives because setuptools added support for `Requires-Python` [1]. However, the support was only added to setuptools 24.2.1 on 2016-07-21. Also support for reading the constraints was only added to pip in 9.0 on 2016-11-02.

1) I'm not sure it's compelling enough right now to lock pyramid to building with setuptools > 24, but I could easily be persuaded.

2) We could do version detection of setuptools in `setup.py` and add the metadata if possible. It looks like `setuptools.__version__` exists, or we could import `pkg_resources`.

3) Just stick with this warning that is squashed and no one will see unless they're using running `setup.py` manually themselves.

[1] https://www.python.org/dev/peps/pep-0345/#requires-python