### PR TITLE
updated docs/interfaces to note change from webob 1.7/1.5

### DIFF
--- a/docs/narr/webob.rst
+++ b/docs/narr/webob.rst
@@ -412,7 +412,7 @@ Here are some highlights:
     (you may also use a timedelta object).  The ``Expires`` key will also be
     set based on the value of ``max_age``.
 
-``response.delete_cookie(key, path='/', domain=None)``
+``response.delete_cookie(name, path='/', domain=None)``
     Delete a cookie from the client.  This sets ``max_age`` to 0 and the cookie
     value to ``''``.
 

--- a/docs/narr/webob.rst
+++ b/docs/narr/webob.rst
@@ -406,7 +406,7 @@ Here are some highlights:
     ``response.text``. ``response.content_type_params`` is a dictionary of all
     the parameters.
 
-``response.set_cookie(key, value, max_age=None, path='/', ...)``
+``response.set_cookie(name, value, max_age=None, path='/', ...)``
     Set a cookie.  The keyword arguments control the various cookie parameters.
     The ``max_age`` argument is the length for the cookie to live in seconds
     (you may also use a timedelta object).  The ``Expires`` key will also be

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -244,7 +244,7 @@ class IResponse(Interface):
         """ Gets and sets and deletes the Server header. For more information
         on Server see RFC216 section 14.38. """)
 
-    def set_cookie(key, value='', max_age=None, path='/', domain=None,
+    def set_cookie(name, value='', max_age=None, path='/', domain=None,
                    secure=False, httponly=False, comment=None, expires=None,
                    overwrite=False):
         """ Set (add) a cookie for the response """

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -180,7 +180,7 @@ class IResponse(Interface):
         """Gets and sets and deletes the Date header. For more information on
         Date see RFC 2616 section 14.18. Converts using HTTP date.""")
 
-    def delete_cookie(key, path='/', domain=None):
+    def delete_cookie(name, path='/', domain=None):
         """ Delete a cookie from the client. Note that path and domain must
         match how the cookie was originally set.  This sets the cookie to the
         empty string, and max_age=0 so that it should expire immediately. """

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -259,7 +259,7 @@ class IResponse(Interface):
         """ Get/set the unicode value of the body (using the charset of
         the Content-Type)""")
 
-    def unset_cookie(key, strict=True):
+    def unset_cookie(name, strict=True):
         """ Unset a cookie with the given name (remove it from the
         response)."""
 


### PR DESCRIPTION
webob 1.5 deprecated 'key' kwarg in favor of 'name'.
webob 1.7 removed 'key'.

This just updates the docs/interfaces to note change from webob 1.7 of `set_cookie(key` to `set_cookie(name`.

after the 1.8 release, i audited my code for any missed deprecations. a search picked up the old name in a tox virtualenv.