### PR TITLE
Make sure PServeCommand kwargs are passed to the hupper worker.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,11 @@ Bug Fixes
   object in which the registry was stored in a closure preventing it from
   being deallocated. See https://github.com/Pylons/pyramid/pull/2973
 
+- Fix a bug directly invoking ``pyramid.scripts.pserve.main`` with the
+  ``--reload`` option in which ``sys.argv`` is always used in the subprocess
+  instead of the supplied ``argv``.
+  See https://github.com/Pylons/pyramid/pull/2974
+
 Documentation Changes
 ---------------------
 

--- a/pyramid/scripts/pserve.py
+++ b/pyramid/scripts/pserve.py
@@ -124,6 +124,8 @@ class PServeCommand(object):
         self.args = self.parser.parse_args(argv[1:])
         if quiet:
             self.args.verbose = 0
+        if self.args.reload:
+            self.worker_kwargs = {'argv': argv, "quiet": quiet}
         self.watch_files = []
 
     def out(self, msg): # pragma: no cover
@@ -203,6 +205,7 @@ class PServeCommand(object):
                 'pyramid.scripts.pserve.main',
                 reload_interval=int(self.args.reload_interval),
                 verbose=self.args.verbose,
+                worker_kwargs=self.worker_kwargs
             )
             return 0
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ docs_extras = [
 testing_extras = tests_require + [
     'nose',
     'coverage',
-    'virtualenv', # for scaffolding tests
+    'virtualenv',  # for scaffolding tests
     ]
 
 setup(name='pyramid',


### PR DESCRIPTION
Backport of #2962 to 1.8-branch.