### PR TITLE
Emphasize additional line in Subrequest docs

### DIFF
--- a/docs/narr/subrequest.rst
+++ b/docs/narr/subrequest.rst
@@ -62,7 +62,7 @@ object:
 
 .. code-block:: python
    :linenos:
-   :emphasize-lines: 11
+   :emphasize-lines: 11,18
 
    from wsgiref.simple_server import make_server
    from pyramid.config import Configurator


### PR DESCRIPTION
This PR emphasizes an additional line which has been changed between the first and second example of [the Subrequest documentation](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/subrequest.html), specifically:

```
config.add_view(view_two, route_name='two', renderer='string')
```