### PR TITLE
Fix pluralization in default domain for non-germanic languages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -149,6 +149,11 @@ Bug Fixes
   from previous orders have executed.
   See https://github.com/Pylons/pyramid/pull/2757
 
+- Fix bug in i18n where the default domain would always use the Germanic plural
+  style, even if a different plural function is defined in the relevant messages
+  file.
+  See https://github.com/Pylons/pyramid/pull/2102
+
 Deprecations
 ------------
 

--- a/pyramid/tests/test_i18n.py
+++ b/pyramid/tests/test_i18n.py
@@ -357,6 +357,36 @@ class TestTranslations(unittest.TestCase):
         inst.add(inst2)
         self.assertEqual(inst._catalog['a'], 'b')
 
+    def test_add_default_domain_replaces_plural_first_time(self):
+        # Create three empty message catalogs in the default domain
+        inst = self._getTargetClass()(None, domain='messages')
+        inst2 = self._getTargetClass()(None, domain='messages')
+        inst3 = self._getTargetClass()(None, domain='messages')
+        inst._catalog = {}
+        inst2._catalog = {}
+        inst3._catalog = {}
+
+        # The default plural scheme is the germanic one
+        self.assertEqual(inst.plural(0), 1)
+        self.assertEqual(inst.plural(1), 0)
+        self.assertEqual(inst.plural(2), 1)
+
+        # inst2 represents a message file that declares french plurals
+        inst2.plural = lambda n: n > 1
+        inst.add(inst2)
+        # that plural rule should now apply to inst
+        self.assertEqual(inst.plural(0), 0)
+        self.assertEqual(inst.plural(1), 0)
+        self.assertEqual(inst.plural(2), 1)
+
+        # We load a second message file with different plural rules
+        inst3.plural = lambda n: n > 0
+        inst.add(inst3)
+        # It doesn't override the previously loaded rule
+        self.assertEqual(inst.plural(0), 0)
+        self.assertEqual(inst.plural(1), 0)
+        self.assertEqual(inst.plural(2), 1)
+
     def test_dgettext(self):
         t = self._makeOne()
         self.assertEqual(t.dgettext('messages', 'foo'), 'Voh')


### PR DESCRIPTION
This is a reimplementation of PR #2102 which is less invasive and tracks the bug to its original location.

When loading a new `.mo` file, Pyramid checks if the domain already exists, and if so it merges the new catalog into the old one. It does not update the `plural` function when this happens, as it's assumed that it is consistent inside a domain.

The default domain is a special case, as it contains the other domains in a dictionary, so it is created ahead of time with an empty catalog, and the default pluralisation rule from #235. As all other files in the `messages` domain will be merged to this catalog, the plural rule is never overwritten.

This change introduces a flag to state if the default plural from #235 has been overridden. When merging two translations it checks if the domain is the default domain, and if the flag isn't set it replaces the `plural` lambda expression with the gettext generated one and sets the flag.