### PR TITLE
views.py: prevent exception on unknown user login

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -313,3 +313,4 @@ Contributors
 
 - Lars Blumberg, 2017/08/14
 
+- Deneys Maartens, 2017/11/03

--- a/docs/quick_tutorial/authentication/tutorial/views.py
+++ b/docs/quick_tutorial/authentication/tutorial/views.py
@@ -43,7 +43,8 @@ class TutorialViews:
         if 'form.submitted' in request.params:
             login = request.params['login']
             password = request.params['password']
-            if check_password(password, USERS.get(login)):
+            hashed_pw = USERS.get(login)
+            if hashed_pw and check_password(password, hashed_pw):
                 headers = remember(request, login)
                 return HTTPFound(location=came_from,
                                  headers=headers)

--- a/docs/quick_tutorial/authorization/tutorial/views.py
+++ b/docs/quick_tutorial/authorization/tutorial/views.py
@@ -45,7 +45,8 @@ class TutorialViews:
         if 'form.submitted' in request.params:
             login = request.params['login']
             password = request.params['password']
-            if check_password(password, USERS.get(login)):
+            hashed_pw = USERS.get(login)
+            if hashed_pw and check_password(password, hashed_pw):
                 headers = remember(request, login)
                 return HTTPFound(location=came_from,
                                  headers=headers)


### PR DESCRIPTION
Attempting a login without specifying the user login, or when the user login is not known, i.e. not 'editor' nor 'viewer', an unhandled exception is raised in `security.py` because `None` is passed to `check_password()` as the hashed password to check against.

This patch checks for a non-None hashed password before calling `check_password()`.