### PR TITLE
Fix a typo in the logging article

### DIFF
--- a/docs/narr/logging.rst
+++ b/docs/narr/logging.rst
@@ -67,7 +67,7 @@ In this logging configuration:
 
      2007-08-17 15:04:08,704 INFO [packagename] Loading resource, id: 86
 
-- a logger named ``myapp`` is configured that logs messages sent at a level
+- a logger named ``myproject`` is configured that logs messages sent at a level
   above or equal to ``DEBUG`` to stderr in the same format as the root logger.
 
 The ``root`` logger will be used by all applications in the Pyramid process


### PR DESCRIPTION
The logger is called `myproject` in the example `development.ini` file, not `myapp`