### PR TITLE
Ignore here and __file__ for pshell configuration

### DIFF
--- a/pyramid/scripts/pshell.py
+++ b/pyramid/scripts/pshell.py
@@ -101,6 +101,8 @@ class PShellCommand(object):
                 self.setup = v
             elif k == 'default_shell':
                 self.preferred_shells = [x.lower() for x in aslist(v)]
+            elif k in ('__file__', 'here'):
+                continue
             else:
                 self.loaded_objects[k] = resolver.maybe_resolve(v)
                 self.object_help[k] = v


### PR DESCRIPTION
If the folder containing the configuration file (`development.ini`) is not a package, then `pshell` fails with `ImportError` because `resolver.maybe_resolve` tries to import `__file__` and `here`.

This pull request tells `pshell` to ignore `__file__` and `here`.