### PR TITLE
add a manifest and a tox step to check it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
           env: TOXENV=py34
         - python: 3.5
           env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
         - python: pypy
           env: TOXENV=pypy
         - python: 3.5
@@ -18,8 +20,8 @@ matrix:
           env: TOXENV=docs
         - python: 3.5
           env: TOXENV=pep8
-        - python: 3.6
-          env: TOXENV=py36
+        - python: 3.5
+          env: TOXENV=sdist
         - python: nightly
           env: TOXENV=py37
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,7 @@ matrix:
         - python: 3.5
           env: TOXENV=docs
         - python: 3.5
-          env: TOXENV=pep8
-        - python: 3.5
-          env: TOXENV=sdist
+          env: TOXENV=lint
         - python: nightly
           env: TOXENV=py37
     allow_failures:

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -51,11 +51,6 @@ repo, from which you can submit a pull request.
   To use the instructions in the steps that follow literally, use the
   ``export VENV=~/hack-on-pyramid/env`` command.
 
-- Install ``setuptools-git`` into the virtual environment (for good measure, as
-  we're using git to do version control):
-
-    $ $VENV/bin/pip install setuptools-git
-
 - Install Pyramid from the checkout into the virtual environment, where the
   current working directory is the ``pyramid`` checkout directory. We will
   install Pyramid in editable (development) mode as well as its testing

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,16 @@
+graft pyramid
+graft docs
+prune docs/_build
+
+include README.rst
+include CHANGES.txt HISTORY.txt BFG_HISTORY.txt
+include CONTRIBUTORS.txt LICENSE.txt COPYRIGHT.txt
+
+include contributing.md RELEASING.txt
+include tox.ini appveyor.yml .travis.yml rtd.txt
+
+include HACKING.txt hacking-tox.ini
+include builddocs.sh coverage.sh scaffoldtests.sh
+include TODO.txt
+
+global-exclude __pycache__ *.py[cod]

--- a/RELEASING.txt
+++ b/RELEASING.txt
@@ -71,15 +71,9 @@ Prepare new release branch
 
 - Change setup.py version to the release version number.
 
-- Make sure PyPI long description renders (requires ``readme_renderer``
-  installed into your Python)::
-
-  $ python setup.py check -r -s -m
-
 - Create a release tag.
 
-- Make sure your Python has ``setuptools-git``, ``twine``, and ``wheel``
-  installed and release to PyPI::
+- Build and publish to PyPI::
 
   $ python setup.py sdist bdist_wheel
   $ twine upload dist/pyramid-X.X-*
@@ -163,9 +157,8 @@ https://github.com/Pylons/pyramid/issues
 ```
 Pyramid 1.X.X has been released.
 
-Here are the changes:
-
-<<changes>>
+The full changelog is here:
+https://docs.pylonsproject.org/projects/pyramid/en/1.X-branch/changes.html
 
 What's New In Pyramid 1.X:
 https://docs.pylonsproject.org/projects/pyramid/en/1.X-branch/whatsnew-1.X.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,3 +66,13 @@ ignore =
     W391
 exclude = pyramid/tests/,pyramid/compat.py,pyramid/resource.py
 show-source = True
+
+[check-manifest]
+ignore =
+    .gitignore
+    PKG-INFO
+    *.egg-info
+    *.egg-info/*
+ignore-default-rules = true
+ignore-bad-ideas =
+    pyramid/tests/pkgs/localeapp/*

--- a/setup.py
+++ b/setup.py
@@ -12,18 +12,14 @@
 #
 ##############################################################################
 
-import os
-
 from setuptools import setup, find_packages
 
-here = os.path.abspath(os.path.dirname(__file__))
-try:
-    with open(os.path.join(here, 'README.rst')) as f:
-        README = f.read()
-    with open(os.path.join(here, 'CHANGES.txt')) as f:
-        CHANGES = f.read()
-except IOError:
-    README = CHANGES = ''
+def readfile(name):
+    with open(name) as f:
+        return f.read()
+
+README = readfile('README.rst')
+CHANGES = readfile('CHANGES.txt')
 
 install_requires = [
     'setuptools',

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,py37,pypy,
-    docs,pep8,
+    py27,py34,py35,py36,pypy,
+    docs,pep8,sdist,
     {py2,py3}-cover,coverage,
-skip_missing_interpreters = True
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
@@ -58,6 +57,15 @@ commands =
     flake8 pyramid/
 deps =
     flake8
+
+[testenv:sdist]
+basepython = python3.5
+commands =
+    python setup.py check -r -s -m
+    check-manifest
+deps =
+    readme_renderer
+    check-manifest
 
 [testenv:docs]
 basepython = python3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
+    lint,
     py27,py34,py35,py36,pypy,
-    docs,pep8,sdist,
-    {py2,py3}-cover,coverage,
+    docs,{py2,py3}-cover,coverage,
 
 [testenv]
 # Most of these are defaults but if you specify any you can't fall back
@@ -51,19 +51,14 @@ commands =
     python pyramid/scaffolds/tests.py
 deps = virtualenv
 
-[testenv:pep8]
+[testenv:lint]
 basepython = python3.5
 commands =
     flake8 pyramid/
-deps =
-    flake8
-
-[testenv:sdist]
-basepython = python3.5
-commands =
     python setup.py check -r -s -m
     check-manifest
 deps =
+    flake8
     readme_renderer
     check-manifest
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ commands =
 deps = virtualenv
 
 [testenv:lint]
+skip_install = True
 basepython = python3.5
 commands =
     flake8 pyramid/
@@ -63,6 +64,7 @@ deps =
     check-manifest
 
 [testenv:docs]
+skip_install = True
 basepython = python3.5
 whitelist_externals = make
 commands =
@@ -70,6 +72,7 @@ commands =
     make -C docs doctest html epub BUILDDIR={envdir} "SPHINXOPTS=-W -E"
 
 [testenv:pdf]
+skip_install = True
 basepython = python3.5
 whitelist_externals = make
 commands =
@@ -96,6 +99,7 @@ setenv =
     COVERAGE_FILE=.coverage.py3
 
 [testenv:coverage]
+skip_install = True
 basepython = python3.5
 commands =
     coverage erase


### PR DESCRIPTION
I generated an sdist and wheel using this method as well as the previous method using setuptools-git and compared them. They are including the same set of files. This adds a new ``sdist`` tox step which checks the sdist's readme for PyPI syntax errors and runs ``check-manifest`` to determine if any files in the sdist are not in either version control or the ``setup.cfg [check-manifest]`` ignore list.

See https://github.com/Pylons/pyramid/issues/121#issuecomment-307645063