### PR TITLE
Add a functional test for the static file

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -310,3 +310,6 @@ Contributors
 - Denis Rykov, 2017/06/15
 
 - Tosh Lyons, 2017/06/27
+
+- Lars Blumberg, 2017/08/14
+

--- a/docs/quick_tutorial/static_assets.rst
+++ b/docs/quick_tutorial/static_assets.rst
@@ -43,13 +43,18 @@ Steps
    .. literalinclude:: static_assets/tutorial/static/app.css
     :language: css
 
-#. Make sure we haven't broken any existing code by running the tests:
+#. We add a functional test that asserts that the newly added static file is delivered:
+
+   .. literalinclude:: static_assets/tutorial/tests.py
+    :linenos:
+
+#. Now run the tests:
 
    .. code-block:: bash
 
     $ $VENV/bin/py.test tutorial/tests.py -q
     ....
-    4 passed in 0.50 seconds
+    5 passed in 0.50 seconds
 
 #. Run your Pyramid application with:
 

--- a/docs/quick_tutorial/static_assets.rst
+++ b/docs/quick_tutorial/static_assets.rst
@@ -46,7 +46,9 @@ Steps
 #. We add a functional test that asserts that the newly added static file is delivered:
 
    .. literalinclude:: static_assets/tutorial/tests.py
-    :linenos:
+    :language: python
+    :pyobject: TutorialFunctionalTests.test_css
+    :lineno-match:
 
 #. Now run the tests:
 

--- a/docs/quick_tutorial/static_assets/tutorial/tests.py
+++ b/docs/quick_tutorial/static_assets/tutorial/tests.py
@@ -42,3 +42,7 @@ class TutorialFunctionalTests(unittest.TestCase):
     def test_hello(self):
         res = self.testapp.get('/howdy', status=200)
         self.assertIn(b'<h1>Hi Hello View', res.body)
+
+    def test_css(self):
+        res = self.testapp.get('/static/app.css', status=200)
+        self.assertIn(b'body', res.body)


### PR DESCRIPTION
Static files were introduced in the quick tutorial step "[static assets](https://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/static_assets.html)". As the tutorials emphasise to write tests, this PR adds a test for the static file `app.css` that was introduced with this tutorial step. This PR also updates the according tutorial page.