### PR TITLE
Make DummyBootstrap return a context manager

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -308,3 +308,5 @@ Contributors
 - Volker Diels-Grabsch, 2017/06/09
 
 - Denis Rykov, 2017/06/15
+
+- Andrey Tretyakov, 2017/06/20

--- a/pyramid/scripts/ptweens.py
+++ b/pyramid/scripts/ptweens.py
@@ -80,29 +80,29 @@ class PTweensCommand(object):
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         self.setup_logging(config_uri, global_conf=config_vars)
-        env = self.bootstrap(config_uri, options=config_vars)
-        registry = env['registry']
-        tweens = self._get_tweens(registry)
-        if tweens is not None:
-            explicit = tweens.explicit
-            if explicit:
-                self.out('"pyramid.tweens" config value set '
-                         '(explicitly ordered tweens used)')
-                self.out('')
-                self.out('Explicit Tween Chain (used)')
-                self.out('')
-                self.show_chain(tweens.explicit)
-                self.out('')
-                self.out('Implicit Tween Chain (not used)')
-                self.out('')
-                self.show_chain(tweens.implicit())
-            else:
-                self.out('"pyramid.tweens" config value NOT set '
-                         '(implicitly ordered tweens used)')
-                self.out('')
-                self.out('Implicit Tween Chain')
-                self.out('')
-                self.show_chain(tweens.implicit())
+        with self.bootstrap(config_uri, options=config_vars) as env:
+            registry = env['registry']
+            tweens = self._get_tweens(registry)
+            if tweens is not None:
+                explicit = tweens.explicit
+                if explicit:
+                    self.out('"pyramid.tweens" config value set '
+                             '(explicitly ordered tweens used)')
+                    self.out('')
+                    self.out('Explicit Tween Chain (used)')
+                    self.out('')
+                    self.show_chain(tweens.explicit)
+                    self.out('')
+                    self.out('Implicit Tween Chain (not used)')
+                    self.out('')
+                    self.show_chain(tweens.implicit())
+                else:
+                    self.out('"pyramid.tweens" config value NOT set '
+                             '(implicitly ordered tweens used)')
+                    self.out('')
+                    self.out('Implicit Tween Chain')
+                    self.out('')
+                    self.show_chain(tweens.implicit())
         return 0
 
 if __name__ == '__main__': # pragma: no cover

--- a/pyramid/tests/test_scripts/dummy.py
+++ b/pyramid/tests/test_scripts/dummy.py
@@ -111,14 +111,21 @@ class DummyBootstrap(object):
         registry = kw.get('registry', self.registry)
         request = kw.get('request', self.request)
         request.registry = registry
-        return {
-            'app': self.app,
-            'registry': registry,
-            'request': request,
-            'root': self.root,
-            'root_factory': self.root_factory,
-            'closer': self.closer,
-        }
+        return DummyAppEnvironment(
+            app=self.app,
+            registry=registry,
+            request=request,
+            root=self.root,
+            root_factory=self.root_factory,
+            closer=self.closer,
+        )
+
+class DummyAppEnvironment(dict):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self['closer']()
 
 
 class DummyEntryPoint(object):


### PR DESCRIPTION
Closes #3096
Currently no scripts use context manager mode, and there was a missing coverage, so I converted ptweens to use the context manager mode