### PR TITLE
Adding pip install -e .

### DIFF
--- a/docs/quick_tutorial/authorization.rst
+++ b/docs/quick_tutorial/authorization.rst
@@ -60,7 +60,13 @@ Steps
 
    .. literalinclude:: authorization/tutorial/views.py
     :linenos:
+    
+#. We can now install our project in development mode:
 
+   .. code-block:: bash
+
+    $ $VENV/bin/pip install -e .
+    
 #. Run your Pyramid application with:
 
    .. code-block:: bash


### PR DESCRIPTION
The pip install was missing, leading to the files from authentication still being used.