### PR TITLE
remove html_use_smartypants

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,8 +175,6 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # Do not use smart quotes.
 smartquotes = False
-# Remove next line when RTD goes to Sphinx==1.6.6
-html_use_smartypants = False
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'pyramid'


### PR DESCRIPTION
- for good, now that we specify Sphinx minimum version of 1.7.4

(cherry picked from commit 819732e)