### PR TITLE
normalize excview tween to use ``request.invoke_exception_view``

### DIFF
--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -778,11 +778,11 @@ class TestViewMethodsMixin(unittest.TestCase):
         orig_response = request.response = DummyResponse(b'foo')
         try:
             raise RuntimeError
-        except RuntimeError:
+        except RuntimeError as ex:
             response = request.invoke_exception_view()
             self.assertEqual(response.app_iter, [b'bar'])
-            self.assertTrue(request.exception is orig_exc)
-            self.assertTrue(request.exc_info is orig_exc_info)
+            self.assertTrue(request.exception is ex)
+            self.assertTrue(request.exc_info[1] is ex)
             self.assertTrue(request.response is orig_response)
         else: # pragma: no cover
             self.fail()

--- a/pyramid/tweens.py
+++ b/pyramid/tweens.py
@@ -1,55 +1,18 @@
 import sys
 
 from pyramid.compat import reraise
-from pyramid.exceptions import PredicateMismatch
-from pyramid.interfaces import (
-    IExceptionViewClassifier,
-    IRequest,
-    )
-
-from zope.interface import providedBy
-from pyramid.view import _call_view
+from pyramid.httpexceptions import HTTPNotFound
 
 def _error_handler(request, exc):
     # NOTE: we do not need to delete exc_info because this function
     # should never be in the call stack of the exception
     exc_info = sys.exc_info()
 
-    attrs = request.__dict__
-    attrs['exc_info'] = exc_info
-    attrs['exception'] = exc
-    # clear old generated request.response, if any; it may
-    # have been mutated by the view, and its state is not
-    # sane (e.g. caching headers)
-    if 'response' in attrs:
-        del attrs['response']
-    # we use .get instead of .__getitem__ below due to
-    # https://github.com/Pylons/pyramid/issues/700
-    request_iface = attrs.get('request_iface', IRequest)
-    provides = providedBy(exc)
     try:
-        response = _call_view(
-            request.registry,
-            request,
-            exc,
-            provides,
-            '',
-            view_classifier=IExceptionViewClassifier,
-            request_iface=request_iface.combined
-            )
-
-    # if views matched but did not pass predicates then treat the
-    # same as not finding any matching views
-    except PredicateMismatch:
-        response = None
-
-    # re-raise the original exception as no exception views were
-    # able to handle the error
-    if response is None:
-        if 'exception' in attrs:
-            del attrs['exception']
-        if 'exc_info' in attrs:
-            del attrs['exc_info']
+        response = request.invoke_exception_view(exc_info)
+    except HTTPNotFound:
+        # re-raise the original exception as no exception views were
+        # able to handle the error
         reraise(*exc_info)
 
     return response


### PR DESCRIPTION
``request.exception`` and ``request.exc_info`` are set to the
exception used to render the response but they are reset to their
original values if no response could be rendered

minor incompatibility in that ``request.response`` is restored after the
excview tween but should not be an issue because a response is returned
thus request.response should be ignored by anyone who cares.

fixes #3030