### PR TITLE
defer config.add_translation_dirs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -140,6 +140,29 @@ Features
   ``--help`` output as well as enabling nicer documentation of their options.
   See https://github.com/Pylons/pyramid/pull/2864
 
+- Any deferred configuration action registered via ``config.action`` may now
+  depend on threadlocal state, such as asset overrides, being active when
+  the action is executed.
+  See https://github.com/Pylons/pyramid/pull/2873
+
+- Asset specifications for directories passed to
+  ``config.add_translation_dirs`` now support overriding the entire asset
+  specification, including the folder name. Previously only the package name
+  was supported and the folder would always need to have the same name.
+  See https://github.com/Pylons/pyramid/pull/2873
+
+- ``config.begin()`` will propagate the current threadlocal request through
+  as long as the registry is the same. For example:
+
+  .. code-block:: python
+
+     request = Request.blank(...)
+     config.begin(request)  # pushes a request
+     config.begin()         # propagates the previous request through unchanged
+     assert get_current_request() is request
+
+  See https://github.com/Pylons/pyramid/pull/2873
+
 Bug Fixes
 ---------
 
@@ -173,6 +196,11 @@ Bug Fixes
 - Fix bug in i18n where the default domain would always use the Germanic plural
   style, even if a different plural function is defined in the relevant
   messages file. See https://github.com/Pylons/pyramid/pull/2859
+
+- The ``config.override_asset`` method now occurs during
+  ``pyramid.config.PHASE1_CONFIG`` such that it is ordered to execute before
+  any calls to ``config.add_translation_dirs``.
+  See https://github.com/Pylons/pyramid/pull/2873
 
 Deprecations
 ------------

--- a/docs/narr/extconfig.rst
+++ b/docs/narr/extconfig.rst
@@ -260,6 +260,7 @@ Pre-defined Phases
 - :meth:`pyramid.config.Configurator.add_subscriber_predicate`
 - :meth:`pyramid.config.Configurator.add_view_predicate`
 - :meth:`pyramid.config.Configurator.add_view_deriver`
+- :meth:`pyramid.config.Configurator.override_asset`
 - :meth:`pyramid.config.Configurator.set_authorization_policy`
 - :meth:`pyramid.config.Configurator.set_default_csrf_options`
 - :meth:`pyramid.config.Configurator.set_default_permission`

--- a/pyramid/config/assets.py
+++ b/pyramid/config/assets.py
@@ -4,7 +4,10 @@ import sys
 
 from zope.interface import implementer
 
-from pyramid.interfaces import IPackageOverrides
+from pyramid.interfaces import (
+    IPackageOverrides,
+    PHASE1_CONFIG,
+)
 
 from pyramid.exceptions import ConfigurationError
 from pyramid.threadlocal import get_current_registry
@@ -387,6 +390,7 @@ class AssetsConfiguratorMixin(object):
             )
         intr['to_override'] = to_override
         intr['override_with'] = override_with
-        self.action(None, register, introspectables=(intr,))
+        self.action(None, register, introspectables=(intr,),
+                    order=PHASE1_CONFIG)
 
     override_resource = override_asset # bw compat

--- a/pyramid/tests/test_config/test_i18n.py
+++ b/pyramid/tests/test_config/test_i18n.py
@@ -36,9 +36,8 @@ class TestI18NConfiguratorMixin(unittest.TestCase):
     def test_add_translation_dirs_missing_dir(self):
         from pyramid.exceptions import ConfigurationError
         config = self._makeOne()
-        self.assertRaises(ConfigurationError,
-                          config.add_translation_dirs,
-                          '/wont/exist/on/my/system')
+        config.add_translation_dirs('/wont/exist/on/my/system')
+        self.assertRaises(ConfigurationError, config.commit)
 
     def test_add_translation_dirs_no_specs(self):
         from pyramid.interfaces import ITranslationDirectories
@@ -87,3 +86,12 @@ class TestI18NConfiguratorMixin(unittest.TestCase):
         self.assertEqual(config.registry.getUtility(ITranslationDirectories),
                          [locale])
 
+    def test_add_translation_dirs_uses_override(self):
+        from pyramid.interfaces import ITranslationDirectories
+        config = self._makeOne()
+        config.add_translation_dirs('pyramid.tests.pkgs.localeapp:locale')
+        config.override_asset('pyramid.tests.pkgs.localeapp:locale/',
+                              'pyramid.tests.pkgs.localeapp:locale2/')
+        config.commit()
+        self.assertEqual(config.registry.getUtility(ITranslationDirectories),
+                        [locale2])

--- a/pyramid/tests/test_config/test_i18n.py
+++ b/pyramid/tests/test_config/test_i18n.py
@@ -86,7 +86,7 @@ class TestI18NConfiguratorMixin(unittest.TestCase):
         self.assertEqual(config.registry.getUtility(ITranslationDirectories),
                          [locale])
 
-    def test_add_translation_dirs_uses_override(self):
+    def test_add_translation_dirs_uses_override_out_of_order(self):
         from pyramid.interfaces import ITranslationDirectories
         config = self._makeOne()
         config.add_translation_dirs('pyramid.tests.pkgs.localeapp:locale')
@@ -94,4 +94,22 @@ class TestI18NConfiguratorMixin(unittest.TestCase):
                               'pyramid.tests.pkgs.localeapp:locale2/')
         config.commit()
         self.assertEqual(config.registry.getUtility(ITranslationDirectories),
-                        [locale2])
+                         [locale2])
+
+    def test_add_translation_dirs_doesnt_use_override_w_autocommit(self):
+        from pyramid.interfaces import ITranslationDirectories
+        config = self._makeOne(autocommit=True)
+        config.add_translation_dirs('pyramid.tests.pkgs.localeapp:locale')
+        config.override_asset('pyramid.tests.pkgs.localeapp:locale/',
+                              'pyramid.tests.pkgs.localeapp:locale2/')
+        self.assertEqual(config.registry.getUtility(ITranslationDirectories),
+                         [locale])
+
+    def test_add_translation_dirs_uses_override_w_autocommit(self):
+        from pyramid.interfaces import ITranslationDirectories
+        config = self._makeOne(autocommit=True)
+        config.override_asset('pyramid.tests.pkgs.localeapp:locale/',
+                              'pyramid.tests.pkgs.localeapp:locale2/')
+        config.add_translation_dirs('pyramid.tests.pkgs.localeapp:locale')
+        self.assertEqual(config.registry.getUtility(ITranslationDirectories),
+                         [locale2])


### PR DESCRIPTION
This resolves #2046.

1. Added docs about importance of `config.begin()` when invoking `add_translation_dirs`.

2. Deferred the computation of the specs until the default config phase in order to allow asset overrides defined later to have an effect.

3. Used the `AssetResolver` to resolve the entire spec instead of just the package name such that translation directories can override each other even if they don't have the same name / subpath.

4. `config.override_asset` now occurs in an earlier config phase to ensure assets are updated prior to `add_translation_dirs` executing.

I would appreciate it if @piotr-dobrogost could review this.