### PR TITLE
cgi.escape() is deprecated. (For Python 3)

### DIFF
--- a/docs/tutorials/wiki2/src/views/tutorial/views/default.py
+++ b/docs/tutorials/wiki2/src/views/tutorial/views/default.py
@@ -1,4 +1,4 @@
-import cgi
+import html
 import re
 from docutils.core import publish_parts
 
@@ -31,10 +31,10 @@ def view_page(request):
         exists = request.dbsession.query(Page).filter_by(name=word).all()
         if exists:
             view_url = request.route_url('view_page', pagename=word)
-            return '<a href="%s">%s</a>' % (view_url, cgi.escape(word))
+            return '<a href="%s">%s</a>' % (view_url, html.escape(word))
         else:
             add_url = request.route_url('add_page', pagename=word)
-            return '<a href="%s">%s</a>' % (add_url, cgi.escape(word))
+            return '<a href="%s">%s</a>' % (add_url, html.escape(word))
 
     content = publish_parts(page.data, writer_name='html')['html_body']
     content = wikiwords.sub(add_link, content)


### PR DESCRIPTION
I just realised this can be a compatible issue for Python 2 and 3 because no warning in the Python 2.7 doc. I am not sure how the Pylon project deals with this. I will leave this decision to you and learn from it. From a newbie. Cheers.

Source: https://docs.python.org/3.6/library/cgi.html
Deprecated since version 3.2: This function is unsafe because quote is false by default, and therefore deprecated. Use html.escape() instead.