### PR TITLE
add an IExecutionPolicy

### DIFF
--- a/docs/api/config.rst
+++ b/docs/api/config.rst
@@ -70,6 +70,7 @@
      .. automethod:: add_subscriber_predicate
      .. automethod:: add_view_predicate
      .. automethod:: add_view_deriver
+     .. automethod:: set_execution_policy
      .. automethod:: set_request_factory
      .. automethod:: set_root_factory
      .. automethod:: set_session_factory

--- a/docs/api/interfaces.rst
+++ b/docs/api/interfaces.rst
@@ -65,6 +65,9 @@ Other Interfaces
   .. autointerface:: IResponseFactory
      :members:
 
+  .. autointerface:: IRouter
+     :members:
+
   .. autointerface:: IViewMapperFactory
      :members:
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1154,3 +1154,7 @@ Glossary
 
    coverage
       A measurement of code coverage, usually expressed as a percentage of which lines of code have been executed over which lines are executable, typically run during test execution.
+   execution policy
+      A policy which wraps the :term:`router` by creating the request object
+      and sending it through the request pipeline.
+      See :class:`pyramid.config.Configurator.set_execution_policy`.

--- a/pyramid/config/factories.py
+++ b/pyramid/config/factories.py
@@ -3,6 +3,7 @@ from zope.interface import implementer
 
 from pyramid.interfaces import (
     IDefaultRootFactory,
+    IExecutionPolicy,
     IRequestFactory,
     IResponseFactory,
     IRequestExtensions,
@@ -10,6 +11,7 @@ from pyramid.interfaces import (
     ISessionFactory,
     )
 
+from pyramid.router import default_execution_policy
 from pyramid.traversal import DefaultRootFactory
 
 from pyramid.util import (
@@ -230,6 +232,29 @@ class FactoriesConfiguratorMixin(object):
         set_request_property,
         'set_request_propery() is deprecated as of Pyramid 1.5; use '
         'add_request_method() with the property=True argument instead')
+
+    @action_method
+    def set_execution_policy(self, policy):
+        """
+        Override the :app:`Pyramid` :term:`execution policy` in the
+        current configuration.  The ``policy`` argument must be an instance
+        of an :class:`pyramid.interfaces.IExecutionPolicy` or a
+        :term:`dotted Python name` that points at an instance of an
+        execution policy.
+
+        """
+        policy = self.maybe_dotted(policy)
+        if policy is None:
+            policy = default_execution_policy
+
+        def register():
+            self.registry.registerUtility(policy, IExecutionPolicy)
+
+        intr = self.introspectable('execution policy', None,
+                                   self.object_description(policy),
+                                   'execution policy')
+        intr['policy'] = policy
+        self.action(IExecutionPolicy, register, introspectables=(intr,))
 
 
 @implementer(IRequestExtensions)

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -682,7 +682,48 @@ class IRouter(Interface):
     registry = Attribute(
         """Component architecture registry local to this application.""")
 
-class ISettings(Interface):
+    def make_request(environ):
+        """
+        Create a new request object.
+
+        This method initializes a new :class:`pyramid.interfaces.IRequest`
+        object using the application's
+        :class:`pyramid.interfaces.IRequestFactory`.
+        """
+
+    def invoke_request(request):
+        """
+        Invoke the :app:`Pyramid` request pipeline.
+
+        See :ref:`router_chapter` for information on the request pipeline.
+        """
+
+class IExecutionPolicy(Interface):
+    def __call__(environ, router):
+        """
+        This callable triggers the router to process a raw WSGI environ dict
+        into a response and controls the :app:`Pyramid` request pipeline.
+
+        The ``environ`` is the raw WSGI environ.
+
+        The ``router`` is an :class:`pyramid.interfaces.IRouter` object which
+        should be used to create a request object and send it into the
+        processing pipeline.
+
+        The return value should be a :class:`pyramid.interfaces.IResponse`
+        object or an exception that will be handled by WSGI middleware.
+
+        The default execution policy simple creates a request and sends it
+        through the pipeline:
+
+        .. code-block:: python
+
+            def simple_execution_policy(environ, router):
+                request = router.make_request(environ)
+                return router.invoke_request(request)
+        """
+
+class ISettings(IDict):
     """ Runtime settings utility for pyramid; represents the
     deployment settings for the application.  Implements a mapping
     interface."""

--- a/pyramid/tests/pkgs/subrequestapp/__init__.py
+++ b/pyramid/tests/pkgs/subrequestapp/__init__.py
@@ -7,7 +7,8 @@ def view_one(request):
     return response
 
 def view_two(request):
-    return 'This came from view_two'
+    # check that request.foo is valid for a subrequest
+    return 'This came from view_two, foo=%s' % (request.foo,)
 
 def view_three(request):
     subreq = Request.blank('/view_four')
@@ -46,5 +47,6 @@ def main():
     config.add_view(view_three, route_name='three')
     config.add_view(view_four, route_name='four')
     config.add_view(view_five, route_name='five')
+    config.add_request_method(lambda r: 'bar', 'foo', property=True)
     return config
 

--- a/pyramid/tests/test_config/test_factories.py
+++ b/pyramid/tests/test_config/test_factories.py
@@ -144,6 +144,24 @@ class TestFactoriesMixin(unittest.TestCase):
 
         self.assertRaises(ConfigurationError, get_bad_name)
 
+    def test_set_execution_policy(self):
+        from pyramid.interfaces import IExecutionPolicy
+        config = self._makeOne(autocommit=True)
+        def dummy_policy(environ, router): pass
+        config.set_execution_policy(dummy_policy)
+        registry = config.registry
+        result = registry.queryUtility(IExecutionPolicy)
+        self.assertEqual(result, dummy_policy)
+
+    def test_set_execution_policy_to_None(self):
+        from pyramid.interfaces import IExecutionPolicy
+        from pyramid.router import default_execution_policy
+        config = self._makeOne(autocommit=True)
+        config.set_execution_policy(None)
+        registry = config.registry
+        result = registry.queryUtility(IExecutionPolicy)
+        self.assertEqual(result, default_execution_policy)
+
 class TestDeprecatedFactoriesMixinMethods(unittest.TestCase):
     def setUp(self):
         from zope.deprecation import __show__
@@ -203,4 +221,3 @@ class TestDeprecatedFactoriesMixinMethods(unittest.TestCase):
         config.set_request_property(bar, name='bar')
         self.assertRaises(ConfigurationConflictError, config.commit)
 
-    

--- a/pyramid/tests/test_integration.py
+++ b/pyramid/tests/test_integration.py
@@ -610,7 +610,7 @@ class SubrequestAppTest(unittest.TestCase):
 
     def test_one(self):
         res = self.testapp.get('/view_one', status=200)
-        self.assertTrue(b'This came from view_two' in res.body)
+        self.assertTrue(b'This came from view_two, foo=bar' in res.body)
 
     def test_three(self):
         res = self.testapp.get('/view_three', status=500)

--- a/pyramid/tests/test_router.py
+++ b/pyramid/tests/test_router.py
@@ -1271,6 +1271,19 @@ class TestRouter(unittest.TestCase):
         start_response = DummyStartResponse()
         self.assertRaises(PredicateMismatch, router, environ, start_response)
 
+    def test_custom_execution_policy(self):
+        from pyramid.interfaces import IExecutionPolicy
+        from pyramid.request import Request
+        from pyramid.response import Response
+        registry = self.config.registry
+        def dummy_policy(environ, router):
+            return Response(status=200, body=b'foo')
+        registry.registerUtility(dummy_policy, IExecutionPolicy)
+        router = self._makeOne()
+        resp = Request.blank('/').get_response(router)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.body, b'foo')
+
 class DummyPredicate(object):
     def __call__(self, info, request):
         return True


### PR DESCRIPTION
The goal here is a hook that can actually create new requests. This gives the execution policy the ability to control the execution of a request in pyramid to the extent that it can throw away all state and try again similar to what could be done in middleware.

I'm writing this for the purpose of pyramid_tm which wants to support "retryable" requests in which the request failed for transient reason where there is a reasonable idea that the request will succeed if tried again. When performing a retry we want to teardown state as much as possible to avoid any state leaking from the failing request into the new request (such as managed objects for aborted transactions).

The key difference between this API and a tween is that the execution policy can create a new request with an assurance that nothing else is wrapping it, depending on the old request object and its old state. Whether this is worth the introduction of the API or not is up for debate but I think it is after trying to implement pyramid_tm without it.