### PR TITLE
Bugfix: p.h.HTTPException.__str __ 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,10 @@ Features
 Bug Fixes
 ---------
 
+- HTTPException's accepts a detail kwarg that may be used to pass additional
+  details to the exception. You may now pass objects so long as they have a
+  valid __str__ method. See https://github.com/Pylons/pyramid/pull/2951 
+
 Deprecations
 ------------
 

--- a/pyramid/httpexceptions.py
+++ b/pyramid/httpexceptions.py
@@ -238,7 +238,7 @@ ${body}''')
             del self.content_length
 
     def __str__(self):
-        return self.detail or self.explanation
+        return str(self.detail) if self.detail else self.explanation
 
     def _json_formatter(self, status, body, title, environ):
         return {'message': body,

--- a/pyramid/tests/test_httpexceptions.py
+++ b/pyramid/tests/test_httpexceptions.py
@@ -2,6 +2,7 @@ import unittest
 
 from pyramid.compat import (
     bytes_,
+    string_types,
     text_,
     )
 
@@ -363,6 +364,11 @@ class TestHTTPException(unittest.TestCase):
         start_response = DummyStartResponse()
         body = list(exc(environ, start_response))[0]
         self.assertEqual(body, b'200 OK\n\n/La Pe\xc3\xb1a')
+
+    def test_allow_detail_non_str(self):
+        exc = self._makeOne(detail={'error': 'This is a test'})
+        self.assertIsInstance(exc.__str__(), string_types)
+
 
 class TestRenderAllExceptionsWithoutArguments(unittest.TestCase):
     def _doit(self, content_type):


### PR DESCRIPTION
There are those crazies among us* that use something like the following:

```
raise HTTPBadRequest({'error': 'Invalid something or other'})
```

This blew up when attempting to call `str()` on the resulting object due to `__str__` returning `self.detail` directly.

This fixes this and lets those crazies continue on with their craziness.

* Me, I am that crazy person, because it makes things like this simple:

```
@view_config(
    accept='application/json',
    renderer='json',
    context=HTTPException,
    )
def reterror(context, request):
    try:
        if not context.detail:
            raise ValueError('Missing detail in context')
        context.json_body = context.detail
    except:
        context.json_body = {'error': 'Unknown error has occured.'}

    return context
```