### PR TITLE
Update GitHub URLs for tutorials

### DIFF
--- a/docs/quick_tour.rst
+++ b/docs/quick_tour.rst
@@ -10,6 +10,7 @@ for those who want to evaluate Pyramid, whether you are new to Python web
 frameworks, or a pro in a hurry. For more detailed treatment of each topic,
 give the :ref:`quick_tutorial` a try.
 
+If you would prefer to cut and paste the example code in this tour you may browse the source code located in the `Pyramid repository in the directory "docs/quick_tour" <https://github.com/Pylons/pyramid/>`. If you have downloaded the source code, you will find the tour in the same location.
 
 Installation
 ============

--- a/docs/quick_tutorial/tutorial_approach.rst
+++ b/docs/quick_tutorial/tutorial_approach.rst
@@ -15,7 +15,7 @@ This "Getting Started" tutorial is broken into independent steps, starting with
 the smallest possible "single file WSGI app" example. Each of these steps
 introduces a topic and a very small set of concepts via working code. The steps
 each correspond to a directory in our workspace, where each step's directory is
-a Python package.
+a Python package. Source code used in this tutorial is located in the `Pyramid repository in the directory "docs/quick_tutorial" <https://github.com/Pylons/pyramid/>`_. You may ``git clone`` the repository, download, or copy-paste the source code. If you do so, then make sure you use the same branch as this documentation.
 
 As we develop our tutorial, our directory tree will resemble the structure
 below:

--- a/docs/tutorials/wiki2/index.rst
+++ b/docs/tutorials/wiki2/index.rst
@@ -7,8 +7,8 @@ This tutorial introduces an :term:`SQLAlchemy` and :term:`URL dispatch`-based
 :app:`Pyramid` application to a developer familiar with Python.  When finished, the developer will have created a basic wiki
 application with authentication and authorization.
 
-For cut and paste purposes, the source code for all stages of this tutorial can
-be browsed on `GitHub <https://github.com/Pylons/pyramid/>`_,
+For cut and paste purposes, the source code for all stages of this
+tutorial can be browsed on GitHub at `GitHub <https://github.com/Pylons/pyramid/>`_ for a specific branch or version under ``docs/tutorials/wiki2/src``,
 which corresponds to the same location if you have Pyramid sources.
 
 .. toctree::


### PR DESCRIPTION
I applied the changes requested in Issue #3283. It's about the docs