### PR TITLE
Feature: Default session cookies to SameSite=Lax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,14 +21,21 @@ Features
   instead of ``pyramid.util.Request``.
   See https://github.com/Pylons/pyramid/pull/3129
 
-- In ``cherrypy_server_runner``, prefer imports from the ``cheroot`` package over the legacy
-  imports from `cherrypy.wsgiserver`.
+- In ``cherrypy_server_runner``, prefer imports from the ``cheroot`` package
+  over the legacy imports from `cherrypy.wsgiserver`.
   See https://github.com/Pylons/pyramid/pull/3235
 
 - Add a context manager ``route_prefix_context`` to the
   ``pyramid.config.Configurator`` to allow for convenient setting of the
   route_prefix for ``include`` and ``add_route`` calls inside the context.
   See https://github.com/Pylons/pyramid/pull/3279
+
+- Modify the builtin session implementations to support SameSite options on
+  cookies and set the default to ``'Lax'``. This affects
+  ``pyramid.session.BaseCookieSessionFactory``,
+  ``pyramid.session.SignedCookieSessionFactory``, and
+  ``pyramid.session.UnencryptedCookieSessionFactoryConfig``.
+  See https://github.com/Pylons/pyramid/pull/3300
 
 Bug Fixes
 ---------
@@ -53,6 +60,12 @@ Backward Incompatibilities
   this package directly in your apps you should make sure that you are
   depending on it directly within your project.
   See https://github.com/Pylons/pyramid/pull/3140
+
+- Modify the builtin session implementations to set ``SameSite='Lax'`` on
+  cookies. This affects ``pyramid.session.BaseCookieSessionFactory``,
+  ``pyramid.session.SignedCookieSessionFactory``, and
+  ``pyramid.session.UnencryptedCookieSessionFactoryConfig``.
+  See https://github.com/Pylons/pyramid/pull/3300
 
 Documentation Changes
 ---------------------

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -242,7 +242,7 @@ or adds the feature.  To build and review docs, use the following steps.
 Change Log
 ----------
 
-- Feature additions and bugfixes must be added to the ``CHANGES.txt``
+- Feature additions and bugfixes must be added to the ``CHANGES.rst``
   file in the prevailing style.  Changelog entries should be long and
   descriptive, not cryptic.  Other developers should be able to know
   what your changelog entry means.

--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -189,7 +189,8 @@ def BaseCookieSessionFactory(
       session cookie. Default: ``False``.
 
     ``samesite``
-      The 'samesite' option of the session cookie. Default ``'Lax'``.
+      The 'samesite' option of the session cookie. Set the value to ``None``
+      to turn off the samesite option.  Default: ``'Lax'``.
 
     ``timeout``
       A number of seconds of inactivity before a session times out. If
@@ -220,6 +221,10 @@ def BaseCookieSessionFactory(
       while rendering a view. Default: ``True``.
 
     .. versionadded: 1.5a3
+
+    .. versionchanged: 1.10
+
+       Added the ``samesite`` option and made the default ``'Lax'``.
     """
 
     @implementer(ISession)
@@ -442,7 +447,8 @@ def UnencryptedCookieSessionFactoryConfig(
       The 'httpOnly' flag of the session cookie.
 
     ``cookie_samesite``
-      The 'samesite' option of the session cookie.  Default: ``'Lax'``.
+      The 'samesite' option of the session cookie. Set the value to ``None``
+      to turn off the samesite option.  Default: ``'Lax'``.
 
     ``cookie_on_exception``
       If ``True``, set a session cookie even if an exception occurs
@@ -457,6 +463,10 @@ def UnencryptedCookieSessionFactoryConfig(
       A callable which takes a signed and serialized data structure in bytes
       and a secret and returns the original data structure if the signature
       is valid. Default: ``signed_deserialize`` (using pickle).
+
+    .. versionchanged: 1.10
+
+       Added the ``samesite`` option and made the default ``'Lax'``.
     """
 
     class SerializerWrapper(object):
@@ -566,7 +576,8 @@ def SignedCookieSessionFactory(
       session cookie. Default: ``False``.
 
     ``samesite``
-      The 'samesite' option of the session cookie.  Default: ``'Lax'``.
+      The 'samesite' option of the session cookie. Set the value to ``None``
+      to turn off the samesite option.  Default: ``'Lax'``.
 
     ``timeout``
       A number of seconds of inactivity before a session times out. If
@@ -604,6 +615,10 @@ def SignedCookieSessionFactory(
       the :class:`pyramid.session.PickleSerializer` serializer will be used.
 
     .. versionadded: 1.5a3
+
+    .. versionchanged: 1.10
+
+       Added the ``samesite`` option and made the default ``Lax``.
     """
     if serializer is None:
         serializer = PickleSerializer()

--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -135,7 +135,7 @@ def BaseCookieSessionFactory(
     domain=None,
     secure=False,
     httponly=False,
-    samesite=b'Lax',
+    samesite='Lax',
     timeout=1200,
     reissue_time=0,
     set_on_exception=True,
@@ -189,7 +189,7 @@ def BaseCookieSessionFactory(
       session cookie. Default: ``False``.
 
     ``samesite``
-      The 'samesite' option of the session cookie. Default ``b'Lax'``.
+      The 'samesite' option of the session cookie. Default ``'Lax'``.
 
     ``timeout``
       A number of seconds of inactivity before a session times out. If
@@ -388,7 +388,7 @@ def UnencryptedCookieSessionFactoryConfig(
     cookie_domain=None,
     cookie_secure=False,
     cookie_httponly=False,
-    cookie_samesite=b'Lax',
+    cookie_samesite='Lax',
     cookie_on_exception=True,
     signed_serialize=signed_serialize,
     signed_deserialize=signed_deserialize,
@@ -442,7 +442,7 @@ def UnencryptedCookieSessionFactoryConfig(
       The 'httpOnly' flag of the session cookie.
 
     ``cookie_samesite``
-      The 'samesite' option of the session cookie.  Default: ``b'Lax'``.
+      The 'samesite' option of the session cookie.  Default: ``'Lax'``.
 
     ``cookie_on_exception``
       If ``True``, set a session cookie even if an exception occurs
@@ -502,7 +502,7 @@ def SignedCookieSessionFactory(
     domain=None,
     secure=False,
     httponly=False,
-    samesite=b'Lax',
+    samesite='Lax',
     set_on_exception=True,
     timeout=1200,
     reissue_time=0,
@@ -566,7 +566,7 @@ def SignedCookieSessionFactory(
       session cookie. Default: ``False``.
 
     ``samesite``
-      The 'samesite' option of the session cookie.  Default: ``b'Lax'``.
+      The 'samesite' option of the session cookie.  Default: ``'Lax'``.
 
     ``timeout``
       A number of seconds of inactivity before a session times out. If

--- a/pyramid/tests/test_session.py
+++ b/pyramid/tests/test_session.py
@@ -504,7 +504,7 @@ class TestUnencryptedCookieSession(SharedCookieSessionTests, unittest.TestCase):
         expected_cookieval = dummy_signed_serialize(
             (session.accessed, session.created, {'key': 'value'}), secret)
         response = Response()
-        response.set_cookie('session', expected_cookieval, samesite=b'Lax')
+        response.set_cookie('session', expected_cookieval, samesite='Lax')
         expected_cookie = response.headerlist[-1][1]
         self.assertEqual(cookie, expected_cookie)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'setuptools',
     'translationstring >= 0.4',  # py3 compat
     'venusian >= 1.0',  # ``ignore``
-    'webob >= 1.8.0',  # acceptparse.create_accept_header
+    'webob >= 1.8.2',  # cookies.make_cookie allows non-bytes samesite
     'zope.deprecation >= 3.5.0',  # py3 compat
     'zope.interface >= 3.8.0',  # has zope.interface.registry
 ]


### PR DESCRIPTION
This is a follow-up to: https://github.com/Pylons/pyramid/pull/3298 that fixes the `b'Lax'` issues and bumps the version of WebOb that is required.