### PR TITLE
fix circular imports

### DIFF
--- a/pyramid/authentication.py
+++ b/pyramid/authentication.py
@@ -34,6 +34,7 @@ from pyramid.security import (
     )
 
 from pyramid.util import strings_differ
+from pyramid.util import SimpleSerializer
 
 VALID_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9+_-]*$")
 
@@ -797,7 +798,7 @@ class AuthTktCookieHelper(object):
                  max_age=None, http_only=False, path="/", wild_domain=True,
                  hashalg='md5', parent_domain=False, domain=None):
 
-        serializer = _SimpleSerializer()
+        serializer = SimpleSerializer()
 
         self.cookie_profile = CookieProfile(
             cookie_name=cookie_name,
@@ -1123,14 +1124,6 @@ class BasicAuthAuthenticationPolicy(CallbackAuthenticationPolicy):
         if credentials:
             username, password = credentials
             return self.check(username, password, request)
-
-
-class _SimpleSerializer(object):
-    def loads(self, bstruct):
-        return native_(bstruct)
-
-    def dumps(self, appstruct):
-        return bytes_(appstruct)
 
 
 HTTPBasicCredentials = namedtuple(

--- a/pyramid/config/__init__.py
+++ b/pyramid/config/__init__.py
@@ -58,11 +58,16 @@ from pyramid.settings import aslist
 from pyramid.threadlocal import manager
 
 from pyramid.util import (
-    ActionInfo,
     WeakOrderedSet,
-    action_method,
     object_description,
     )
+
+from pyramid.config.util import (
+    ActionInfo,
+    PredicateList,
+    action_method,
+    not_,
+)
 
 from pyramid.config.adapters import AdaptersConfiguratorMixin
 from pyramid.config.assets import AssetsConfiguratorMixin
@@ -74,7 +79,6 @@ from pyramid.config.security import SecurityConfiguratorMixin
 from pyramid.config.settings import SettingsConfiguratorMixin
 from pyramid.config.testing import TestingConfiguratorMixin
 from pyramid.config.tweens import TweensConfiguratorMixin
-from pyramid.config.util import PredicateList, not_
 from pyramid.config.views import ViewsConfiguratorMixin
 from pyramid.config.zca import ZCAConfiguratorMixin
 
@@ -83,9 +87,7 @@ from pyramid.path import DottedNameResolver
 empty = text_('')
 _marker = object()
 
-ConfigurationError = ConfigurationError # pyflakes
-
-not_ = not_ # pyflakes, this is an API
+not_ = not_  # api
 
 PHASE0_CONFIG = PHASE0_CONFIG  # api
 PHASE1_CONFIG = PHASE1_CONFIG  # api

--- a/pyramid/config/adapters.py
+++ b/pyramid/config/adapters.py
@@ -10,10 +10,9 @@ from pyramid.interfaces import (
     IResourceURL,
     )
 
-from pyramid.config.util import (
-    action_method,
-    takes_one_arg,
-    )
+from pyramid.util import takes_one_arg
+
+from pyramid.config.util import action_method
 
 
 class AdaptersConfiguratorMixin(object):

--- a/pyramid/config/assets.py
+++ b/pyramid/config/assets.py
@@ -12,7 +12,7 @@ from pyramid.interfaces import (
 from pyramid.exceptions import ConfigurationError
 from pyramid.threadlocal import get_current_registry
 
-from pyramid.util import action_method
+from pyramid.config.util import action_method
 
 class OverrideProvider(pkg_resources.DefaultProvider):
     def __init__(self, module):

--- a/pyramid/config/factories.py
+++ b/pyramid/config/factories.py
@@ -15,11 +15,11 @@ from pyramid.router import default_execution_policy
 from pyramid.traversal import DefaultRootFactory
 
 from pyramid.util import (
-    action_method,
     get_callable_name,
     InstancePropertyHelper,
     )
 
+from pyramid.config.util import action_method
 
 class FactoriesConfiguratorMixin(object):
     @action_method

--- a/pyramid/config/i18n.py
+++ b/pyramid/config/i18n.py
@@ -5,7 +5,8 @@ from pyramid.interfaces import (
 
 from pyramid.exceptions import ConfigurationError
 from pyramid.path import AssetResolver
-from pyramid.util import action_method
+
+from pyramid.config.util import action_method
 
 class I18NConfiguratorMixin(object):
     @action_method

--- a/pyramid/config/predicates.py
+++ b/pyramid/config/predicates.py
@@ -1,2 +1,2 @@
 import zope.deprecation
-zope.deprecation.moved('pyramid.predicates', 'Pyramid 2.0')
+zope.deprecation.moved('pyramid.predicates', 'Pyramid 1.10')

--- a/pyramid/config/rendering.py
+++ b/pyramid/config/rendering.py
@@ -3,8 +3,8 @@ from pyramid.interfaces import (
     PHASE1_CONFIG,
     )
 
-from pyramid.util import action_method
 from pyramid import renderers
+from pyramid.config.util import action_method
 
 DEFAULT_RENDERERS = (
     ('json', renderers.json_renderer_factory),

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -10,14 +10,17 @@ from pyramid.interfaces import (
     )
 
 from pyramid.exceptions import ConfigurationError
-from pyramid.registry import predvalseq
 from pyramid.request import route_request_iface
 from pyramid.urldispatch import RoutesMapper
 
-from pyramid.config.util import action_method
 from pyramid.util import as_sorted_tuple
 
 import pyramid.predicates
+
+from pyramid.config.util import (
+    action_method,
+    predvalseq,
+)
 
 class RoutesConfiguratorMixin(object):
     @action_method

--- a/pyramid/config/security.py
+++ b/pyramid/config/security.py
@@ -12,9 +12,9 @@ from pyramid.interfaces import (
 
 from pyramid.csrf import LegacySessionCSRFStoragePolicy
 from pyramid.exceptions import ConfigurationError
-from pyramid.util import action_method
 from pyramid.util import as_sorted_tuple
 
+from pyramid.config.util import action_method
 
 class SecurityConfiguratorMixin(object):
 

--- a/pyramid/config/testing.py
+++ b/pyramid/config/testing.py
@@ -14,7 +14,7 @@ from pyramid.traversal import (
     split_path_info,
     )
 
-from pyramid.util import action_method
+from pyramid.config.util import action_method
 
 class TestingConfiguratorMixin(object):
     # testing API

--- a/pyramid/config/tweens.py
+++ b/pyramid/config/tweens.py
@@ -15,11 +15,12 @@ from pyramid.tweens import (
     EXCVIEW,
     )
 
-from pyramid.config.util import (
-    action_method,
+from pyramid.util import (
+    is_string_or_iterable,
     TopologicalSorter,
     )
-from pyramid.util import is_string_or_iterable
+
+from pyramid.config.util import action_method
 
 class TweensConfiguratorMixin(object):
     def add_tween(self, tween_factory, under=None, over=None):

--- a/pyramid/csrf.py
+++ b/pyramid/csrf.py
@@ -4,8 +4,6 @@ from webob.cookies import CookieProfile
 from zope.interface import implementer
 
 
-from pyramid.authentication import _SimpleSerializer
-
 from pyramid.compat import (
     bytes_,
     urlparse,
@@ -18,6 +16,7 @@ from pyramid.exceptions import (
 from pyramid.interfaces import ICSRFStoragePolicy
 from pyramid.settings import aslist
 from pyramid.util import (
+    SimpleSerializer,
     is_same_domain,
     strings_differ
 )
@@ -112,7 +111,7 @@ class CookieCSRFStoragePolicy(object):
 
     def __init__(self, cookie_name='csrf_token', secure=False, httponly=False,
                  domain=None, max_age=None, path='/'):
-        serializer = _SimpleSerializer()
+        serializer = SimpleSerializer()
         self.cookie_profile = CookieProfile(
             cookie_name=cookie_name,
             secure=secure,

--- a/pyramid/predicates.py
+++ b/pyramid/predicates.py
@@ -12,8 +12,10 @@ from pyramid.traversal import (
     )
 
 from pyramid.urldispatch import _compile_route
-from pyramid.util import object_description
-from pyramid.util import as_sorted_tuple
+from pyramid.util import (
+    as_sorted_tuple,
+    object_description,
+)
 
 _marker = object()
 
@@ -298,3 +300,27 @@ class EffectivePrincipalsPredicate(object):
                 return True
         return False
 
+class Notted(object):
+    def __init__(self, predicate):
+        self.predicate = predicate
+
+    def _notted_text(self, val):
+        # if the underlying predicate doesnt return a value, it's not really
+        # a predicate, it's just something pretending to be a predicate,
+        # so dont update the hash
+        if val:
+            val = '!' + val
+        return val
+
+    def text(self):
+        return self._notted_text(self.predicate.text())
+
+    def phash(self):
+        return self._notted_text(self.predicate.phash())
+
+    def __call__(self, context, request):
+        result = self.predicate(context, request)
+        phash = self.phash()
+        if phash:
+            result = not result
+        return result

--- a/pyramid/registry.py
+++ b/pyramid/registry.py
@@ -2,7 +2,6 @@ import operator
 import threading
 
 from zope.interface import implementer
-
 from zope.interface.registry import Components
 
 from pyramid.compat import text_
@@ -294,6 +293,5 @@ def undefer(v):
 
 class predvalseq(tuple):
     """ A subtype of tuple used to represent a sequence of predicate values """
-    pass
 
 global_registry = Registry('global')

--- a/pyramid/tests/test_authentication.py
+++ b/pyramid/tests/test_authentication.py
@@ -1549,21 +1549,6 @@ class TestExtractHTTPBasicCredentials(unittest.TestCase):
 
         self.assertEqual(result.username, 'chrisr')
         self.assertEqual(result.password, 'pass')
-
-
-
-class TestSimpleSerializer(unittest.TestCase):
-    def _makeOne(self):
-        from pyramid.authentication import _SimpleSerializer
-        return _SimpleSerializer()
-
-    def test_loads(self):
-        inst = self._makeOne()
-        self.assertEqual(inst.loads(b'abc'), text_('abc'))
-
-    def test_dumps(self):
-        inst = self._makeOne()
-        self.assertEqual(inst.dumps('abc'), bytes_('abc'))
         
 class DummyContext:
     pass

--- a/pyramid/tests/test_config/test_init.py
+++ b/pyramid/tests/test_config/test_init.py
@@ -852,7 +852,7 @@ pyramid.tests.test_config.dummy_include2""",
         self.assertEqual(config.action('discrim', kw={'a':1}), None)
 
     def test_action_autocommit_with_introspectables(self):
-        from pyramid.util import ActionInfo
+        from pyramid.config.util import ActionInfo
         config = self._makeOne(autocommit=True)
         intr = DummyIntrospectable()
         config.action('discrim', introspectables=(intr,))

--- a/pyramid/tests/test_config/test_views.py
+++ b/pyramid/tests/test_config/test_views.py
@@ -542,8 +542,8 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_default_phash_overrides_default_phash(self):
-        from pyramid.renderers import null_renderer
         from pyramid.config.util import DEFAULT_PHASH
+        from pyramid.renderers import null_renderer
         from zope.interface import Interface
         from pyramid.interfaces import IRequest
         from pyramid.interfaces import IView
@@ -564,8 +564,8 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_exc_default_phash_overrides_default_phash(self):
-        from pyramid.renderers import null_renderer
         from pyramid.config.util import DEFAULT_PHASH
+        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
         from pyramid.interfaces import IRequest
         from pyramid.interfaces import IView
@@ -3384,6 +3384,18 @@ class Test_view_description(unittest.TestCase):
         result = self._callFUT(view)
         self.assertEqual(result,
                          'function pyramid.tests.test_config.test_views.view')
+
+class Test_viewdefaults(unittest.TestCase):
+    def _makeOne(self, wrapped):
+        from pyramid.decorator import reify
+        return reify(wrapped)
+
+    def test_dunder_attrs_copied(self):
+        from pyramid.config.views import viewdefaults
+        decorator = self._makeOne(viewdefaults)
+        self.assertEqual(decorator.__doc__, viewdefaults.__doc__)
+        self.assertEqual(decorator.__name__, viewdefaults.__name__)
+        self.assertEqual(decorator.__module__, viewdefaults.__module__)
 
 
 class DummyRegistry:

--- a/pyramid/tests/test_decorator.py
+++ b/pyramid/tests/test_decorator.py
@@ -21,13 +21,6 @@ class TestReify(unittest.TestCase):
         result = decorator.__get__(None)
         self.assertEqual(result, decorator)
 
-    def test_dunder_attrs_copied(self):
-        from pyramid.util import viewdefaults
-        decorator = self._makeOne(viewdefaults)
-        self.assertEqual(decorator.__doc__, viewdefaults.__doc__)
-        self.assertEqual(decorator.__name__, viewdefaults.__name__)
-        self.assertEqual(decorator.__module__, viewdefaults.__module__)
-
 
 class Dummy(object):
     pass

--- a/pyramid/tests/test_predicates.py
+++ b/pyramid/tests/test_predicates.py
@@ -514,13 +514,43 @@ class Test_EffectivePrincipalsPredicate(unittest.TestCase):
         context = Dummy()
         self.assertFalse(inst(context, request))
 
+
+class TestNotted(unittest.TestCase):
+    def _makeOne(self, predicate):
+        from pyramid.predicates import Notted
+        return Notted(predicate)
+
+    def test_it_with_phash_val(self):
+        pred = DummyPredicate('val')
+        inst = self._makeOne(pred)
+        self.assertEqual(inst.text(), '!val')
+        self.assertEqual(inst.phash(), '!val')
+        self.assertEqual(inst(None, None), False)
+
+    def test_it_without_phash_val(self):
+        pred = DummyPredicate('')
+        inst = self._makeOne(pred)
+        self.assertEqual(inst.text(), '')
+        self.assertEqual(inst.phash(), '')
+        self.assertEqual(inst(None, None), True)
+
 class predicate(object):
     def __repr__(self):
         return 'predicate'
     def __hash__(self):
         return 1
-    
+
 class Dummy(object):
-    def __init__(self, **kw):
-        self.__dict__.update(**kw)
-        
+    pass
+
+class DummyPredicate(object):
+    def __init__(self, result):
+        self.result = result
+
+    def text(self):
+        return self.result
+
+    phash = text
+
+    def __call__(self, context, request):
+        return True

--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -1,5 +1,9 @@
 import unittest
-from pyramid.compat import PY2
+from pyramid.compat import (
+    PY2,
+    text_,
+    bytes_,
+    )
 
 
 class Test_InstancePropertyHelper(unittest.TestCase):
@@ -747,36 +751,6 @@ class TestSentinel(unittest.TestCase):
         r = repr(Sentinel('ABC'))
         self.assertEqual(r, 'ABC')
 
-class TestActionInfo(unittest.TestCase):
-    def _getTargetClass(self):
-        from pyramid.util import ActionInfo
-        return ActionInfo
-
-    def _makeOne(self, filename, lineno, function, linerepr):
-        return self._getTargetClass()(filename, lineno, function, linerepr)
-
-    def test_class_conforms(self):
-        from zope.interface.verify import verifyClass
-        from pyramid.interfaces import IActionInfo
-        verifyClass(IActionInfo, self._getTargetClass())
-
-    def test_instance_conforms(self):
-        from zope.interface.verify import verifyObject
-        from pyramid.interfaces import IActionInfo
-        verifyObject(IActionInfo, self._makeOne('f', 0, 'f', 'f'))
-
-    def test_ctor(self):
-        inst = self._makeOne('filename', 10, 'function', 'src')
-        self.assertEqual(inst.file, 'filename')
-        self.assertEqual(inst.line, 10)
-        self.assertEqual(inst.function, 'function')
-        self.assertEqual(inst.src, 'src')
-
-    def test___str__(self):
-        inst = self._makeOne('filename', 0, 'function', '   linerepr  ')
-        self.assertEqual(str(inst),
-                         "Line 0 of file filename:\n       linerepr  ")
-
 
 class TestCallableName(unittest.TestCase):
     def test_valid_ascii(self):
@@ -927,3 +901,211 @@ class Test_make_contextmanager(unittest.TestCase):
         mgr = self._callFUT(mygen)
         with mgr() as ctx:
             self.assertEqual(ctx, 'a')
+
+
+class Test_takes_one_arg(unittest.TestCase):
+    def _callFUT(self, view, attr=None, argname=None):
+        from pyramid.util import takes_one_arg
+        return takes_one_arg(view, attr=attr, argname=argname)
+
+    def test_requestonly_newstyle_class_no_init(self):
+        class foo(object):
+            """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_requestonly_newstyle_class_init_toomanyargs(self):
+        class foo(object):
+            def __init__(self, context, request):
+                """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_requestonly_newstyle_class_init_onearg_named_request(self):
+        class foo(object):
+            def __init__(self, request):
+                """ """
+        self.assertTrue(self._callFUT(foo))
+
+    def test_newstyle_class_init_onearg_named_somethingelse(self):
+        class foo(object):
+            def __init__(self, req):
+                """ """
+        self.assertTrue(self._callFUT(foo))
+
+    def test_newstyle_class_init_defaultargs_firstname_not_request(self):
+        class foo(object):
+            def __init__(self, context, request=None):
+                """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_newstyle_class_init_defaultargs_firstname_request(self):
+        class foo(object):
+            def __init__(self, request, foo=1, bar=2):
+                """ """
+        self.assertTrue(self._callFUT(foo, argname='request'))
+
+    def test_newstyle_class_init_firstname_request_with_secondname(self):
+        class foo(object):
+            def __init__(self, request, two):
+                """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_newstyle_class_init_noargs(self):
+        class foo(object):
+            def __init__():
+                """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_oldstyle_class_no_init(self):
+        class foo:
+            """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_oldstyle_class_init_toomanyargs(self):
+        class foo:
+            def __init__(self, context, request):
+                """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_oldstyle_class_init_onearg_named_request(self):
+        class foo:
+            def __init__(self, request):
+                """ """
+        self.assertTrue(self._callFUT(foo))
+
+    def test_oldstyle_class_init_onearg_named_somethingelse(self):
+        class foo:
+            def __init__(self, req):
+                """ """
+        self.assertTrue(self._callFUT(foo))
+
+    def test_oldstyle_class_init_defaultargs_firstname_not_request(self):
+        class foo:
+            def __init__(self, context, request=None):
+                """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_oldstyle_class_init_defaultargs_firstname_request(self):
+        class foo:
+            def __init__(self, request, foo=1, bar=2):
+                """ """
+        self.assertTrue(self._callFUT(foo, argname='request'), True)
+
+    def test_oldstyle_class_init_noargs(self):
+        class foo:
+            def __init__():
+                """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_function_toomanyargs(self):
+        def foo(context, request):
+            """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_function_with_attr_false(self):
+        def bar(context, request):
+            """ """
+        def foo(context, request):
+            """ """
+        foo.bar = bar
+        self.assertFalse(self._callFUT(foo, 'bar'))
+
+    def test_function_with_attr_true(self):
+        def bar(context, request):
+            """ """
+        def foo(request):
+            """ """
+        foo.bar = bar
+        self.assertTrue(self._callFUT(foo, 'bar'))
+
+    def test_function_onearg_named_request(self):
+        def foo(request):
+            """ """
+        self.assertTrue(self._callFUT(foo))
+
+    def test_function_onearg_named_somethingelse(self):
+        def foo(req):
+            """ """
+        self.assertTrue(self._callFUT(foo))
+
+    def test_function_defaultargs_firstname_not_request(self):
+        def foo(context, request=None):
+            """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_function_defaultargs_firstname_request(self):
+        def foo(request, foo=1, bar=2):
+            """ """
+        self.assertTrue(self._callFUT(foo, argname='request'))
+
+    def test_function_noargs(self):
+        def foo():
+            """ """
+        self.assertFalse(self._callFUT(foo))
+
+    def test_instance_toomanyargs(self):
+        class Foo:
+            def __call__(self, context, request):
+                """ """
+        foo = Foo()
+        self.assertFalse(self._callFUT(foo))
+
+    def test_instance_defaultargs_onearg_named_request(self):
+        class Foo:
+            def __call__(self, request):
+                """ """
+        foo = Foo()
+        self.assertTrue(self._callFUT(foo))
+
+    def test_instance_defaultargs_onearg_named_somethingelse(self):
+        class Foo:
+            def __call__(self, req):
+                """ """
+        foo = Foo()
+        self.assertTrue(self._callFUT(foo))
+
+    def test_instance_defaultargs_firstname_not_request(self):
+        class Foo:
+            def __call__(self, context, request=None):
+                """ """
+        foo = Foo()
+        self.assertFalse(self._callFUT(foo))
+
+    def test_instance_defaultargs_firstname_request(self):
+        class Foo:
+            def __call__(self, request, foo=1, bar=2):
+                """ """
+        foo = Foo()
+        self.assertTrue(self._callFUT(foo, argname='request'), True)
+
+    def test_instance_nocall(self):
+        class Foo: pass
+        foo = Foo()
+        self.assertFalse(self._callFUT(foo))
+
+    def test_method_onearg_named_request(self):
+        class Foo:
+            def method(self, request):
+                """ """
+        foo = Foo()
+        self.assertTrue(self._callFUT(foo.method))
+
+    def test_function_annotations(self):
+        def foo(bar):
+            """ """
+        # avoid SyntaxErrors in python2, this if effectively nop
+        getattr(foo, '__annotations__', {}).update({'bar': 'baz'})
+        self.assertTrue(self._callFUT(foo))
+
+
+class TestSimpleSerializer(unittest.TestCase):
+    def _makeOne(self):
+        from pyramid.util import SimpleSerializer
+        return SimpleSerializer()
+
+    def test_loads(self):
+        inst = self._makeOne()
+        self.assertEqual(inst.loads(b'abc'), text_('abc'))
+
+    def test_dumps(self):
+        inst = self._makeOne()
+        self.assertEqual(inst.dumps('abc'), bytes_('abc'))


### PR DESCRIPTION
This is a WIP to refactor `pyramid.config.utils` into `pyramid.utils` and `pyramid.predicates`. The over-arching design principal here is to keep `pyramid.config` focused as much as possible on just directives and keep the actual application components in the top-level `pyramid` namespace.

- [x] Move `pyramid.config.utils.PredicateList` and `not_`, `Notted`, `predvalseq`, `MAX_ORDER`, `DEFAULT_PHASH` into `pyramid.predicates`.
- [x] Move `takes_one_arg` into `pyramid.util`.
- [x] Deprecate the old locations but keep stubs for now.
- [x] Move tests around.

This is a fix for the future 1.10 release. For a patch we can backport we should be able to make something much simpler that doesn't move too much code around.

fixes #3112 