### PR TITLE
Minor wording changes

### DIFF
--- a/docs/narr/views.rst
+++ b/docs/narr/views.rst
@@ -524,7 +524,7 @@ Alternate View Callable Argument/Calling Conventions
 
 Usually view callables are defined to accept only a single argument:
 ``request``.  However, view callables may alternately be defined as classes,
-functions, or any callable that accept *two* positional arguments: a
+functions, or any callable that accepts *two* positional arguments: a
 :term:`context` resource as the first argument and a :term:`request` as the
 second argument.
 


### PR DESCRIPTION
"or any callable that accepts" flows a little better.  Another option could be, "any callables that accept", matches the plural "functions" and "classes", and allows use of "accept", if that sounds better.