### PR TITLE
A helper for quick starting a simple Pyramid app

### DIFF
--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -329,6 +329,13 @@ class Configurator(
                 exceptionresponse_view=exceptionresponse_view,
                 )
 
+    def run_app(self, host='localhost', port=8080, **kwargs):
+        from wsgiref.simple_server import make_server
+        app = self.make_wsgi_app()
+        server = make_server(host, port, app, **kwargs)
+        print('Running on http://{}:{} (stop with Ctrl-C)'.format(host, port))
+        server.serve_forever()
+
     def setup_registry(self,
                        settings=None,
                        root_factory=None,

--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -329,11 +329,15 @@ class Configurator(
                 exceptionresponse_view=exceptionresponse_view,
                 )
 
-    def run_app(self, host='localhost', port=8080, **kwargs):
+    def run_app(self, host='localhost', port=8080):
+        """ Helper method to quickly run a development server listening on ``host`` and ``port``."""
         from wsgiref.simple_server import make_server
         app = self.make_wsgi_app()
-        server = make_server(host, port, app, **kwargs)
+        server = make_server(host, port, app)
         print('Running on http://{}:{} (stop with Ctrl-C)'.format(host, port))
+        docs_link = 'http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/project.html#using-an-alternate-wsgi-server'
+        print('This is running on wsgiref server and is not appropriate for production' \
+              'please see: {}'.format(docs_link))
         server.serve_forever()
 
     def setup_registry(self,

--- a/pyramid/tests/test_config/test_init.py
+++ b/pyramid/tests/test_config/test_init.py
@@ -1996,3 +1996,23 @@ class DummyIntrospectable(object):
         
 class DummyPredicate(object):
     pass
+
+class TestRunAppHelper(unittest.TestCase):
+
+    def test_run_app(self):
+        from pyramid.config import Configurator
+        from pyramid.response import Response
+
+        self.running = False
+        # Mocks wsgiref's serve_forever method
+        def serve_forever_mock(*args, **kwargs):
+            self.running = True
+
+        from wsgiref.simple_server import WSGIServer
+        WSGIServer.serve_forever = serve_forever_mock
+
+        config = Configurator()
+
+        config.run_app()
+        self.assertTrue(self.running)
+


### PR DESCRIPTION
When comparing the Flask and Pyramid quick start example,
it is obvious that we could significantly simplify Pyramid’s one
by having a method such as this.

Consider the following examples:

BEFORE
```python
from wsgiref.simple_server import make_server
from pyramid.config import Configurator
from pyramid.view import view_config

@view_config(route_name='hello', renderer='string')
def hello_world(request):
    return {'content': 'Hello World!'}

if __name__ == '__main__':
    config = Configurator()
    config.add_route('hello', '/')
    config.scan()
    app = config.make_wsgi_app()
    server = make_server('0.0.0.0', 8080, app)
    server.serve_forever()
```

AFTER
```python
from pyramid.config import Configurator
from pyramid.view import view_config

@view_config(route_name='hello', renderer='string')
def hello_world(request):
    return {'content': 'Hello World!'}

if __name__ == '__main__':
    config = Configurator()
    config.add_route('hello', '/')
    config.scan()
    config.run_app()
```

Such a helper makes writing simple tutorials more, well, simple.