### PR TITLE
catch other pickle errors when loading content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,12 @@ Bug Fixes
   code. The old ``MIMEAccept`` has been deprecated. The new methods follow the
   RFC's more closely. See https://github.com/Pylons/pyramid/pull/3251
 
+- Catch extra errors like ``AttributeError`` when unpickling "trusted"
+  session cookies with bad pickle data in them. This would occur when sharing
+  a secret between projects that shouldn't actually share session cookies,
+  like when reusing secrets between projects in development.
+  See https://github.com/Pylons/pyramid/pull/3325
+
 Deprecations
 ------------
 

--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -121,7 +121,11 @@ class PickleSerializer(object):
 
     def loads(self, bstruct):
         """Accept bytes and return a Python object."""
-        return pickle.loads(bstruct)
+        try:
+            return pickle.loads(bstruct)
+        # at least ValueError, AttributeError, ImportError but more to be safe
+        except Exception:
+            raise ValueError
 
     def dumps(self, appstruct):
         """Accept a Python object and return bytes."""


### PR DESCRIPTION
Hypothetical: you have more pyramid projects than dummy secrets and the browser starts sending back signed-pickled session cookies from project A to the server for project B. In this case it passes all signature checks but fails to unpickle with a non-`ValueError` exception.