### PR TITLE
fix p.security.ACLPermitsResult to subclass p.security.PermitsResult

### DIFF
--- a/docs/api/security.rst
+++ b/docs/api/security.rst
@@ -80,15 +80,23 @@ Return Values
     'george', 'read')`` that means deny access.  A sequence of ACEs
     makes up an ACL.  It is a string, and its actual value is "Deny".
 
-.. autoclass:: ACLDenied
-   :members:
-
-.. autoclass:: ACLAllowed
-   :members:
-
 .. autoclass:: Denied
-   :members:
+   :members: msg
+
+   .. automethod:: __new__
 
 .. autoclass:: Allowed
-   :members:
+   :members: msg
+
+   .. automethod:: __new__
+
+.. autoclass:: ACLDenied
+   :members: msg
+
+   .. automethod:: __new__
+
+.. autoclass:: ACLAllowed
+   :members: msg
+
+   .. automethod:: __new__
 

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -503,8 +503,10 @@ class IAuthenticationPolicy(Interface):
 class IAuthorizationPolicy(Interface):
     """ An object representing a Pyramid authorization policy. """
     def permits(context, principals, permission):
-        """ Return ``True`` if any of the ``principals`` is allowed the
-        ``permission`` in the current ``context``, else return ``False``
+        """ Return an instance of :class:`pyramid.security.Allowed` if any
+        of the ``principals`` is allowed the ``permission`` in the current
+        ``context``, else return an instance of
+        :class:`pyramid.security.Denied`.
         """
 
     def principals_allowed_by_permission(context, permission):

--- a/pyramid/tests/test_security.py
+++ b/pyramid/tests/test_security.py
@@ -92,9 +92,11 @@ class TestACLAllowed(unittest.TestCase):
         return klass(*arg, **kw)
 
     def test_it(self):
+        from pyramid.security import Allowed
         msg = ("ACLAllowed permission 'permission' via ACE 'ace' in ACL 'acl' "
                "on context 'ctx' for principals 'principals'")
         allowed = self._makeOne('ace', 'acl', 'permission', 'principals', 'ctx')
+        self.assertIsInstance(allowed, Allowed)
         self.assertTrue(msg in allowed.msg)
         self.assertEqual(allowed, True)
         self.assertTrue(allowed)
@@ -112,9 +114,11 @@ class TestACLDenied(unittest.TestCase):
         return klass(*arg, **kw)
 
     def test_it(self):
+        from pyramid.security import Denied
         msg = ("ACLDenied permission 'permission' via ACE 'ace' in ACL 'acl' "
                "on context 'ctx' for principals 'principals'")
         denied = self._makeOne('ace', 'acl', 'permission', 'principals', 'ctx')
+        self.assertIsInstance(denied, Denied)
         self.assertTrue(msg in denied.msg)
         self.assertEqual(denied, False)
         self.assertFalse(denied)


### PR DESCRIPTION
The ``IAuthorizationPolicy`` is expected to return an instance of
``PermitsResult`` and the ``ACLPermitsResult`` now subclasses this to
form a consistent class hierarchy.

Similarly the ``ACLDenied`` subclasses ``Denied`` and ``ACLAllowed``
subclasses ``Allowed`` for consistency.

Fixes #3078.