### PR TITLE
Update `request_param` kwarg documentation for `add_route` config method

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -322,3 +322,5 @@ Contributors
 - Junhak Lee, 2018/05/14
 
 - Alex Gaynor, 2018/05/24
+
+- Benjamin Gmurczyk, 2018/06/14

--- a/pyramid/config/routes.py
+++ b/pyramid/config/routes.py
@@ -198,9 +198,9 @@ class RoutesConfiguratorMixin(object):
 
         request_param
 
-          This value can be any string.  A view declaration with this
-          argument ensures that the associated route will only match
-          when the request has a key in the ``request.params``
+          This value can be any string or an iterable of strings.  A view
+          declaration with this argument ensures that the associated route will
+          only match when the request has a key in the ``request.params``
           dictionary (an HTTP ``GET`` or ``POST`` variable) that has a
           name which matches the supplied value.  If the value
           supplied as the argument has a ``=`` sign in it,


### PR DESCRIPTION
Add a note that the `request_param` kwarg for the `add_route` config method also accepts an iterable.

This functionality was added in <https://github.com/Pylons/pyramid/pull/705>.