### PR TITLE
use pyramid.compat.escape instead of cgi.escape

### DIFF
--- a/docs/quick_tour/views/views.py
+++ b/docs/quick_tour/views/views.py
@@ -1,4 +1,4 @@
-import cgi
+from pyramid.compat import escape
 
 from pyramid.httpexceptions import HTTPFound
 from pyramid.response import Response
@@ -16,8 +16,8 @@ def home_view(request):
 def hello_view(request):
     name = request.params.get('name', 'No Name')
     body = '<p>Hi %s, this <a href="/goto">redirects</a></p>'
-    # cgi.escape to prevent Cross-Site Scripting (XSS) [CWE 79]
-    return Response(body % cgi.escape(name))
+    # pyramid.compat.escape to prevent Cross-Site Scripting (XSS) [CWE 79]
+    return Response(body % escape(name))
 
 
 # /goto which issues HTTP redirect to the last view


### PR DESCRIPTION
- backport of #3165 and #3171

(cherry picked from commit e0eda61)