### PR TITLE
Minor update to modwsgi tutorial

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -326,3 +326,5 @@ Contributors
 - Jason Williams, 2018/06/11
 
 - Benjamin Gmurczyk, 2018/06/14
+
+- Jack Desert, 2018/07/11

--- a/docs/tutorials/modwsgi/index.rst
+++ b/docs/tutorials/modwsgi/index.rst
@@ -39,7 +39,7 @@ specific path information for commands and files.
     .. code-block:: bash
 
        $ cd ~
-       $ cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+       $ cookiecutter gh:Pylons/pyramid-cookiecutter-starter
 
     If prompted for the first item, accept the default ``yes`` by hitting return.
 


### PR DESCRIPTION
such that cookiecutter uses "latest" instead of "bleeding edge"

As was suggested for a tutorial that used this file as a template.
See this pull request comment in the cookbook:
https://github.com/Pylons/pyramid_cookbook/pull/208#discussion-diff-201600555R21