### PR TITLE
fix the __module__ and import path of the request after custom proper…

### DIFF
--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -293,6 +293,14 @@ class Test_InstancePropertyMixin(unittest.TestCase):
         foo.set_property(lambda _: 2, name='x', reify=True)
         self.assertEqual(1, foo.x)
 
+    def test_new_class_keeps_parent_module_name(self):
+        foo = self._makeOne()
+        self.assertEqual(foo.__module__, 'pyramid.tests.test_util')
+        self.assertEqual(foo.__class__.__module__, 'pyramid.tests.test_util')
+        foo.set_property(lambda _: 1, name='x', reify=True)
+        self.assertEqual(foo.__module__, 'pyramid.tests.test_util')
+        self.assertEqual(foo.__class__.__module__, 'pyramid.tests.test_util')
+
 class Test_WeakOrderedSet(unittest.TestCase):
     def _makeOne(self):
         from pyramid.config import WeakOrderedSet

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -97,6 +97,9 @@ class InstancePropertyHelper(object):
         attrs = dict(properties)
         if attrs:
             parent = target.__class__
+            # fix the module name so it appears to still be the parent
+            # e.g. pyramid.request instead of pyramid.util
+            attrs.setdefault('__module__', parent.__module__)
             newcls = type(parent.__name__, (parent, object), attrs)
             # We assign __provides__ and __implemented__ below to prevent a
             # memory leak that results from from the usage of this instance's


### PR DESCRIPTION
…ties have been set

previously anytime ``config.add_request_method`` was used the request
would appear as ``pyramid.util.Request`` when displaying
``request.__class__``. This overwrites the ``__module__`` which fixes
that issue so that it appears as ``pyramid.request.Request``.