### PR TITLE
improve display of help's description for p* scripts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -256,5 +256,5 @@ Documentation Changes
   See https://github.com/Pylons/pyramid/pull/2881 and
   https://github.com/Pylons/pyramid/pull/2883.
 
-- Improve output of p* script output of description for help.
+- Improve output of p* script descriptions for help.
   See https://github.com/Pylons/pyramid/pull/2886

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -255,3 +255,6 @@ Documentation Changes
 
   See https://github.com/Pylons/pyramid/pull/2881 and
   https://github.com/Pylons/pyramid/pull/2883.
+
+- Improve output of p* script output of description for help.
+  See https://github.com/Pylons/pyramid/pull/2886

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -23,13 +23,16 @@ def main(argv=sys.argv, quiet=False):
 
 class PCreateCommand(object):
     verbosity = 1  # required
-    parser = argparse.ArgumentParser(description="""\
+    parser = argparse.ArgumentParser(
+        description="""\
 Render Pyramid scaffolding to an output directory.
 
 Note: As of Pyramid 1.8, this command is deprecated. Use a specific
 cookiecutter instead:
 https://github.com/Pylons/?q=cookiecutter
-""")
+""",
+        formatter_class = argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument('-s', '--scaffold',
                         dest='scaffold_name',
                         action='append',

--- a/pyramid/scripts/pcreate.py
+++ b/pyramid/scripts/pcreate.py
@@ -31,7 +31,7 @@ Note: As of Pyramid 1.8, this command is deprecated. Use a specific
 cookiecutter instead:
 https://github.com/Pylons/?q=cookiecutter
 """,
-        formatter_class = argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument('-s', '--scaffold',
                         dest='scaffold_name',

--- a/pyramid/scripts/prequest.py
+++ b/pyramid/scripts/prequest.py
@@ -48,7 +48,7 @@ class PRequestCommand(object):
 
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
-        formatter_class = argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         )
     parser.add_argument(
         '-n', '--app-name',

--- a/pyramid/scripts/prequest.py
+++ b/pyramid/scripts/prequest.py
@@ -47,7 +47,8 @@ class PRequestCommand(object):
     """
 
     parser = argparse.ArgumentParser(
-        description=textwrap.dedent(description)
+        description=textwrap.dedent(description),
+        formatter_class = argparse.RawDescriptionHelpFormatter,
         )
     parser.add_argument(
         '-n', '--app-name',

--- a/pyramid/scripts/proutes.py
+++ b/pyramid/scripts/proutes.py
@@ -249,7 +249,8 @@ class PRoutesCommand(object):
     stdout = sys.stdout
     ConfigParser = configparser.ConfigParser  # testing
     parser = argparse.ArgumentParser(
-        description=textwrap.dedent(description)
+        description=textwrap.dedent(description),
+        formatter_class = argparse.RawDescriptionHelpFormatter,
         )
     parser.add_argument('-g', '--glob',
                         action='store',

--- a/pyramid/scripts/proutes.py
+++ b/pyramid/scripts/proutes.py
@@ -250,7 +250,7 @@ class PRoutesCommand(object):
     ConfigParser = configparser.ConfigParser  # testing
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
-        formatter_class = argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         )
     parser.add_argument('-g', '--glob',
                         action='store',

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -51,7 +51,8 @@ class PServeCommand(object):
     default_verbosity = 1
 
     parser = argparse.ArgumentParser(
-        description=textwrap.dedent(description)
+        description=textwrap.dedent(description),
+        formatter_class = argparse.RawDescriptionHelpFormatter,
         )
     parser.add_argument(
         '-n', '--app-name',

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -52,7 +52,7 @@ class PServeCommand(object):
 
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
-        formatter_class = argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         )
     parser.add_argument(
         '-n', '--app-name',

--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -46,7 +46,7 @@ class PShellCommand(object):
 
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
-        formatter_class = argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         )
     parser.add_argument('-p', '--python-shell',
                         action='store',

--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -45,7 +45,8 @@ class PShellCommand(object):
     pkg_resources = pkg_resources  # for testing
 
     parser = argparse.ArgumentParser(
-        description=textwrap.dedent(description)
+        description=textwrap.dedent(description),
+        formatter_class = argparse.RawDescriptionHelpFormatter,
         )
     parser.add_argument('-p', '--python-shell',
                         action='store',

--- a/pyramid/scripts/ptweens.py
+++ b/pyramid/scripts/ptweens.py
@@ -29,6 +29,7 @@ class PTweensCommand(object):
     """
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
+        formatter_class = argparse.RawDescriptionHelpFormatter,
         )
 
     parser.add_argument('config_uri',

--- a/pyramid/scripts/ptweens.py
+++ b/pyramid/scripts/ptweens.py
@@ -29,7 +29,7 @@ class PTweensCommand(object):
     """
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
-        formatter_class = argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         )
 
     parser.add_argument('config_uri',

--- a/pyramid/scripts/pviews.py
+++ b/pyramid/scripts/pviews.py
@@ -28,7 +28,8 @@ class PViewsCommand(object):
     stdout = sys.stdout
 
     parser = argparse.ArgumentParser(
-        description=textwrap.dedent(description)
+        description=textwrap.dedent(description),
+        formatter_class = argparse.RawDescriptionHelpFormatter,
         )
 
     parser.add_argument('config_uri',

--- a/pyramid/scripts/pviews.py
+++ b/pyramid/scripts/pviews.py
@@ -29,7 +29,7 @@ class PViewsCommand(object):
 
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
-        formatter_class = argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         )
 
     parser.add_argument('config_uri',


### PR DESCRIPTION
- Without ``formatter_class = argparse.RawDescriptionHelpFormatter``, whitespace is removed from the description, rendering it as a blob of text and less readable