### PR TITLE
Add Configurator context manager 'route_prefix_context' to allow for …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,11 @@ Features
   imports from `cherrypy.wsgiserver`.
   See https://github.com/Pylons/pyramid/pull/3235
 
+- Add a context manager ``route_prefix_context`` to the
+  ``pyramid.config.Configurator`` to allow for convenient setting of the
+  route_prefix for ``include`` and ``add_route`` calls inside the context.
+  See https://github.com/Pylons/pyramid/pull/3279
+
 Bug Fixes
 ---------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -316,3 +316,7 @@ Contributors
 - Deneys Maartens, 2017/11/03
 
 - Heron Rossi, 2018/03/08
+
+- Hunter Senft-Grupp, 2018/05/14
+
+- Junhak Lee, 2018/05/14

--- a/docs/narr/urldispatch.rst
+++ b/docs/narr/urldispatch.rst
@@ -1045,6 +1045,24 @@ may be added in the future.  For example:
        config = Configurator()
        config.include(users_include, route_prefix='/users')
 
+A convenience context manager exists to set the route prefix for any
+:meth:`pyramid.config.Configurator.add_route` or
+:meth:`pyramid.config.Configurator.include` calls within the context.
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid.config import Configurator
+
+   def timing_include(config):
+      config.add_route('timing.show_times', '/times')
+
+   def main(global_config, **settings)
+      config = Configurator()
+      with config.route_prefix_context('/timing'):
+         config.include(timing_include)
+         config.add_route('timing.average', '/average')
+
 .. index::
    single: route predicates (custom)
 

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -1,3 +1,4 @@
+import contextlib
 import warnings
 
 from pyramid.compat import urlparse
@@ -467,3 +468,53 @@ class RoutesConfiguratorMixin(object):
             self.registry.registerUtility(mapper, IRoutesMapper)
         return mapper
 
+    @contextlib.contextmanager
+    def route_prefix_context(self, route_prefix):
+        """ Return this configurator with the
+        :attr:`pyramid.config.Configurator.route_prefix` attribute mutated to
+        include the new ``route_prefix``.
+
+        When the context exits, the ``route_prefix`` is reset to the original.
+
+        Example Usage:
+
+        >>> config = Configurator()
+        >>> with config.route_prefix_context('foo'):
+        ...     config.add_route('bar', '/bar')
+
+        Arguments
+
+        route_prefix
+
+          A string suitable to be used as a route prefix, or ``None``.
+
+        .. versionadded:: 1.9.10
+        """
+
+        original_route_prefix = self.route_prefix
+
+        if route_prefix is None:
+            route_prefix = ''
+
+        old_route_prefix = self.route_prefix
+        if old_route_prefix is None:
+            old_route_prefix = ''
+
+        route_prefix = '{}/{}'.format(
+            old_route_prefix.rstrip('/'),
+            route_prefix.lstrip('/'),
+        )
+
+        route_prefix = route_prefix.strip('/')
+
+        if not route_prefix:
+            route_prefix = None
+
+        self.begin()
+        try:
+            self.route_prefix = route_prefix
+            yield
+
+        finally:
+            self.route_prefix = original_route_prefix
+            self.end()

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -488,7 +488,7 @@ class RoutesConfiguratorMixin(object):
 
           A string suitable to be used as a route prefix, or ``None``.
 
-        .. versionadded:: 1.9.10
+        .. versionadded:: 1.10
         """
 
         original_route_prefix = self.route_prefix


### PR DESCRIPTION
…adding routes and including configuration callables with a particular route prefix.