### PR TITLE
webob 1.7 compat: provide a charset for json responses

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -292,3 +292,5 @@ Contributors
 - Mikko Ohtamaa, 2016/12/6
 
 - Martin Frlin, 2016/12/7
+
+- Anthony Sottile, 2017/03/03

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -270,7 +270,7 @@ class JSON(object):
                 response = request.response
                 ct = response.content_type
                 if ct == response.default_content_type:
-                    response.content_type = 'application/json'
+                    response.content_type = 'application/json; charset=utf-8'
             default = self._make_default(request)
             return self.serializer(value, default=default, **self.kw)
 

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -25,6 +25,7 @@ class TestJSON(unittest.TestCase):
         renderer = self._makeOne()(None)
         renderer({'a':1}, {'request':request})
         self.assertEqual(request.response.content_type, 'application/json')
+        self.assertEqual(request.response.charset.lower(), 'utf-8')
 
     def test_with_request_content_type_set(self):
         request = testing.DummyRequest()


### PR DESCRIPTION
Hitting this at work while trying to upgrade webob -- we're using this hackety workaround for now:

```python
def charset_json_renderer(info):
    json_renderer = renderers.JSON()(info)

    def render_json(value, system):
        request = system['request']
        ret = json_renderer(value, system)
        request.response.charset = 'utf-8'
        return ret
    return render_json


def setup_app(cfg):
    # ...
    cfg.add_renderer(None, charset_json_renderer)
```

Demonstration of failing test:

## with test, webob<1.7

```
$ pip install 'webob<1.7.0'
Collecting webob<1.7.0
  Downloading WebOb-1.6.3-py2.py3-none-any.whl (78kB)
    100% |████████████████████████████████| 81kB 2.9MB/s 
Installing collected packages: webob
  Found existing installation: WebOb 1.7.0
    Uninstalling WebOb-1.7.0:
      Successfully uninstalled WebOb-1.7.0
Successfully installed webob-1.6.3
$ py.test pyramid/tests/test_renderers.py 
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /home/asottile/workspace/pyramid, inifile: 
collected 60 items 

pyramid/tests/test_renderers.py ............................................................

========================== 60 passed in 0.32 seconds ===========================
```

## with test, webob==1.7.1

```
$ pip install webob --upgrade
Collecting webob
  Using cached WebOb-1.7.1-py2.py3-none-any.whl
Installing collected packages: webob
  Found existing installation: WebOb 1.6.3
    Uninstalling WebOb-1.6.3:
      Successfully uninstalled WebOb-1.6.3
Successfully installed webob-1.7.1
$ py.test pyramid/tests/test_renderers.py 
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /home/asottile/workspace/pyramid, inifile: 
collected 60 items 

pyramid/tests/test_renderers.py ......F.....................................................

=================================== FAILURES ===================================
________________ TestJSON.test_with_request_content_type_notset ________________

self = <pyramid.tests.test_renderers.TestJSON testMethod=test_with_request_content_type_notset>

    def test_with_request_content_type_notset(self):
        request = testing.DummyRequest()
        renderer = self._makeOne()(None)
        renderer({'a':1}, {'request':request})
        self.assertEqual(request.response.content_type, 'application/json')
>       self.assertEqual(request.response.charset, 'utf-8')
E       AssertionError: None != 'utf-8'

pyramid/tests/test_renderers.py:28: AssertionError
===================== 1 failed, 59 passed in 0.34 seconds ======================
```

## After the patch, the tests passes in both versions
