### PR TITLE
push threadlocals while executing config.include functions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,12 @@ Features
   requirement that the server is being run in this format so it may fail.
   See https://github.com/Pylons/pyramid/pull/2984
 
+- The threadlocals are now available inside any function invoked via
+  ``config.include``. This means the only config-time code that cannot rely
+  on threadlocals is code executed from non-actions inside the main. This
+  can be alleviated by invoking ``config.begin()`` and ``config.end()``
+  appropriately. See https://github.com/Pylons/pyramid/pull/2989
+
 Bug Fixes
 ---------
 

--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -753,6 +753,11 @@ class Configurator(
         .. versionadded:: 1.2
            The ``route_prefix`` parameter.
 
+        .. versionchanged:: 1.9
+           The included function is wrapped with a call to
+           :meth:`pyramid.config.Configurator.begin` and
+           :meth:`pyramid.config.Configurator.end` while it is executed.
+
         """
         # """ <-- emacs
 
@@ -802,7 +807,11 @@ class Configurator(
                 )
             configurator.basepath = os.path.dirname(sourcefile)
             configurator.includepath = self.includepath + (spec,)
-            c(configurator)
+            self.begin()
+            try:
+                c(configurator)
+            finally:
+                self.end()
 
     def add_directive(self, name, directive, action_wrap=True):
         """

--- a/pyramid/tests/test_config/test_init.py
+++ b/pyramid/tests/test_config/test_init.py
@@ -817,6 +817,16 @@ pyramid.tests.test_config.dummy_include2""",
         self.assertEqual(results['root_package'], tests)
         self.assertEqual(results['package'], test_config)
 
+    def test_include_threadlocals_active(self):
+        from pyramid.tests import test_config
+        from pyramid.threadlocal import get_current_registry
+        stack = []
+        def include(config):
+            stack.append(get_current_registry())
+        config = self._makeOne()
+        config.include(include)
+        self.assertTrue(stack[0] is config.registry)
+
     def test_action_branching_kw_is_None(self):
         config = self._makeOne(autocommit=True)
         self.assertEqual(config.action('discrim'), None)


### PR DESCRIPTION
We don't push threadlocals in the `main` because there is no clear contract on its lifecycle. However we can push them during `config.include(...)` calls so that they are available there. Just a little more incentive to put all your code into include functions!