### PR TITLE
scaffold starter now uses Jinja2

### DIFF
--- a/pyramid/scaffolds/__init__.py
+++ b/pyramid/scaffolds/__init__.py
@@ -52,7 +52,7 @@ class PyramidTemplate(Template):
 
 class StarterProjectTemplate(PyramidTemplate):
     _template_dir = 'starter'
-    summary = 'Pyramid starter project using URL dispatch and Chameleon'
+    summary = 'Pyramid starter project using URL dispatch and Jinja2'
 
 class ZODBProjectTemplate(PyramidTemplate):
     _template_dir = 'zodb'


### PR DESCRIPTION
- Closes misplaced issue https://github.com/Pylons/pyramid-cookiecutter-starter/issues/13

(cherry picked from commit 00a16de)