### PR TITLE
The Configurator object should not alter the input settings dict object.

### DIFF
--- a/pyramid/config/settings.py
+++ b/pyramid/config/settings.py
@@ -56,6 +56,7 @@ def Settings(d=None, _environ_=os.environ, **kw):
     keyword args)."""
     if d is None:
         d = {}
+    d = dict(d)
     d.update(**kw)
 
     eget = _environ_.get

--- a/pyramid/tests/test_config/test_settings.py
+++ b/pyramid/tests/test_config/test_settings.py
@@ -12,12 +12,12 @@ class TestSettingsConfiguratorMixin(unittest.TestCase):
         settings = config._set_settings(None)
         self.assertTrue(settings)
 
-    def test__set_settings_uses_original_dict(self):
+    def test__set_settings_does_not_uses_original_dict(self):
         config = self._makeOne()
         dummy = {}
         result = config._set_settings(dummy)
-        self.assertTrue(dummy is result)
-        self.assertEqual(dummy['pyramid.debug_all'], False)
+        self.assertTrue(dummy is not result)
+        self.assertNotIn('pyramid.debug_all', dummy)
 
     def test__set_settings_as_dictwithvalues(self):
         config = self._makeOne()

--- a/pyramid/tests/test_config/test_settings.py
+++ b/pyramid/tests/test_config/test_settings.py
@@ -66,7 +66,7 @@ class TestSettingsConfiguratorMixin(unittest.TestCase):
 
     def test_settings_parameter_dict_is_never_updated(self):
         class ReadOnlyDict(dict):
-            def __readonly__(self, *args, **kwargs):
+            def __readonly__(self, *args, **kwargs):  # pragma: no cover
                 raise RuntimeError("Cannot modify ReadOnlyDict")
             __setitem__ = __readonly__
             __delitem__ = __readonly__

--- a/pyramid/tests/test_config/test_settings.py
+++ b/pyramid/tests/test_config/test_settings.py
@@ -1,5 +1,6 @@
 import unittest
 
+
 class TestSettingsConfiguratorMixin(unittest.TestCase):
     def _makeOne(self, *arg, **kw):
         from pyramid.config import Configurator
@@ -62,6 +63,24 @@ class TestSettingsConfiguratorMixin(unittest.TestCase):
         config.add_settings(None, a=1)
         settings = reg.getUtility(ISettings)
         self.assertEqual(settings['a'], 1)
+
+    def test_settings_parameter_dict_is_never_updated(self):
+        class ReadOnlyDict(dict):
+            def __readonly__(self, *args, **kwargs):
+                raise RuntimeError("Cannot modify ReadOnlyDict")
+            __setitem__ = __readonly__
+            __delitem__ = __readonly__
+            pop = __readonly__
+            popitem = __readonly__
+            clear = __readonly__
+            update = __readonly__
+            setdefault = __readonly__
+            del __readonly__
+
+        initial = ReadOnlyDict()
+        config = self._makeOne(settings=initial)
+        config._set_settings({'a': '1'})
+
 
 class TestSettings(unittest.TestCase):
 


### PR DESCRIPTION
Test showing #2958 behavior.