### PR TITLE
Drop repoze.lru on Python 3

### DIFF
--- a/pyramid/compat.py
+++ b/pyramid/compat.py
@@ -17,6 +17,12 @@ try:
 except ImportError:  # pragma: no cover
     import pickle
 
+try:
+    from functools import lru_cache
+
+except ImportError:
+    from repoze.lru import lru_cache
+
 # PY3 is left as bw-compat but PY2 should be used for most checks.
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3

--- a/pyramid/static.py
+++ b/pyramid/static.py
@@ -17,14 +17,15 @@ from pkg_resources import (
     resource_isdir,
     )
 
-from repoze.lru import lru_cache
-
 from pyramid.asset import (
     abspath_from_asset_spec,
     resolve_asset_spec,
 )
 
-from pyramid.compat import text_
+from pyramid.compat import (
+    lru_cache,
+    text_,
+)
 
 from pyramid.httpexceptions import (
     HTTPNotFound,

--- a/pyramid/traversal.py
+++ b/pyramid/traversal.py
@@ -1,8 +1,6 @@
 from zope.interface import implementer
 from zope.interface.interfaces import IInterface
 
-from repoze.lru import lru_cache
-
 from pyramid.interfaces import (
     IResourceURL,
     IRequestFactory,
@@ -20,6 +18,7 @@ from pyramid.compat import (
     is_nonstr_iter,
     decode_path_info,
     unquote_bytes_to_wsgi,
+    lru_cache,
     )
 
 from pyramid.encode import url_quote

--- a/pyramid/url.py
+++ b/pyramid/url.py
@@ -2,8 +2,6 @@
 
 import os
 
-from repoze.lru import lru_cache
-
 from pyramid.interfaces import (
     IResourceURL,
     IRoutesMapper,
@@ -12,6 +10,7 @@ from pyramid.interfaces import (
 
 from pyramid.compat import (
     bytes_,
+    lru_cache,
     string_types,
     )
 from pyramid.encode import (

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@
 #
 ##############################################################################
 
+import sys
+
 from setuptools import setup, find_packages
 
 def readfile(name):
@@ -24,7 +26,6 @@ CHANGES = readfile('CHANGES.txt')
 install_requires = [
     'setuptools',
     'WebOb >= 1.7.0rc2', # Response.has_body
-    'repoze.lru >= 0.4', # py3 compat
     'zope.interface >= 3.8.0',  # has zope.interface.registry
     'zope.deprecation >= 3.5.0', # py3 compat
     'venusian >= 1.0a3', # ``ignore``
@@ -87,6 +88,7 @@ setup(name='pyramid',
       python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
       install_requires=install_requires,
       extras_require={
+          ':python_version<"3.2"': ['repoze.lru >= 0.4'],
           'testing': testing_extras,
           'docs': docs_extras,
           },


### PR DESCRIPTION
Starting with Python 3.2, the functools module grew a lru_cache function which can replace our usage of repoze.lru.