### PR TITLE
Minor change

### DIFF
--- a/docs/narr/views.rst
+++ b/docs/narr/views.rst
@@ -523,8 +523,7 @@ Alternate View Callable Argument/Calling Conventions
 ----------------------------------------------------
 
 Usually view callables are defined to accept only a single argument:
-``request``.  However, view callables may alternately be defined as classes,
-functions, or any callable that accept *two* positional arguments: a
+``request``.  However, a view callable may alternately be defined as any class, function, or callable that accepts *two* positional arguments: a
 :term:`context` resource as the first argument and a :term:`request` as the
 second argument.
 


### PR DESCRIPTION
"classes, functions, or any callable that accept" - the mix of plural and singular followed by "accept" which requires "accept" for "classes" and "functions", but "accepts" for "callable".  Proposed change sticks with only singular "any class, function, or callable that accepts" - flows a little better while reading.