### PR TITLE
Fix docs for Sphinx 1.5

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -286,3 +286,5 @@ Contributors
 - Keith Yang, 2016/07/22
 
 - Moriyoshi Koizumi, 2016/11/20
+
+- Mikko Ohtamaa, 2016/12/6

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ latex_documents = [
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-latex_use_parts = True
+latex_toplevel_sectioning = "section"
 
 # If false, no module index is generated.
 latex_use_modindex = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,7 +194,7 @@ latex_documents = [
 latex_toplevel_sectioning = "section"
 
 # If false, no module index is generated.
-latex_use_modindex = False
+latex_domain_indices = False
 
 ## Say, for a moment that you have a twoside document that needs a 3cm
 ## inner margin to allow for binding and at least two centimetres the

--- a/pyramid/config/util.py
+++ b/pyramid/config/util.py
@@ -4,8 +4,7 @@ import inspect
 from pyramid.compat import (
     bytes_,
     getargspec,
-    is_nonstr_iter,
-    string_types,
+    is_nonstr_iter
     )
 
 from pyramid.compat import im_func


### PR DESCRIPTION
Sphinx 1.5 changes configuration file format. Docs tests won't run anymore until this change.

https://travis-ci.org/Pylons/pyramid/jobs/181607736

http://www.sphinx-doc.org/en/1.4.8/config.html#confval-latex_toplevel_sectioning