### PR TITLE
Corrected typo

### DIFF
--- a/pyramid/scaffolds/alchemy/+package+/templates/layout.jinja2_tmpl
+++ b/pyramid/scaffolds/alchemy/+package+/templates/layout.jinja2_tmpl
@@ -16,7 +16,7 @@
     <!-- Custom styles for this scaffold -->
     <link href="\{\{request.static_url('{{package}}:static/theme.css')\}\}" rel="stylesheet">
 
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- HTML5 shiv and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
       <script src="//oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js" integrity="sha384-0s5Pv64cNZJieYFkXYOTId2HMA2Lfb6q2nAcx2n0RTLUnCAoTTsS0nKEO27XyKcY" crossorigin="anonymous"></script>
       <script src="//oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js" integrity="sha384-f1r2UzjsxZ9T4V1f2zBO/evUqSEOpeaUUZcMTz1Up63bl4ruYnFYeM+BxI4NhyI0" crossorigin="anonymous"></script>


### PR DESCRIPTION
There is a typo at line 19 in pyramid/scaffolds/alchemy/+package+/templates/layout.jinja2_tmpl file:
   ...HTML5 shi**m** and Respond.js IE8 support of HTML5 elements and media queries...
should be:
   ...HTML5 shi**v** and Respond.js IE8 support of HTML5 elements and media queries...