### PR TITLE
Replace MIMEAccept with acceptparse.create_accept_header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ jyenv/
 pypyenv/
 env*/
 venv/
+.cache/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,11 @@ Bug Fixes
   error code.
   See https://github.com/Pylons/pyramid/pull/3280
 
+- Replace ``webob.acceptparse.MIMEAccept`` from WebOb with
+  ``webob.acceptparse.create_accept_header`` in the HTTP exception handling
+  code. The old ``MIMEAccept`` has been deprecated. The new methods follow the
+  RFC's more closely. See https://github.com/Pylons/pyramid/pull/3251
+
 Deprecations
 ------------
 

--- a/pyramid/httpexceptions.py
+++ b/pyramid/httpexceptions.py
@@ -133,7 +133,7 @@ from string import Template
 from zope.interface import implementer
 
 from webob import html_escape as _html_escape
-from webob.acceptparse import MIMEAccept
+from webob.acceptparse import create_accept_header
 
 from pyramid.compat import (
     class_types,
@@ -250,10 +250,12 @@ ${body}''')
             html_comment = ''
             comment = self.comment or ''
             accept_value = environ.get('HTTP_ACCEPT', '')
-            accept = MIMEAccept(accept_value)
+            accept = create_accept_header(accept_value)
             # Attempt to match text/html or application/json, if those don't
             # match, we will fall through to defaulting to text/plain
-            match = accept.best_match(['text/html', 'application/json'])
+            acceptable = accept.acceptable_offers(['text/html', 'application/json'])
+            acceptable = [offer[0] for offer in acceptable] + ['text/plain']
+            match = acceptable[0]
 
             if match == 'text/html':
                 self.content_type = 'text/html'

--- a/pyramid/tests/test_httpexceptions.py
+++ b/pyramid/tests/test_httpexceptions.py
@@ -283,6 +283,17 @@ class TestHTTPException(unittest.TestCase):
             if header[0] == 'Content-Type':
                 self.assertEqual(header[1], 'application/json')
 
+    def test__content_type_invalid(self):
+        cls = self._getTargetSubclass()
+        exc = cls()
+        environ = _makeEnviron()
+        environ['HTTP_ACCEPT'] = 'invalid'
+        start_response = DummyStartResponse()
+        exc(environ, start_response)
+        for header in start_response.headerlist:
+            if header[0] == 'Content-Type':
+                self.assertEqual(header[1], 'text/html; charset=UTF-8')
+
     def test__default_app_iter_with_comment_ampersand(self):
         cls = self._getTargetSubclass()
         exc = cls(comment='comment & comment')

--- a/setup.py
+++ b/setup.py
@@ -11,47 +11,49 @@
 # FITNESS FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 
 def readfile(name):
     with open(name) as f:
         return f.read()
 
+
 README = readfile('README.rst')
 CHANGES = readfile('CHANGES.rst')
 
 install_requires = [
-    'setuptools',
-    'WebOb >= 1.7.0', # Response.has_body
-    'zope.interface >= 3.8.0',  # has zope.interface.registry
-    'zope.deprecation >= 3.5.0', # py3 compat
-    'venusian >= 1.0', # ``ignore``
-    'translationstring >= 0.4', # py3 compat
+    'hupper',
     'plaster',
     'plaster_pastedeploy',
-    'hupper',
-    ]
+    'setuptools',
+    'translationstring >= 0.4',  # py3 compat
+    'venusian >= 1.0',  # ``ignore``
+    'webob >= 1.8.0',  # acceptparse.create_accept_header
+    'zope.deprecation >= 3.5.0',  # py3 compat
+    'zope.interface >= 3.8.0',  # has zope.interface.registry
+]
 
 tests_require = [
-    'WebTest >= 1.3.1', # py3 compat
-    'zope.component >= 4.0', # py3 compat
-    ]
+    'webtest >= 1.3.1',  # py3 compat
+    'zope.component >= 4.0',  # py3 compat
+]
 
 
 docs_extras = [
     'Sphinx >= 1.7.4',
     'docutils',
-    'repoze.sphinx.autointerface',
-    'pylons_sphinx_latesturl',
     'pylons-sphinx-themes',
+    'pylons_sphinx_latesturl',
+    'repoze.sphinx.autointerface',
     'sphinxcontrib-autoprogram',
-    ]
+]
 
 testing_extras = tests_require + [
-    'nose',
     'coverage',
+    'nose',
     'virtualenv',  # for scaffolding tests
-    ]
+]
 
 setup(name='pyramid',
       version='1.10.dev0',
@@ -87,7 +89,7 @@ setup(name='pyramid',
           ':python_version<"3.2"': ['repoze.lru >= 0.4'],
           'testing': testing_extras,
           'docs': docs_extras,
-          },
+      },
       tests_require=tests_require,
       test_suite="pyramid.tests",
       entry_points="""\


### PR DESCRIPTION
Due to changes in WebOb, `MIMEAccept` now raises if you pass it an invalid `Accept` header. `MIMEAccept` is also deprecated moving forward, so start using the new WebOb API's.

Closes https://github.com/Pylons/pyramid/issues/3250