### PR TITLE
Fix #1603, add closest predicate name in error message

### DIFF
--- a/pyramid/config/util.py
+++ b/pyramid/config/util.py
@@ -1,3 +1,4 @@
+from difflib import get_close_matches
 from hashlib import md5
 import inspect
 
@@ -36,7 +37,7 @@ class not_(object):
 
        config.add_view(
            'mypackage.views.my_view',
-           route_name='ok', 
+           route_name='ok',
            request_method=not_('POST')
            )
 
@@ -69,7 +70,7 @@ class Notted(object):
         # if the underlying predicate doesnt return a value, it's not really
         # a predicate, it's just something pretending to be a predicate,
         # so dont update the hash
-        if val: 
+        if val:
             val = '!' + val
         return val
 
@@ -90,7 +91,7 @@ class Notted(object):
 # over = before
 
 class PredicateList(object):
-    
+
     def __init__(self):
         self.sorter = TopologicalSorter()
         self.last_added = None
@@ -152,7 +153,15 @@ class PredicateList(object):
                 weights.append(1 << n + 1)
                 preds.append(pred)
         if kw:
-            raise ConfigurationError('Unknown predicate values: %r' % (kw,))
+            closest = []
+            names = [ name for name, _ in ordered ]
+            for name in kw:
+                closest.extend(get_close_matches(name, names, 3))
+
+            raise ConfigurationError(
+                'Unknown predicate values: %r (did you mean %s)'
+                % (kw, ','.join(closest))
+            )
         # A "order" is computed for the predicate list.  An order is
         # a scoring.
         #

--- a/pyramid/config/util.py
+++ b/pyramid/config/util.py
@@ -1,4 +1,3 @@
-from difflib import get_close_matches
 from hashlib import md5
 import inspect
 
@@ -153,6 +152,7 @@ class PredicateList(object):
                 weights.append(1 << n + 1)
                 preds.append(pred)
         if kw:
+            from difflib import get_close_matches
             closest = []
             names = [ name for name, _ in ordered ]
             for name in kw:

--- a/pyramid/tests/test_config/test_util.py
+++ b/pyramid/tests/test_config/test_util.py
@@ -365,6 +365,16 @@ class TestPredicateList(unittest.TestCase):
         from pyramid.exceptions import ConfigurationError
         self.assertRaises(ConfigurationError, self._callFUT, unknown=1)
 
+    def test_predicate_close_matches(self):
+        from pyramid.exceptions import ConfigurationError
+        with  self.assertRaises(ConfigurationError) as context:
+            self._callFUT(method='GET')
+        expected_msg = (
+            "Unknown predicate values: {'method': 'GET'} "
+            "(did you mean request_method)"
+        )
+        self.assertEqual(context.exception.args[0], expected_msg)
+
     def test_notted(self):
         from pyramid.config import not_
         from pyramid.testing import DummyRequest


### PR DESCRIPTION
Fix #1603, add closest predicate name in error message