### PR TITLE
Fix NameError in doc

### DIFF
--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -155,7 +155,7 @@ forbidden view:
 .. code-block:: python
    :linenos:
 
-   def forbidden(request):
+   def forbidden_view(request):
        return Response('forbidden')
 
    def main(globals, **settings):


### PR DESCRIPTION
Make sure the names match.

Some lines later `config.add_forbidden_view(forbidden_view)` is called.