### PR TITLE
Fix development.ini for wsgiref

### DIFF
--- a/docs/quick_tutorial/ini/development.ini
+++ b/docs/quick_tutorial/ini/development.ini
@@ -3,4 +3,4 @@ use = egg:tutorial
 
 [server:main]
 use = egg:pyramid#wsgiref
-listen = *:6543
+port = 6543


### PR DESCRIPTION
Looks like the listen statement is ignored by wsgiref, but using the "port = 6543" instead causes the server to listen on the correct port.