### PR TITLE
enable the setup function in pshell to wrap the command lifecycle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,14 @@ Features
   exception/response object for a HTTP 308 redirect.
   See https://github.com/Pylons/pyramid/pull/3302
 
+- Within ``pshell``, allow the user-defined ``setup`` function to be a
+  generator, in which case it may wrap the command's lifecycle.
+  See https://github.com/Pylons/pyramid/pull/3318
+
+- Within ``pshell``, variables defined by the ``[pshell]`` settings are
+  available within the user-defined ``setup`` function.
+  See https://github.com/Pylons/pyramid/pull/3318
+
 Bug Fixes
 ---------
 
@@ -75,6 +83,10 @@ Backward Incompatibilities
   ``pyramid.session.SignedCookieSessionFactory``, and
   ``pyramid.session.UnencryptedCookieSessionFactoryConfig``.
   See https://github.com/Pylons/pyramid/pull/3300
+
+- Variables defined in the ``[pshell]`` section of the settings will no
+  longer override those set by the ``setup`` function.
+  See https://github.com/Pylons/pyramid/pull/3318
 
 Documentation Changes
 ---------------------

--- a/pyramid/tests/test_scripts/dummy.py
+++ b/pyramid/tests/test_scripts/dummy.py
@@ -22,11 +22,13 @@ class DummyShell(object):
     env = {}
     help = ''
     called = False
+    dummy_attr = 1
 
     def __call__(self, env, help):
         self.env = env
         self.help = help
         self.called = True
+        self.env['request'].dummy_attr = self.dummy_attr
 
 class DummyInteractor:
     def __call__(self, banner, local):

--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -889,3 +889,41 @@ class Test_is_same_domain(unittest.TestCase):
         self.assertTrue(self._callFUT("example.com:8080", "example.com:8080"))
         self.assertFalse(self._callFUT("example.com:8080", "example.com"))
         self.assertFalse(self._callFUT("example.com", "example.com:8080"))
+
+
+class Test_make_contextmanager(unittest.TestCase):
+    def _callFUT(self, *args, **kw):
+        from pyramid.util import make_contextmanager
+        return make_contextmanager(*args, **kw)
+
+    def test_with_None(self):
+        mgr = self._callFUT(None)
+        with mgr() as ctx:
+            self.assertIsNone(ctx)
+
+    def test_with_generator(self):
+        def mygen(ctx):
+            yield ctx
+        mgr = self._callFUT(mygen)
+        with mgr('a') as ctx:
+            self.assertEqual(ctx, 'a')
+
+    def test_with_multiple_yield_generator(self):
+        def mygen():
+            yield 'a'
+            yield 'b'
+        mgr = self._callFUT(mygen)
+        try:
+            with mgr() as ctx:
+                self.assertEqual(ctx, 'a')
+        except RuntimeError:
+            pass
+        else:  # pragma: no cover
+            raise AssertionError('expected raise from multiple yields')
+
+    def test_with_regular_fn(self):
+        def mygen():
+            return 'a'
+        mgr = self._callFUT(mygen)
+        with mgr() as ctx:
+            self.assertEqual(ctx, 'a')

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -1,4 +1,4 @@
-import contextlib
+from contextlib import contextmanager
 import functools
 try:
     # py2.7.7+ and py3.3+ have native comparison support
@@ -613,7 +613,7 @@ def get_callable_name(name):
         )
         raise ConfigurationError(msg % name)
 
-@contextlib.contextmanager
+@contextmanager
 def hide_attrs(obj, *attrs):
     """
     Temporarily delete object attrs and restore afterward.
@@ -648,3 +648,17 @@ def is_same_domain(host, pattern):
     return (pattern[0] == "." and
             (host.endswith(pattern) or host == pattern[1:]) or
             pattern == host)
+
+
+def make_contextmanager(fn):
+    if inspect.isgeneratorfunction(fn):
+        return contextmanager(fn)
+
+    if fn is None:
+        fn = lambda *a, **kw: None
+
+    @contextmanager
+    @functools.wraps(fn)
+    def wrapper(*a, **kw):
+        yield fn(*a, **kw)
+    return wrapper


### PR DESCRIPTION
The next step here is to decide whether to:

1. Integrate support directly into pshell for detecting `env['request'].tm` and doing "the right thing".

2. Add documentation in the command line chapter about how to handle transactions in pshell.

3. Add a setup function to each cookiecutter which does the right thing in that codebase.

For example:

```python
from contextlib import suppress
from transaction.interfaces import NoTransaction

def setup(env):
    tm = env['request'].tm
    tm.begin()
    try:
        yield
    finally:
        with suppress(NoTransaction):
            tm.abort()
```

The above code is what most people should want: abort any pending changes when exiting the shell. If I build this into pshell by default then it'd just be a default. If anyone defined their own `setup` func then it would override this behavior.