### PR TITLE
migrate pyramid to use plaster

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,14 +1,32 @@
 unreleased
 ==========
 
-Features
---------
+Major Features
+--------------
+
+- The file format used by all ``p*`` command line scripts such as ``pserve``
+  and ``pshell``, as well as the ``pyramid.paster.bootstrap`` function
+  is now replaceable thanks to a new dependency on
+  `plaster <http://docs.pylonsproject.org/projects/plaster/en/latest/>`.
+
+  For now, Pyramid is still shipping with integrated support for the
+  PasteDeploy INI format by depending on the ``plaster_pastedeploy`` binding.
+
+  See https://github.com/Pylons/pyramid/pull/2985
 
 - Added an execution policy hook to the request pipeline. An execution
   policy has the ability to control creation and execution of the request
-  objects before they enter rest of the pipeline. This means for a given
-  request that the policy may create more than one request for retry
-  purposes. See https://github.com/Pylons/pyramid/pull/2964
+  objects before they enter rest of the pipeline. This means for a single
+  request environ the policy may create more than one request object.
+
+  The first library to use this feature is
+  `pyramid_retry
+  <http://docs.pylonsproject.org/projects/pyramid-retry/en/latest/>`.
+
+  See https://github.com/Pylons/pyramid/pull/2964
+
+Features
+--------
 
 - Support an ``open_url`` config setting in the ``pserve`` section of the
   config file. This url is used to open a web browser when ``pserve --browser``

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,7 +7,7 @@ Major Features
 - The file format used by all ``p*`` command line scripts such as ``pserve``
   and ``pshell``, as well as the ``pyramid.paster.bootstrap`` function
   is now replaceable thanks to a new dependency on
-  `plaster <http://docs.pylonsproject.org/projects/plaster/en/latest/>`.
+  `plaster <http://docs.pylonsproject.org/projects/plaster/en/latest/>`_.
 
   For now, Pyramid is still shipping with integrated support for the
   PasteDeploy INI format by depending on the ``plaster_pastedeploy`` binding.
@@ -16,12 +16,12 @@ Major Features
 
 - Added an execution policy hook to the request pipeline. An execution
   policy has the ability to control creation and execution of the request
-  objects before they enter rest of the pipeline. This means for a single
+  objects before they enter the rest of the pipeline. This means for a single
   request environ the policy may create more than one request object.
 
   The first library to use this feature is
   `pyramid_retry
-  <http://docs.pylonsproject.org/projects/pyramid-retry/en/latest/>`.
+  <http://docs.pylonsproject.org/projects/pyramid-retry/en/latest/>`_.
 
   See https://github.com/Pylons/pyramid/pull/2964
 

--- a/docs/api/paster.rst
+++ b/docs/api/paster.rst
@@ -7,8 +7,8 @@
 
     .. autofunction:: bootstrap
 
-    .. autofunction:: get_app(config_uri, name=None, options=None)
+    .. autofunction:: get_app
 
-    .. autofunction:: get_appsettings(config_uri, name=None, options=None)
+    .. autofunction:: get_appsettings
 
-    .. autofunction:: setup_logging(config_uri, global_conf=None)
+    .. autofunction:: setup_logging

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -366,6 +366,14 @@ Glossary
      :term:`WSGI` components together declaratively within an ``.ini``
      file.  It was developed by Ian Bicking.
 
+   plaster
+     `plaster <http://docs.pylonsproject.org/projects/plaster/en/latest/>`_ is
+     a library used by :app:`Pyramid` which acts as an abstraction between
+     command-line scripts and the file format used to load the :term:`WSGI`
+     components and application settings. By default :app:`Pyramid` ships
+     with the ``plaster_pastedeploy`` library installed which provides
+     integrated support for loading a :term:`PasteDeploy` INI file.
+
    Chameleon
      `chameleon <https://chameleon.readthedocs.org/en/latest/>`_ is an
      attribute language template compiler which supports the :term:`ZPT`

--- a/docs/narr/paste.rst
+++ b/docs/narr/paste.rst
@@ -26,12 +26,7 @@ documentation, see http://pythonpaste.org/deploy/.
 PasteDeploy
 -----------
 
-:term:`PasteDeploy` is the system that Pyramid uses to allow :term:`deployment
-settings` to be specified using an ``.ini`` configuration file format.  It also
-allows the ``pserve`` command to work.  Its configuration format provides a
-convenient place to define application :term:`deployment settings` and WSGI
-server settings, and its server runner allows you to stop and start a Pyramid
-application easily.
+:term:`plaster` is the system that Pyramid uses to load settings from configuration files. The most common format for these files is an ``.ini`` format structured in a way defined by :term:`PasteDeploy`.  The format supports mechanisms to define WSGI app :term:`deployment settings`, WSGI server settings and logging. This allows the ``pserve`` command to work, allowing you to stop and start a Pyramid application easily.
 
 .. _pastedeploy_entry_points:
 
@@ -96,3 +91,8 @@ applications, servers, and :term:`middleware` defined within the configuration
 file.  The values in a ``[DEFAULT]`` section will be passed to your
 application's ``main`` function as ``global_config`` (see the reference to the
 ``main`` function in :ref:`init_py`).
+
+Alternative Configuration File Formats
+--------------------------------------
+
+It is possible to use different file formats with :app:`Pyramid` if you do not like :term:`PasteDeploy`. Under the hood all command-line scripts such as ``pserve`` and ``pshell`` pass the ``config_uri`` (e.g. ``development.ini`` or ``production.ini``) to the :term:`plaster` library which performs a lookup for an appropriate parser. For ``.ini`` files it uses PasteDeploy but you can register your own configuration formats that plaster will find instead.

--- a/docs/narr/startup.rst
+++ b/docs/narr/startup.rst
@@ -38,7 +38,14 @@ Here's a high-level time-ordered overview of what happens when you press
    begin to run and serve an application using the information contained
    within the ``development.ini`` file.
 
-#. The framework finds a section named either ``[app:main]``,
+#. ``pserve`` passes the ``development.ini`` path to :term:`plaster` which
+   finds an available configuration loader that recognizes the ``ini`` format.
+
+#. :term:`plaster` finds the ``plaster_pastedeploy`` library which binds
+   the :term:`PasteDeploy` library and returns a parser that can understand
+   the format.
+
+#. The :term:`PasteDeploy` finds a section named either ``[app:main]``,
    ``[pipeline:main]``, or ``[composite:main]`` in the ``.ini`` file.  This
    section represents the configuration of a :term:`WSGI` application that will
    be served.  If you're using a simple application (e.g., ``[app:main]``), the

--- a/pyramid/scripts/common.py
+++ b/pyramid/scripts/common.py
@@ -1,6 +1,4 @@
-import os
-from pyramid.compat import configparser
-from logging.config import fileConfig
+import plaster
 
 def parse_vars(args):
     """
@@ -17,26 +15,9 @@ def parse_vars(args):
         result[name] = value
     return result
 
-def setup_logging(config_uri, global_conf=None,
-                  fileConfig=fileConfig,
-                  configparser=configparser):
+def get_config_loader(config_uri):
     """
-    Set up logging via :func:`logging.config.fileConfig` with the filename
-    specified via ``config_uri`` (a string in the form
-    ``filename#sectionname``).
+    Find a ``plaster.ILoader`` object supporting the "wsgi" protocol.
 
-    ConfigParser defaults are specified for the special ``__file__``
-    and ``here`` variables, similar to PasteDeploy config loading.
-    Extra defaults can optionally be specified as a dict in ``global_conf``.
     """
-    path = config_uri.split('#', 1)[0]
-    parser = configparser.ConfigParser()
-    parser.read([path])
-    if parser.has_section('loggers'):
-        config_file = os.path.abspath(path)
-        full_global_conf = dict(
-            __file__=config_file,
-            here=os.path.dirname(config_file))
-        if global_conf:
-            full_global_conf.update(global_conf)
-        return fileConfig(config_file, full_global_conf)
+    return plaster.get_loader(config_uri, protocols=['wsgi'])

--- a/pyramid/scripts/ptweens.py
+++ b/pyramid/scripts/ptweens.py
@@ -7,6 +7,7 @@ from pyramid.interfaces import ITweens
 from pyramid.tweens import MAIN
 from pyramid.tweens import INGRESS
 from pyramid.paster import bootstrap
+from pyramid.paster import setup_logging
 from pyramid.scripts.common import parse_vars
 
 def main(argv=sys.argv, quiet=False):
@@ -47,7 +48,8 @@ class PTweensCommand(object):
         )
 
     stdout = sys.stdout
-    bootstrap = (bootstrap,) # testing
+    bootstrap = staticmethod(bootstrap) # testing
+    setup_logging = staticmethod(setup_logging) # testing
 
     def __init__(self, argv, quiet=False):
         self.quiet = quiet
@@ -76,7 +78,9 @@ class PTweensCommand(object):
             self.out('Requires a config file argument')
             return 2
         config_uri = self.args.config_uri
-        env = self.bootstrap[0](config_uri, options=parse_vars(self.args.config_vars))
+        config_vars = parse_vars(self.args.config_vars)
+        self.setup_logging(config_uri, global_conf=config_vars)
+        env = self.bootstrap(config_uri, options=config_vars)
         registry = env['registry']
         tweens = self._get_tweens(registry)
         if tweens is not None:

--- a/pyramid/scripts/pviews.py
+++ b/pyramid/scripts/pviews.py
@@ -4,6 +4,7 @@ import textwrap
 
 from pyramid.interfaces import IMultiView
 from pyramid.paster import bootstrap
+from pyramid.paster import setup_logging
 from pyramid.request import Request
 from pyramid.scripts.common import parse_vars
 from pyramid.view import _find_views
@@ -51,7 +52,8 @@ class PViewsCommand(object):
         )
 
 
-    bootstrap = (bootstrap,) # testing
+    bootstrap = staticmethod(bootstrap) # testing
+    setup_logging = staticmethod(setup_logging) # testing
 
     def __init__(self, argv, quiet=False):
         self.quiet = quiet
@@ -252,13 +254,15 @@ class PViewsCommand(object):
             self.out('Command requires a config file arg and a url arg')
             return 2
         config_uri = self.args.config_uri
+        config_vars = parse_vars(self.args.config_vars)
         url = self.args.url
+
+        self.setup_logging(config_uri, global_conf=config_vars)
 
         if not url.startswith('/'):
             url = '/%s' % url
         request = Request.blank(url)
-        env = self.bootstrap[0](config_uri, options=parse_vars(self.args.config_vars),
-                                request=request)
+        env = self.bootstrap(config_uri, options=config_vars, request=request)
         view = self._find_view(request)
         self.out('')
         self.out("URL = %s" % url)

--- a/pyramid/tests/test_paster.py
+++ b/pyramid/tests/test_paster.py
@@ -22,7 +22,7 @@ class Test_get_app(unittest.TestCase):
         result = self._callFUT(
             '/foo/bar/myapp.ini', 'myapp', options={'a': 'b'},
             _loader=loader)
-        self.assertEqual(loader.uri, '/foo/bar/myapp.ini')
+        self.assertEqual(loader.uri.path, '/foo/bar/myapp.ini')
         self.assertEqual(len(loader.calls), 1)
         self.assertEqual(loader.calls[0]['op'], 'app')
         self.assertEqual(loader.calls[0]['name'], 'myapp')
@@ -54,7 +54,7 @@ class Test_get_appsettings(unittest.TestCase):
         result = self._callFUT(
             '/foo/bar/myapp.ini', 'myapp', options={'a': 'b'},
             _loader=loader)
-        self.assertEqual(loader.uri, '/foo/bar/myapp.ini')
+        self.assertEqual(loader.uri.path, '/foo/bar/myapp.ini')
         self.assertEqual(len(loader.calls), 1)
         self.assertEqual(loader.calls[0]['op'], 'app_settings')
         self.assertEqual(loader.calls[0]['name'], 'myapp')
@@ -81,24 +81,24 @@ class Test_setup_logging(unittest.TestCase):
 
     def test_it_no_global_conf(self):
         loader = DummyLoader()
-        self._callFUT('/abc', _loader=loader)
-        self.assertEqual(loader.uri, '/abc')
+        self._callFUT('/abc.ini', _loader=loader)
+        self.assertEqual(loader.uri.path, '/abc.ini')
         self.assertEqual(len(loader.calls), 1)
         self.assertEqual(loader.calls[0]['op'], 'logging')
         self.assertEqual(loader.calls[0]['defaults'], None)
 
     def test_it_global_conf_empty(self):
         loader = DummyLoader()
-        self._callFUT('/abc', global_conf={}, _loader=loader)
-        self.assertEqual(loader.uri, '/abc')
+        self._callFUT('/abc.ini', global_conf={}, _loader=loader)
+        self.assertEqual(loader.uri.path, '/abc.ini')
         self.assertEqual(len(loader.calls), 1)
         self.assertEqual(loader.calls[0]['op'], 'logging')
         self.assertEqual(loader.calls[0]['defaults'], {})
 
     def test_it_global_conf_not_empty(self):
         loader = DummyLoader()
-        self._callFUT('/abc', global_conf={'key': 'val'}, _loader=loader)
-        self.assertEqual(loader.uri, '/abc')
+        self._callFUT('/abc.ini', global_conf={'key': 'val'}, _loader=loader)
+        self.assertEqual(loader.uri.path, '/abc.ini')
         self.assertEqual(len(loader.calls), 1)
         self.assertEqual(loader.calls[0]['op'], 'logging')
         self.assertEqual(loader.calls[0]['defaults'], {'key': 'val'})
@@ -166,13 +166,3 @@ class DummyRequest:
     def __init__(self, environ):
         self.environ = environ
         self.matchdict = {}
-
-class DummyConfigParser(object):
-    def read(self, x):
-        pass
-
-    def has_section(self, name):
-        return True
-
-class DummyConfigParserModule(object):
-    ConfigParser = DummyConfigParser

--- a/pyramid/tests/test_paster.py
+++ b/pyramid/tests/test_paster.py
@@ -1,58 +1,32 @@
 import os
 import unittest
+from pyramid.tests.test_scripts.dummy import DummyLoader
 
 here = os.path.dirname(__file__)
 
 class Test_get_app(unittest.TestCase):
-    def _callFUT(self, config_file, section_name, **kw):
-        from pyramid.paster import get_app
-        return get_app(config_file, section_name, **kw)
+    def _callFUT(self, config_file, section_name, options=None, _loader=None):
+        import pyramid.paster
+        old_loader = pyramid.paster.get_config_loader
+        try:
+            if _loader is not None:
+                pyramid.paster.get_config_loader = _loader
+            return pyramid.paster.get_app(config_file, section_name,
+                                          options=options)
+        finally:
+            pyramid.paster.get_config_loader = old_loader
 
     def test_it(self):
         app = DummyApp()
-        loadapp = DummyLoadWSGI(app)
-        result = self._callFUT('/foo/bar/myapp.ini', 'myapp', loadapp=loadapp)
-        self.assertEqual(loadapp.config_name, 'config:/foo/bar/myapp.ini')
-        self.assertEqual(loadapp.section_name, 'myapp')
-        self.assertEqual(loadapp.relative_to, os.getcwd())
-        self.assertEqual(result, app)
-
-    def test_it_with_hash(self):
-        app = DummyApp()
-        loadapp = DummyLoadWSGI(app)
+        loader = DummyLoader(app=app)
         result = self._callFUT(
-            '/foo/bar/myapp.ini#myapp', None, loadapp=loadapp
-            )
-        self.assertEqual(loadapp.config_name, 'config:/foo/bar/myapp.ini')
-        self.assertEqual(loadapp.section_name, 'myapp')
-        self.assertEqual(loadapp.relative_to, os.getcwd())
-        self.assertEqual(result, app)
-
-    def test_it_with_hash_and_name_override(self):
-        app = DummyApp()
-        loadapp = DummyLoadWSGI(app)
-        result = self._callFUT(
-            '/foo/bar/myapp.ini#myapp', 'yourapp', loadapp=loadapp
-            )
-        self.assertEqual(loadapp.config_name, 'config:/foo/bar/myapp.ini')
-        self.assertEqual(loadapp.section_name, 'yourapp')
-        self.assertEqual(loadapp.relative_to, os.getcwd())
-        self.assertEqual(result, app)
-
-    def test_it_with_options(self):
-        app = DummyApp()
-        loadapp = DummyLoadWSGI(app)
-        options = {'a':1}
-        result = self._callFUT(
-            '/foo/bar/myapp.ini#myapp',
-            'yourapp',
-            loadapp=loadapp,
-            options=options,
-            )
-        self.assertEqual(loadapp.config_name, 'config:/foo/bar/myapp.ini')
-        self.assertEqual(loadapp.section_name, 'yourapp')
-        self.assertEqual(loadapp.relative_to, os.getcwd())
-        self.assertEqual(loadapp.kw, {'global_conf':options})
+            '/foo/bar/myapp.ini', 'myapp', options={'a': 'b'},
+            _loader=loader)
+        self.assertEqual(loader.uri, '/foo/bar/myapp.ini')
+        self.assertEqual(len(loader.calls), 1)
+        self.assertEqual(loader.calls[0]['op'], 'app')
+        self.assertEqual(loader.calls[0]['name'], 'myapp')
+        self.assertEqual(loader.calls[0]['defaults'], {'a': 'b'})
         self.assertEqual(result, app)
 
     def test_it_with_dummyapp_requiring_options(self):
@@ -63,38 +37,28 @@ class Test_get_app(unittest.TestCase):
         self.assertEqual(app.settings['foo'], 'baz')
 
 class Test_get_appsettings(unittest.TestCase):
-    def _callFUT(self, config_file, section_name, **kw):
-        from pyramid.paster import get_appsettings
-        return get_appsettings(config_file, section_name, **kw)
+    def _callFUT(self, config_file, section_name, options=None, _loader=None):
+        import pyramid.paster
+        old_loader = pyramid.paster.get_config_loader
+        try:
+            if _loader is not None:
+                pyramid.paster.get_config_loader = _loader
+            return pyramid.paster.get_appsettings(config_file, section_name,
+                                                  options=options)
+        finally:
+            pyramid.paster.get_config_loader = old_loader
 
     def test_it(self):
-        values = {'a':1}
-        appconfig = DummyLoadWSGI(values)
-        result = self._callFUT('/foo/bar/myapp.ini', 'myapp',
-                               appconfig=appconfig)
-        self.assertEqual(appconfig.config_name, 'config:/foo/bar/myapp.ini')
-        self.assertEqual(appconfig.section_name, 'myapp')
-        self.assertEqual(appconfig.relative_to, os.getcwd())
-        self.assertEqual(result, values)
-
-    def test_it_with_hash(self):
-        values = {'a':1}
-        appconfig = DummyLoadWSGI(values)
-        result = self._callFUT('/foo/bar/myapp.ini#myapp', None,
-                               appconfig=appconfig)
-        self.assertEqual(appconfig.config_name, 'config:/foo/bar/myapp.ini')
-        self.assertEqual(appconfig.section_name, 'myapp')
-        self.assertEqual(appconfig.relative_to, os.getcwd())
-        self.assertEqual(result, values)
-
-    def test_it_with_hash_and_name_override(self):
-        values = {'a':1}
-        appconfig = DummyLoadWSGI(values)
-        result = self._callFUT('/foo/bar/myapp.ini#myapp', 'yourapp',
-                               appconfig=appconfig)
-        self.assertEqual(appconfig.config_name, 'config:/foo/bar/myapp.ini')
-        self.assertEqual(appconfig.section_name, 'yourapp')
-        self.assertEqual(appconfig.relative_to, os.getcwd())
+        values = {'a': 1}
+        loader = DummyLoader(app_settings=values)
+        result = self._callFUT(
+            '/foo/bar/myapp.ini', 'myapp', options={'a': 'b'},
+            _loader=loader)
+        self.assertEqual(loader.uri, '/foo/bar/myapp.ini')
+        self.assertEqual(len(loader.calls), 1)
+        self.assertEqual(loader.calls[0]['op'], 'app_settings')
+        self.assertEqual(loader.calls[0]['name'], 'myapp')
+        self.assertEqual(loader.calls[0]['defaults'], {'a': 'b'})
         self.assertEqual(result, values)
 
     def test_it_with_dummyapp_requiring_options(self):
@@ -105,40 +69,39 @@ class Test_get_appsettings(unittest.TestCase):
         self.assertEqual(result['foo'], 'baz')
 
 class Test_setup_logging(unittest.TestCase):
-    def _callFUT(self, config_file, global_conf=None):
-        from pyramid.paster import setup_logging
-        dummy_cp = DummyConfigParserModule
-        return setup_logging(
-            config_uri=config_file,
-            global_conf=global_conf,
-            fileConfig=self.fileConfig,
-            configparser=dummy_cp,
-            )
+    def _callFUT(self, config_file, global_conf=None, _loader=None):
+        import pyramid.paster
+        old_loader = pyramid.paster.get_config_loader
+        try:
+            if _loader is not None:
+                pyramid.paster.get_config_loader = _loader
+            return pyramid.paster.setup_logging(config_file, global_conf)
+        finally:
+            pyramid.paster.get_config_loader = old_loader
 
     def test_it_no_global_conf(self):
-        config_file, dict = self._callFUT('/abc')
-        # os.path.abspath is a sop to Windows
-        self.assertEqual(config_file, os.path.abspath('/abc'))
-        self.assertEqual(dict['__file__'], os.path.abspath('/abc'))
-        self.assertEqual(dict['here'], os.path.abspath('/'))
+        loader = DummyLoader()
+        self._callFUT('/abc', _loader=loader)
+        self.assertEqual(loader.uri, '/abc')
+        self.assertEqual(len(loader.calls), 1)
+        self.assertEqual(loader.calls[0]['op'], 'logging')
+        self.assertEqual(loader.calls[0]['defaults'], None)
 
     def test_it_global_conf_empty(self):
-        config_file, dict = self._callFUT('/abc', global_conf={})
-        # os.path.abspath is a sop to Windows
-        self.assertEqual(config_file, os.path.abspath('/abc'))
-        self.assertEqual(dict['__file__'], os.path.abspath('/abc'))
-        self.assertEqual(dict['here'], os.path.abspath('/'))
+        loader = DummyLoader()
+        self._callFUT('/abc', global_conf={}, _loader=loader)
+        self.assertEqual(loader.uri, '/abc')
+        self.assertEqual(len(loader.calls), 1)
+        self.assertEqual(loader.calls[0]['op'], 'logging')
+        self.assertEqual(loader.calls[0]['defaults'], {})
 
     def test_it_global_conf_not_empty(self):
-        config_file, dict = self._callFUT('/abc', global_conf={'key': 'val'})
-        # os.path.abspath is a sop to Windows
-        self.assertEqual(config_file, os.path.abspath('/abc'))
-        self.assertEqual(dict['__file__'], os.path.abspath('/abc'))
-        self.assertEqual(dict['here'], os.path.abspath('/'))
-        self.assertEqual(dict['key'], 'val')
-
-    def fileConfig(self, config_file, dict):
-        return config_file, dict
+        loader = DummyLoader()
+        self._callFUT('/abc', global_conf={'key': 'val'}, _loader=loader)
+        self.assertEqual(loader.uri, '/abc')
+        self.assertEqual(len(loader.calls), 1)
+        self.assertEqual(loader.calls[0]['op'], 'logging')
+        self.assertEqual(loader.calls[0]['defaults'], {'key': 'val'})
 
 class Test_bootstrap(unittest.TestCase):
     def _callFUT(self, config_uri, request=None):
@@ -186,17 +149,6 @@ class DummyRegistry(object):
     settings = {}
 
 dummy_registry = DummyRegistry()
-
-class DummyLoadWSGI:
-    def __init__(self, result):
-        self.result = result
-
-    def __call__(self, config_name, name=None, relative_to=None, **kw):
-        self.config_name = config_name
-        self.section_name = name
-        self.relative_to = relative_to
-        self.kw = kw
-        return self.result
 
 class DummyApp:
     def __init__(self):

--- a/pyramid/tests/test_scripts/dummy.py
+++ b/pyramid/tests/test_scripts/dummy.py
@@ -167,7 +167,7 @@ class DummyPkgResources(object):
 class dummy_setup_logging(object):
     def __call__(self, config_uri, global_conf):
         self.config_uri = config_uri
-        self.global_conf = global_conf
+        self.defaults = global_conf
 
 
 class DummyLoader(object):
@@ -190,7 +190,7 @@ class DummyLoader(object):
 
     def get_settings(self, name=None, defaults=None):
         self.add_call('settings', name, defaults)
-        return self.result
+        return self.settings.get(name, {})
 
     def get_wsgi_app(self, name=None, defaults=None):
         self.add_call('app', name, defaults)

--- a/pyramid/tests/test_scripts/dummy.py
+++ b/pyramid/tests/test_scripts/dummy.py
@@ -162,3 +162,44 @@ class DummyPkgResources(object):
 
     def iter_entry_points(self, name):
         return self.entry_points
+
+
+class dummy_setup_logging(object):
+    def __call__(self, config_uri, global_conf):
+        self.config_uri = config_uri
+        self.global_conf = global_conf
+
+
+class DummyLoader(object):
+    def __init__(self, settings=None, app_settings=None, app=None):
+        if not settings:
+            settings = {}
+        if not app_settings:
+            app_settings = {}
+        self.settings = settings
+        self.app_settings = app_settings
+        self.app = app
+        self.calls = []
+
+    def __call__(self, uri):
+        self.uri = uri
+        return self
+
+    def add_call(self, op, name, defaults):
+        self.calls.append({'op': op, 'name': name, 'defaults': defaults})
+
+    def get_settings(self, name=None, defaults=None):
+        self.add_call('settings', name, defaults)
+        return self.result
+
+    def get_wsgi_app(self, name=None, defaults=None):
+        self.add_call('app', name, defaults)
+        return self.app
+
+    def get_wsgi_app_settings(self, name=None, defaults=None):
+        self.add_call('app_settings', name, defaults)
+        return self.app_settings
+
+    def setup_logging(self, defaults):
+        self.add_call('logging', None, defaults)
+        self.defaults = defaults

--- a/pyramid/tests/test_scripts/dummy.py
+++ b/pyramid/tests/test_scripts/dummy.py
@@ -81,29 +81,6 @@ class DummyMultiView(object):
         self.views = [(None, view, None) for view in views]
         self.__request_attrs__ = attrs
 
-class DummyConfigParser(object):
-    def __init__(self, result, defaults=None):
-        self.result = result
-        self.defaults = defaults
-
-    def read(self, filename):
-        self.filename = filename
-
-    def items(self, section):
-        self.section = section
-        if self.result is None:
-            from pyramid.compat import configparser
-            raise configparser.NoSectionError(section)
-        return self.result
-
-class DummyConfigParserFactory(object):
-    items = None
-
-    def __call__(self, defaults=None):
-        self.defaults = defaults
-        self.parser = DummyConfigParser(self.items, defaults)
-        return self.parser
-
 class DummyCloser(object):
     def __call__(self):
         self.called = True
@@ -171,7 +148,7 @@ class dummy_setup_logging(object):
 
 
 class DummyLoader(object):
-    def __init__(self, settings=None, app_settings=None, app=None):
+    def __init__(self, settings=None, app_settings=None, app=None, server=None):
         if not settings:
             settings = {}
         if not app_settings:
@@ -179,10 +156,12 @@ class DummyLoader(object):
         self.settings = settings
         self.app_settings = app_settings
         self.app = app
+        self.server = server
         self.calls = []
 
     def __call__(self, uri):
-        self.uri = uri
+        import plaster
+        self.uri = plaster.parse_uri(uri)
         return self
 
     def add_call(self, op, name, defaults):
@@ -199,6 +178,10 @@ class DummyLoader(object):
     def get_wsgi_app_settings(self, name=None, defaults=None):
         self.add_call('app_settings', name, defaults)
         return self.app_settings
+
+    def get_wsgi_server(self, name=None, defaults=None):
+        self.add_call('server', name, defaults)
+        return self.server
 
     def setup_logging(self, defaults):
         self.add_call('logging', None, defaults)

--- a/pyramid/tests/test_scripts/test_prequest.py
+++ b/pyramid/tests/test_scripts/test_prequest.py
@@ -1,4 +1,5 @@
 import unittest
+from pyramid.tests.test_scripts import dummy
 
 class TestPRequestCommand(unittest.TestCase):
     def _getTargetClass(self):
@@ -7,23 +8,17 @@ class TestPRequestCommand(unittest.TestCase):
 
     def _makeOne(self, argv, headers=None):
         cmd = self._getTargetClass()(argv)
-        cmd.get_app = self.get_app
-        self._headers = headers or []
-        self._out = []
-        cmd.out = self.out
-        return cmd
-
-    def get_app(self, spec, app_name=None, options=None):
-        self._spec = spec
-        self._app_name = app_name
-        self._options = options or {}
 
         def helloworld(environ, start_request):
             self._environ = environ
             self._path_info = environ['PATH_INFO']
-            start_request('200 OK', self._headers)
+            start_request('200 OK', headers or [])
             return [b'abc']
-        return helloworld
+        self.loader = dummy.DummyLoader(app=helloworld)
+        self._out = []
+        cmd._get_config_loader = self.loader
+        cmd.out = self.out
+        return cmd
 
     def out(self, msg):
         self._out.append(msg)
@@ -38,8 +33,10 @@ class TestPRequestCommand(unittest.TestCase):
                 [('Content-Type', 'text/html; charset=UTF-8')])
         command.run()
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
+        self.assertEqual(self.loader.uri, 'development.ini')
+        self.assertEqual(self.loader.calls[0]['op'], 'logging')
+        self.assertEqual(self.loader.calls[1]['op'], 'app')
+        self.assertEqual(self.loader.calls[1]['name'], None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_path_doesnt_start_with_slash(self):
@@ -47,8 +44,7 @@ class TestPRequestCommand(unittest.TestCase):
                 [('Content-Type', 'text/html; charset=UTF-8')])
         command.run()
         self.assertEqual(self._path_info, '/abc')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
+        self.assertEqual(self.loader.uri, 'development.ini')
         self.assertEqual(self._out, ['abc'])
 
     def test_command_has_bad_config_header(self):
@@ -67,8 +63,6 @@ class TestPRequestCommand(unittest.TestCase):
         command.run()
         self.assertEqual(self._environ['HTTP_NAME'], 'value')
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_w_basic_auth(self):
@@ -81,8 +75,6 @@ class TestPRequestCommand(unittest.TestCase):
         self.assertEqual(self._environ['HTTP_AUTHORIZATION'],
                         'Basic dXNlcjpwYXNzd29yZA==')
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_has_content_type_header_var(self):
@@ -92,8 +84,6 @@ class TestPRequestCommand(unittest.TestCase):
         command.run()
         self.assertEqual(self._environ['CONTENT_TYPE'], 'app/foo')
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_has_multiple_header_vars(self):
@@ -109,8 +99,6 @@ class TestPRequestCommand(unittest.TestCase):
         self.assertEqual(self._environ['HTTP_NAME'], 'value')
         self.assertEqual(self._environ['HTTP_NAME2'], 'value2')
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_method_get(self):
@@ -119,8 +107,6 @@ class TestPRequestCommand(unittest.TestCase):
         command.run()
         self.assertEqual(self._environ['REQUEST_METHOD'], 'GET')
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_method_post(self):
@@ -134,8 +120,6 @@ class TestPRequestCommand(unittest.TestCase):
         self.assertEqual(self._environ['CONTENT_LENGTH'], '-1')
         self.assertEqual(self._environ['wsgi.input'], stdin)
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_method_put(self):
@@ -149,8 +133,6 @@ class TestPRequestCommand(unittest.TestCase):
         self.assertEqual(self._environ['CONTENT_LENGTH'], '-1')
         self.assertEqual(self._environ['wsgi.input'], stdin)
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_method_patch(self):
@@ -164,8 +146,6 @@ class TestPRequestCommand(unittest.TestCase):
         self.assertEqual(self._environ['CONTENT_LENGTH'], '-1')
         self.assertEqual(self._environ['wsgi.input'], stdin)
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_method_propfind(self):
@@ -178,8 +158,6 @@ class TestPRequestCommand(unittest.TestCase):
         command.run()
         self.assertEqual(self._environ['REQUEST_METHOD'], 'PROPFIND')
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_method_options(self):
@@ -192,8 +170,6 @@ class TestPRequestCommand(unittest.TestCase):
         command.run()
         self.assertEqual(self._environ['REQUEST_METHOD'], 'OPTIONS')
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_with_query_string(self):
@@ -202,8 +178,6 @@ class TestPRequestCommand(unittest.TestCase):
         command.run()
         self.assertEqual(self._environ['QUERY_STRING'], 'a=1&b=2&c')
         self.assertEqual(self._path_info, '/abc')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(self._out, ['abc'])
 
     def test_command_display_headers(self):
@@ -212,8 +186,6 @@ class TestPRequestCommand(unittest.TestCase):
             [('Content-Type', 'text/html; charset=UTF-8')])
         command.run()
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
         self.assertEqual(
             self._out,
             ['200 OK', 'Content-Type: text/html; charset=UTF-8', 'abc'])
@@ -223,21 +195,13 @@ class TestPRequestCommand(unittest.TestCase):
                                 headers=[('Content-Type', 'image/jpeg')])
         command.run()
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self._spec, 'development.ini')
-        self.assertEqual(self._app_name, None)
 
         self.assertEqual(self._out, [b'abc'])
 
     def test_command_method_configures_logging(self):
         command = self._makeOne(['', 'development.ini', '/'])
-        called_args = []
-
-        def configure_logging(app_spec):
-            called_args.append(app_spec)
-
-        command.configure_logging = configure_logging
         command.run()
-        self.assertEqual(called_args, ['development.ini'])
+        self.assertEqual(self.loader.calls[0]['op'], 'logging')
 
 
 class Test_main(unittest.TestCase):

--- a/pyramid/tests/test_scripts/test_prequest.py
+++ b/pyramid/tests/test_scripts/test_prequest.py
@@ -33,7 +33,7 @@ class TestPRequestCommand(unittest.TestCase):
                 [('Content-Type', 'text/html; charset=UTF-8')])
         command.run()
         self.assertEqual(self._path_info, '/')
-        self.assertEqual(self.loader.uri, 'development.ini')
+        self.assertEqual(self.loader.uri.path, 'development.ini')
         self.assertEqual(self.loader.calls[0]['op'], 'logging')
         self.assertEqual(self.loader.calls[1]['op'], 'app')
         self.assertEqual(self.loader.calls[1]['name'], None)
@@ -44,7 +44,7 @@ class TestPRequestCommand(unittest.TestCase):
                 [('Content-Type', 'text/html; charset=UTF-8')])
         command.run()
         self.assertEqual(self._path_info, '/abc')
-        self.assertEqual(self.loader.uri, 'development.ini')
+        self.assertEqual(self.loader.uri.path, 'development.ini')
         self.assertEqual(self._out, ['abc'])
 
     def test_command_has_bad_config_header(self):

--- a/pyramid/tests/test_scripts/test_proutes.py
+++ b/pyramid/tests/test_scripts/test_proutes.py
@@ -19,7 +19,8 @@ class TestPRoutesCommand(unittest.TestCase):
 
     def _makeOne(self):
         cmd = self._getTargetClass()([])
-        cmd.bootstrap = (dummy.DummyBootstrap(),)
+        cmd.bootstrap = dummy.DummyBootstrap()
+        cmd.get_config_loader = dummy.DummyLoader()
         cmd.args.config_uri = '/foo/bar/myapp.ini#myapp'
 
         return cmd
@@ -37,14 +38,15 @@ class TestPRoutesCommand(unittest.TestCase):
 
     def test_good_args(self):
         cmd = self._getTargetClass()([])
-        cmd.bootstrap = (dummy.DummyBootstrap(),)
+        cmd.bootstrap = dummy.DummyBootstrap()
+        cmd.get_config_loader = dummy.DummyLoader()
         cmd.args.config_uri = '/foo/bar/myapp.ini#myapp'
         cmd.args.config_args = ('a=1',)
         route = dummy.DummyRoute('a', '/a')
         mapper = dummy.DummyMapper(route)
         cmd._get_mapper = lambda *arg: mapper
         registry = self._makeRegistry()
-        cmd.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        cmd.bootstrap = dummy.DummyBootstrap(registry=registry)
         L = []
         cmd.out = lambda msg: L.append(msg)
         cmd.run()
@@ -52,7 +54,8 @@ class TestPRoutesCommand(unittest.TestCase):
 
     def test_bad_args(self):
         cmd = self._getTargetClass()([])
-        cmd.bootstrap = (dummy.DummyBootstrap(),)
+        cmd.bootstrap = dummy.DummyBootstrap()
+        cmd.get_config_loader = dummy.DummyLoader()
         cmd.args.config_uri = '/foo/bar/myapp.ini#myapp'
         cmd.args.config_vars = ('a',)
         route = dummy.DummyRoute('a', '/a')
@@ -86,7 +89,7 @@ class TestPRoutesCommand(unittest.TestCase):
         mapper = dummy.DummyMapper(route)
         command._get_mapper = lambda *arg: mapper
         registry = self._makeRegistry()
-        command.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=registry)
 
         L = []
         command.out = L.append
@@ -103,7 +106,7 @@ class TestPRoutesCommand(unittest.TestCase):
         L = []
         command.out = L.append
         registry = self._makeRegistry()
-        command.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -124,7 +127,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command._get_mapper = lambda *arg: mapper
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -150,7 +153,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command._get_mapper = lambda *arg: mapper
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -190,7 +193,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command._get_mapper = lambda *arg: mapper
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -218,7 +221,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -252,7 +255,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command._get_mapper = lambda *arg: mapper
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -288,7 +291,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command._get_mapper = lambda *arg: mapper
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -327,7 +330,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -354,7 +357,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -382,7 +385,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -410,7 +413,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -436,7 +439,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 5)
@@ -461,7 +464,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -491,7 +494,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config2.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config2.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -521,7 +524,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -551,7 +554,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -592,7 +595,7 @@ class TestPRoutesCommand(unittest.TestCase):
 
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -624,7 +627,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command.args.format = 'method,name'
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)
@@ -654,7 +657,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command.args.format = 'predicates,name,pattern'
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         expected = (
             "You provided invalid formats ['predicates'], "
             "Available formats are ['name', 'pattern', 'view', 'method']"
@@ -682,10 +685,9 @@ class TestPRoutesCommand(unittest.TestCase):
 
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
-        config_factory = dummy.DummyConfigParserFactory()
-        command.ConfigParser = config_factory
-        config_factory.items = [('format', 'method\nname')]
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
+        command.get_config_loader = dummy.DummyLoader(
+            {'proutes': {'format': 'method\nname'}})
 
         result = command.run()
         self.assertEqual(result, 0)
@@ -715,10 +717,9 @@ class TestPRoutesCommand(unittest.TestCase):
 
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
-        config_factory = dummy.DummyConfigParserFactory()
-        command.ConfigParser = config_factory
-        config_factory.items = [('format', 'method name')]
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
+        command.get_config_loader = dummy.DummyLoader(
+            {'proutes': {'format': 'method name'}})
 
         result = command.run()
         self.assertEqual(result, 0)
@@ -748,10 +749,9 @@ class TestPRoutesCommand(unittest.TestCase):
 
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
-        config_factory = dummy.DummyConfigParserFactory()
-        command.ConfigParser = config_factory
-        config_factory.items = [('format', 'method,name')]
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
+        command.get_config_loader = dummy.DummyLoader(
+            {'proutes': {'format': 'method,name'}})
 
         result = command.run()
         self.assertEqual(result, 0)
@@ -771,7 +771,7 @@ class TestPRoutesCommand(unittest.TestCase):
         command = self._makeOne()
         L = []
         command.out = L.append
-        command.bootstrap = (dummy.DummyBootstrap(registry=config.registry),)
+        command.bootstrap = dummy.DummyBootstrap(registry=config.registry)
         result = command.run()
         self.assertEqual(result, 0)
         self.assertEqual(len(L), 3)

--- a/pyramid/tests/test_scripts/test_pshell.py
+++ b/pyramid/tests/test_scripts/test_pshell.py
@@ -8,16 +8,16 @@ class TestPShellCommand(unittest.TestCase):
         from pyramid.scripts.pshell import PShellCommand
         return PShellCommand
 
-    def _makeOne(self, patch_bootstrap=True, patch_config=True,
+    def _makeOne(self, patch_bootstrap=True, patch_loader=True,
                  patch_args=True, patch_options=True):
         cmd = self._getTargetClass()([])
 
         if patch_bootstrap:
             self.bootstrap = dummy.DummyBootstrap()
-            cmd.bootstrap = (self.bootstrap,)
-        if patch_config:
-            self.config_factory = dummy.DummyConfigParserFactory()
-            cmd.ConfigParser = self.config_factory
+            cmd.bootstrap = self.bootstrap
+        if patch_loader:
+            self.loader = dummy.DummyLoader()
+            cmd.get_config_loader = self.loader
         if patch_args:
             class Args(object): pass
             self.args = Args()
@@ -46,9 +46,6 @@ class TestPShellCommand(unittest.TestCase):
 
         command.default_runner = shell
         command.run()
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertEqual(shell.env, {
             'app':self.bootstrap.app, 'root':self.bootstrap.root,
@@ -79,9 +76,6 @@ class TestPShellCommand(unittest.TestCase):
         self.assertEqual(
             out_calls, ['could not find a shell named "unknown_python_shell"']
         )
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertTrue(self.bootstrap.closer.called)
 
@@ -100,9 +94,6 @@ class TestPShellCommand(unittest.TestCase):
         command.args.python_shell = 'ipython'
 
         command.run()
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertEqual(shell.env, {
             'app':self.bootstrap.app, 'root':self.bootstrap.root,
@@ -199,12 +190,9 @@ class TestPShellCommand(unittest.TestCase):
         command = self._makeOne()
         model = dummy.Dummy()
         user = dummy.Dummy()
-        self.config_factory.items = [('m', model), ('User', user)]
+        self.loader.settings = {'pshell': {'m': model, 'User': user}}
         shell = dummy.DummyShell()
         command.run(shell)
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertEqual(shell.env, {
             'app':self.bootstrap.app, 'root':self.bootstrap.root,
@@ -223,12 +211,9 @@ class TestPShellCommand(unittest.TestCase):
             env['a'] = 1
             env['root'] = 'root override'
             env['none'] = None
-        self.config_factory.items = [('setup', setup)]
+        self.loader.settings = {'pshell': {'setup': setup}}
         shell = dummy.DummyShell()
         command.run(shell)
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertEqual(shell.env, {
             'app':self.bootstrap.app, 'root':'root override',
@@ -252,12 +237,9 @@ class TestPShellCommand(unittest.TestCase):
                 'python': dshell,
             }
         )
-        self.config_factory.items = [
-            ('default_shell', 'bpython python\nipython')]
+        self.loader.settings = {'pshell': {
+            'default_shell': 'bpython python\nipython'}}
         command.run()
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertTrue(dshell.called)
 
@@ -268,12 +250,9 @@ class TestPShellCommand(unittest.TestCase):
             env['a'] = 1
             env['m'] = 'model override'
             env['root'] = 'root override'
-        self.config_factory.items = [('setup', setup), ('m', model)]
+        self.loader.settings = {'pshell': {'setup': setup, 'm': model}}
         shell = dummy.DummyShell()
         command.run(shell)
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertEqual(shell.env, {
             'app':self.bootstrap.app, 'root':'root override',
@@ -291,14 +270,10 @@ class TestPShellCommand(unittest.TestCase):
             env['a'] = 1
             env['root'] = 'root override'
         model = dummy.Dummy()
-        self.config_factory.items = [('setup', 'abc'),
-                                     ('m', model)]
+        self.loader.settings = {'pshell': {'setup': 'abc', 'm': model}}
         command.args.setup = setup
         shell = dummy.DummyShell()
         command.run(shell)
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertEqual(shell.env, {
             'app':self.bootstrap.app, 'root':'root override',
@@ -313,13 +288,11 @@ class TestPShellCommand(unittest.TestCase):
     def test_command_custom_section_override(self):
         command = self._makeOne()
         dummy_ = dummy.Dummy()
-        self.config_factory.items = [('app', dummy_), ('root', dummy_),
-                                     ('registry', dummy_), ('request', dummy_)]
+        self.loader.settings = {'pshell': {
+            'app': dummy_, 'root': dummy_, 'registry': dummy_,
+            'request': dummy_}}
         shell = dummy.DummyShell()
         command.run(shell)
-        self.assertTrue(self.config_factory.parser)
-        self.assertEqual(self.config_factory.parser.filename,
-                         '/foo/bar/myapp.ini')
         self.assertEqual(self.bootstrap.a[0], '/foo/bar/myapp.ini#myapp')
         self.assertEqual(shell.env, {
             'app':dummy_, 'root':dummy_, 'registry':dummy_, 'request':dummy_,

--- a/pyramid/tests/test_scripts/test_ptweens.py
+++ b/pyramid/tests/test_scripts/test_ptweens.py
@@ -8,7 +8,8 @@ class TestPTweensCommand(unittest.TestCase):
 
     def _makeOne(self):
         cmd = self._getTargetClass()([])
-        cmd.bootstrap = (dummy.DummyBootstrap(),)
+        cmd.bootstrap = dummy.DummyBootstrap()
+        cmd.setup_logging = dummy.dummy_setup_logging()
         cmd.args.config_uri = '/foo/bar/myapp.ini#myapp'
         return cmd
 

--- a/pyramid/tests/test_scripts/test_pviews.py
+++ b/pyramid/tests/test_scripts/test_pviews.py
@@ -8,7 +8,8 @@ class TestPViewsCommand(unittest.TestCase):
 
     def _makeOne(self, registry=None):
         cmd = self._getTargetClass()([])
-        cmd.bootstrap = (dummy.DummyBootstrap(registry=registry),)
+        cmd.bootstrap = dummy.DummyBootstrap(registry=registry)
+        cmd.setup_logging = dummy.dummy_setup_logging()
         cmd.args.config_uri = '/foo/bar/myapp.ini#myapp'
         return cmd
 

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,12 @@ install_requires = [
     'venusian >= 1.0a3', # ``ignore``
     'translationstring >= 0.4', # py3 compat
     'PasteDeploy >= 1.5.0', # py3 compat
+    'plaster',
     'hupper',
     ]
 
 tests_require = [
+    'plaster_pastedeploy',
     'WebTest >= 1.3.1', # py3 compat
     'zope.component >= 4.0', # py3 compat
     ]

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ install_requires = [
     'translationstring >= 0.4', # py3 compat
     'PasteDeploy >= 1.5.0', # py3 compat
     'plaster',
+    'plaster_pastedeploy',
     'hupper',
     ]
 
 tests_require = [
-    'plaster_pastedeploy',
     'WebTest >= 1.3.1', # py3 compat
     'zope.component >= 4.0', # py3 compat
     ]


### PR DESCRIPTION
- [x] Replace low-level functions with plaster.
- [x] Update proutes.
- [x] Update pserve.
- [x] Update pshell.
- [x] Update logging chapter.
- [x] Update PasteDeploy chapter.
- ~~Update cookiecutters to depend on plaster_pastedeploy.~~

Fixes #2419, #1394.