### PR TITLE
Category support for view config

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -308,3 +308,5 @@ Contributors
 - Volker Diels-Grabsch, 2017/06/09
 
 - Denis Rykov, 2017/06/15
+
+- Tosh Lyons, 2017/06/27

--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -566,6 +566,26 @@ class TestViewConfigDecorator(unittest.TestCase):
         decorator(foo)
         self.assertEqual(venusian.depth, 2)
 
+    def test_call_withoutcategory(self):
+        decorator = self._makeOne()
+        venusian = DummyVenusian()
+        decorator.venusian = venusian
+        def foo(): pass
+        decorator(foo)
+        attachments = venusian.attachments
+        category = attachments[0][2]
+        self.assertEqual(category, 'pyramid')
+
+    def test_call_withcategory(self):
+        decorator = self._makeOne(category='not_pyramid')
+        venusian = DummyVenusian()
+        decorator.venusian = venusian
+        def foo(): pass
+        decorator(foo)
+        attachments = venusian.attachments
+        category = attachments[0][2]
+        self.assertEqual(category, 'not_pyramid')
+
 class Test_append_slash_notfound_view(BaseTest, unittest.TestCase):
     def _callFUT(self, context, request):
         from pyramid.view import append_slash_notfound_view

--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -577,7 +577,7 @@ class TestViewConfigDecorator(unittest.TestCase):
         self.assertEqual(category, 'pyramid')
 
     def test_call_withcategory(self):
-        decorator = self._makeOne(category='not_pyramid')
+        decorator = self._makeOne(_category='not_pyramid')
         venusian = DummyVenusian()
         decorator.venusian = venusian
         def foo(): pass

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -196,10 +196,10 @@ class view_config(object):
     context. It's not often used, but it can be useful in this circumstance.
 
     ``category`` sets the decorator category name. It can be useful in
-    combination with the ``category`` argument to ``scan`` to control which
+    combination with the ``category`` argument of ``scan`` to control which
     views should be processed.
 
-    See the ``attach`` function in Venusian for more information.
+    See the :py:func:`venusian.attach` function in Venusian for more information.
     
     .. seealso::
     

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -186,7 +186,7 @@ class view_config(object):
     out, its default will be the equivalent ``add_view`` default.
 
     Two additional keyword arguments which will be passed to the
-    :term:`venusian` ``attach`` function are ``_depth`` and ``category``.
+    :term:`venusian` ``attach`` function are ``_depth`` and ``_category``.
 
     ``_depth`` is provided for people who wish to reuse this class from another
     decorator. The default value is ``0`` and should be specified relative to
@@ -195,7 +195,7 @@ class view_config(object):
     Venusian checks if the decorator is being used in a class or module
     context. It's not often used, but it can be useful in this circumstance.
 
-    ``category`` sets the decorator category name. It can be useful in
+    ``_category`` sets the decorator category name. It can be useful in
     combination with the ``category`` argument of ``scan`` to control which
     views should be processed.
 
@@ -222,7 +222,7 @@ class view_config(object):
     def __call__(self, wrapped):
         settings = self.__dict__.copy()
         depth = settings.pop('_depth', 0)
-        category = settings.pop('category', 'pyramid')
+        category = settings.pop('_category', 'pyramid')
 
         def callback(context, name, ob):
             config = context.config.with_package(info.module)

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -215,12 +215,13 @@ class view_config(object):
     def __call__(self, wrapped):
         settings = self.__dict__.copy()
         depth = settings.pop('_depth', 0)
+        category = settings.pop('category', 'pyramid')
 
         def callback(context, name, ob):
             config = context.config.with_package(info.module)
             config.add_view(view=ob, **settings)
 
-        info = self.venusian.attach(wrapped, callback, category='pyramid',
+        info = self.venusian.attach(wrapped, callback, category=category,
                                     depth=depth + 1)
 
         if info.scope == 'class':

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -185,14 +185,21 @@ class view_config(object):
     :meth:`pyramid.config.Configurator.add_view`.  If any argument is left
     out, its default will be the equivalent ``add_view`` default.
 
-    An additional keyword argument named ``_depth`` is provided for people who
-    wish to reuse this class from another decorator.  The default value is
-    ``0`` and should be specified relative to the ``view_config`` invocation.
-    It will be passed in to the :term:`venusian` ``attach`` function as the
-    depth of the callstack when Venusian checks if the decorator is being used
-    in a class or module context.  It's not often used, but it can be useful
-    in this circumstance.  See the ``attach`` function in Venusian for more
-    information.
+    Two additional keyword arguments which will be passed to the
+    :term:`venusian` ``attach`` function are ``_depth`` and ``category``.
+
+    ``_depth`` is provided for people who wish to reuse this class from another
+    decorator. The default value is ``0`` and should be specified relative to
+    the ``view_config`` invocation. It will be passed in to the
+    :term:`venusian` ``attach`` function as the depth of the callstack when
+    Venusian checks if the decorator is being used in a class or module
+    context. It's not often used, but it can be useful in this circumstance.
+
+    ``category`` sets the decorator category name. It can be useful in
+    combination with the ``category`` argument to ``scan`` to control which
+    views should be processed.
+
+    See the ``attach`` function in Venusian for more information.
     
     .. seealso::
     


### PR DESCRIPTION
Allow users to assign custom categories.

This is useful for controlling which views are processed during a scan. 