### PR TITLE
notfound view: use HTTPTemporaryRedirect as default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,6 +99,11 @@ Backward Incompatibilities
   longer override those set by the ``setup`` function.
   See https://github.com/Pylons/pyramid/pull/3318
 
+- ``pyramid.config.Configurator.add_notfound_view`` uses default redirect
+  class exception ``pyramid.httpexceptions.HTTPTemporaryRedirect`` instead
+  of previous ``pyramid.httpexceptions.HTTPFound``.
+  See https://github.com/Pylons/pyramid/pull/3328
+
 Documentation Changes
 ---------------------
 

--- a/pyramid/config/views.py
+++ b/pyramid/config/views.py
@@ -1631,8 +1631,8 @@ class ViewsConfiguratorMixin(object):
         instead implements :class:`~pyramid.interfaces.IResponse`, the
         append_slash logic will behave as if ``append_slash=True`` was passed,
         but the provided class will be used as the response class instead of
-        the default :class:`~pyramid.httpexceptions.HTTPFound` response class
-        when a redirect is performed.  For example:
+        the default :class:`~pyramid.httpexceptions.HTTPTemporaryRedirect`
+        response class when a redirect is performed.  For example:
 
           .. code-block:: python
 
@@ -1640,9 +1640,14 @@ class ViewsConfiguratorMixin(object):
             config.add_notfound_view(append_slash=HTTPMovedPermanently)
 
         The above means that a redirect to a slash-appended route will be
-        attempted, but instead of :class:`~pyramid.httpexceptions.HTTPFound`
+        attempted, but instead of :class:`~pyramid.httpexceptions.HTTPTemporaryRedirect`
         being used, :class:`~pyramid.httpexceptions.HTTPMovedPermanently will
         be used` for the redirect response if a slash-appended route is found.
+
+        :class:`~pyramid.httpexceptions.HTTPTemporaryRedirect` class is used
+        as default response, which is equivalent to
+        :class:`~pyramid.httpexceptions.HTTPFound` with addition of redirecting
+        with the same HTTP method (useful when doing POST requests).
 
         .. versionadded:: 1.3
 
@@ -1655,6 +1660,12 @@ class ViewsConfiguratorMixin(object):
         .. versionchanged:: 1.8
 
            The view is created using ``exception_only=True``.
+
+        .. versionchanged: 1.10
+
+           Default response was changed from :class:`~pyramid.httpexceptions.HTTPFound`
+           to :class:`~pyramid.httpexceptions.HTTPTemporaryRedirect`.
+
         """
         for arg in (
             'name', 'permission', 'context', 'for_', 'require_csrf',

--- a/pyramid/tests/test_config/test_views.py
+++ b/pyramid/tests/test_config/test_views.py
@@ -2238,7 +2238,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
         from pyramid.interfaces import IRequest
-        from pyramid.httpexceptions import HTTPFound, HTTPNotFound
+        from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPNotFound
         config = self._makeOne(autocommit=True)
         config.add_route('foo', '/foo/')
         def view(request): return Response('OK')
@@ -2251,7 +2251,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
                                      exc_iface=implementedBy(HTTPNotFound),
                                      request_iface=IRequest)
         result = view(None, request)
-        self.assertTrue(isinstance(result, HTTPFound))
+        self.assertTrue(isinstance(result, HTTPTemporaryRedirect))
         self.assertEqual(result.location, '/scriptname/foo/?a=1&b=2')
 
     def test_add_notfound_view_append_slash_custom_response(self):

--- a/pyramid/tests/test_integration.py
+++ b/pyramid/tests/test_integration.py
@@ -386,11 +386,11 @@ class TestNotFoundView(IntegrationBase, unittest.TestCase):
     def test_it(self):
         res = self.testapp.get('/wontbefound', status=200)
         self.assertTrue(b'generic_notfound' in res.body)
-        res = self.testapp.get('/bar', status=302)
+        res = self.testapp.get('/bar', status=307)
         self.assertEqual(res.location, 'http://localhost/bar/')
         res = self.testapp.get('/bar/', status=200)
         self.assertTrue(b'OK bar' in res.body)
-        res = self.testapp.get('/foo', status=302)
+        res = self.testapp.get('/foo', status=307)
         self.assertEqual(res.location, 'http://localhost/foo/')
         res = self.testapp.get('/foo/', status=200)
         self.assertTrue(b'OK foo2' in res.body)

--- a/pyramid/tests/test_view.py
+++ b/pyramid/tests/test_view.py
@@ -686,7 +686,7 @@ class Test_append_slash_notfound_view(BaseTest, unittest.TestCase):
         context = ExceptionResponse()
         self._registerMapper(request.registry, True)
         response = self._callFUT(context, request)
-        self.assertEqual(response.status, '302 Found')
+        self.assertEqual(response.status, '307 Temporary Redirect')
         self.assertEqual(response.location, '/abc/')
 
     def test_matches_with_script_name(self):
@@ -694,7 +694,7 @@ class Test_append_slash_notfound_view(BaseTest, unittest.TestCase):
         context = ExceptionResponse()
         self._registerMapper(request.registry, True)
         response = self._callFUT(context, request)
-        self.assertEqual(response.status, '302 Found')
+        self.assertEqual(response.status, '307 Temporary Redirect')
         self.assertEqual(response.location, '/foo/abc/')
 
     def test_with_query_string(self):
@@ -702,7 +702,7 @@ class Test_append_slash_notfound_view(BaseTest, unittest.TestCase):
         context = ExceptionResponse()
         self._registerMapper(request.registry, True)
         response = self._callFUT(context, request)
-        self.assertEqual(response.status, '302 Found')
+        self.assertEqual(response.status, '307 Temporary Redirect')
         self.assertEqual(response.location, '/abc/?a=1&b=2')
 
 class TestAppendSlashNotFoundViewFactory(BaseTest, unittest.TestCase):

--- a/pyramid/view.py
+++ b/pyramid/view.py
@@ -24,8 +24,8 @@ from pyramid.exceptions import (
 )
 
 from pyramid.httpexceptions import (
-    HTTPFound,
     HTTPNotFound,
+    HTTPTemporaryRedirect,
     default_exceptionresponse_view,
     )
 
@@ -292,7 +292,7 @@ class AppendSlashNotFoundViewFactory(object):
     .. deprecated:: 1.3
 
     """
-    def __init__(self, notfound_view=None, redirect_class=HTTPFound):
+    def __init__(self, notfound_view=None, redirect_class=HTTPTemporaryRedirect):
         if notfound_view is None:
             notfound_view = default_exceptionresponse_view
         self.notfound_view = notfound_view
@@ -377,8 +377,8 @@ class notfound_view_config(object):
     instead implements :class:`~pyramid.interfaces.IResponse`, the
     append_slash logic will behave as if ``append_slash=True`` was passed,
     but the provided class will be used as the response class instead of
-    the default :class:`~pyramid.httpexceptions.HTTPFound` response class
-    when a redirect is performed.  For example:
+    the default :class:`~pyramid.httpexceptions.HTTPTemporaryRedirect`
+    response class when a redirect is performed.  For example:
 
       .. code-block:: python
 
@@ -392,7 +392,7 @@ class notfound_view_config(object):
             return HTTPNotFound('not found')
 
     The above means that a redirect to a slash-appended route will be
-    attempted, but instead of :class:`~pyramid.httpexceptions.HTTPFound`
+    attempted, but instead of :class:`~pyramid.httpexceptions.HTTPTemporaryRedirect`
     being used, :class:`~pyramid.httpexceptions.HTTPMovedPermanently will
     be used` for the redirect response if a slash-appended route is found.
 


### PR DESCRIPTION
So that it will redirect POST requests without failing out.