### PR TITLE
Proposal for optional split between HTTPForbidden and HTTPUnauthorized (#3066)

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -302,3 +302,5 @@ Contributors
 - Jeremy(Ching-Rui) Chen, 2017/04/19
 
 - Fang-Pen Lin, 2017/05/22
+
+- Volker Diels-Grabsch, 2017/06/09

--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -1072,29 +1072,31 @@ class BasicAuthAuthenticationPolicy(CallbackAuthenticationPolicy):
         steps.  The output from debugging is useful for reporting to maillist
         or IRC channels when asking for support.
 
-    **Issuing a challenge**
+    ``use_http_unauthorized_exception``
 
-    Regular browsers will not send username/password credentials unless they
-    first receive a challenge from the server.  The following recipe will
-    register a view that will send a Basic Auth challenge to the user whenever
-    there is an attempt to call a view which results in a Forbidden response::
+        Default: ``False``.  Regular browsers will not send username/password
+        credentials unless they first receive a challenge from the server.
+        Setting ``use_http_unauthorized_exception`` to ``True`` will send a
+        Basic Auth challenge to the user whenever the user is not authenticated
+        (``request.authenticated_userid`` is ``None``) and there is an attempt
+        to call a view which is forbidden.  You can perform custom operations
+        on a challenge page by providing a custom exception view for
+        ``HTTPUnauthorized``::
 
-        from pyramid.httpexceptions import HTTPUnauthorized
-        from pyramid.security import forget
-        from pyramid.view import forbidden_view_config
+            from pyramid.httpexceptions import HTTPUnauthorized
+            from pyramid.security import forget
+            from pyramid.view import exception_view_config
 
-        @forbidden_view_config()
-        def forbidden_view(request):
-            if request.authenticated_userid is None:
-                response = HTTPUnauthorized()
+            @exception_view_config(HTTPUnauthorized)
+            def unauthorized_view(request):
                 response.headers.update(forget(request))
                 return response
-            return HTTPForbidden()
     """
-    def __init__(self, check, realm='Realm', debug=False):
+    def __init__(self, check, realm='Realm', debug=False, use_http_unauthorized_exception=False):
         self.check = check
         self.realm = realm
         self.debug = debug
+        self.use_http_unauthorized_exception = use_http_unauthorized_exception
 
     def unauthenticated_userid(self, request):
         """ The userid parsed from the ``Authorization`` request header."""

--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -1084,10 +1084,12 @@ class BasicAuthAuthenticationPolicy(CallbackAuthenticationPolicy):
         from pyramid.view import forbidden_view_config
 
         @forbidden_view_config()
-        def basic_challenge(request):
-            response = HTTPUnauthorized()
-            response.headers.update(forget(request))
-            return response
+        def forbidden_view(request):
+            if request.authenticated_userid is None:
+                response = HTTPUnauthorized()
+                response.headers.update(forget(request))
+                return response
+            return HTTPForbidden()
     """
     def __init__(self, check, realm='Realm', debug=False):
         self.check = check

--- a/pyramid/viewderivers.py
+++ b/pyramid/viewderivers.py
@@ -302,6 +302,8 @@ def _secured_view(view, info):
             msg = getattr(
                 request, 'authdebug_message',
                 'Unauthorized: %s failed permission check' % view_name)
+            if getattr(authn_policy, 'use_http_unauthorized_exception', False) and request.authenticated_userid is None:
+                raise HTTPUnauthorized(msg, result=result)
             raise HTTPForbidden(msg, result=result)
         wrapped_view = secured_view
         wrapped_view.__call_permissive__ = view


### PR DESCRIPTION
Add optional use_http_unauthorized_exception to split between HTTPForbidden and HTTPUnauthorized.

Discussion: https://github.com/Pylons/pyramid/issues/3066#issuecomment-307409096

Note that the documentation adjustment in this pull request builds upon the documentation corrections provided #3079.