### PR TITLE
deprecate pickleable sessions, recommend json

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,15 @@ Deprecations
   of the documentation for more information about this change.
   See https://github.com/Pylons/pyramid/pull/3353
 
+- The ``pyramid.session.signed_serialize`` and
+  ``pyramid.session.signed_deserialize`` functions will be removed in Pyramid
+  2.0, along with the removal of
+  ``pyramid.session.UnencryptedCookieSessionFactoryConfig`` which was
+  deprecated in Pyramid 1.5. Please switch to using the
+  ``SignedCookieSessionFactory``, copying the code, or another session
+  implementation if you're still using these features.
+  See https://github.com/Pylons/pyramid/pull/3353
+
 Backward Incompatibilities
 --------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,7 +85,7 @@ Deprecations
 ------------
 
 - The ``pyramid.intefaces.ISession`` interface will move to require
-  json-serializable objects in Pyramid 2.0. See
+  JSON-serializable objects in Pyramid 2.0. See
   "Upcoming Changes to ISession in Pyramid 2.0" in the "Sessions" chapter
   of the documentation for more information about this change.
   See https://github.com/Pylons/pyramid/pull/3353

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,11 @@ Features
 - Add support for Python 3.7. Add testing on Python 3.8 with allowed failures.
   See https://github.com/Pylons/pyramid/pull/3333
 
+- Added ``pyramid.session.JSONSerializer``. See "Upcoming Changes to ISession
+  in Pyramid 2.0" in the "Sessions" chapter of the documentation for more
+  information about this feature.
+  See https://github.com/Pylons/pyramid/pull/3353
+
 Bug Fixes
 ---------
 
@@ -78,6 +83,12 @@ Bug Fixes
 
 Deprecations
 ------------
+
+- The ``pyramid.intefaces.ISession`` interface will move to require
+  json-serializable objects in Pyramid 2.0. See
+  "Upcoming Changes to ISession in Pyramid 2.0" in the "Sessions" chapter
+  of the documentation for more information about this change.
+  See https://github.com/Pylons/pyramid/pull/3353
 
 Backward Incompatibilities
 --------------------------

--- a/docs/api/session.rst
+++ b/docs/api/session.rst
@@ -5,13 +5,7 @@
 
 .. automodule:: pyramid.session
 
-  .. autofunction:: signed_serialize
-
-  .. autofunction:: signed_deserialize
-
   .. autofunction:: SignedCookieSessionFactory
-
-  .. autofunction:: UnencryptedCookieSessionFactoryConfig
 
   .. autofunction:: BaseCookieSessionFactory
 

--- a/docs/api/session.rst
+++ b/docs/api/session.rst
@@ -17,3 +17,5 @@
 
   .. autoclass:: PickleSerializer
 
+  .. autoclass:: JSONSerializer
+

--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -77,10 +77,10 @@ using the :meth:`pyramid.config.Configurator.set_session_factory` method.
 
    In short, use a different session factory implementation (preferably one which keeps session data on the server) for anything but the most basic of applications where "session security doesn't matter", you are sure your application has no cross-site scripting vulnerabilities, and you are confident your secret key will not be exposed.
 
-.. _pickle_session_deprecation:
-
 .. index::
     triple: pickle deprecation; JSON-serializable; ISession interface
+
+.. _pickle_session_deprecation:
 
 Upcoming Changes to ISession in Pyramid 2.0
 -------------------------------------------

--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -98,6 +98,7 @@ Remember that sessions should be short-lived and thus the number of clients affe
 
     from pyramid.session import JSONSerializer
     from pyramid.session import PickleSerializer
+    from pyramid.session import SignedCookieSessionFactory
 
     class JSONSerializerWithPickleFallback(object):
         def __init__(self):
@@ -115,6 +116,11 @@ Remember that sessions should be short-lived and thus the number of clients affe
                 return self.json.loads(value)
             except ValueError:
                 return self.pickle.loads(value)
+
+    # somewhere in your configuration code
+    serializer = JSONSerializerWithPickleFallback()
+    session_factory = SignedCookieSessionFactory(..., serializer=serializer)
+    config.set_session_factory(session_factory)
 
 .. index::
    single: session object

--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -79,10 +79,13 @@ using the :meth:`pyramid.config.Configurator.set_session_factory` method.
 
 .. _pickle_session_deprecation:
 
+.. index::
+    triple: pickle deprecation; JSON-serializable; ISession interface
+
 Upcoming Changes to ISession in Pyramid 2.0
 -------------------------------------------
 
-In :app:`Pyramid` 2.0 the :class:`pyramid.interfaces.ISession` interface will be changing to require that session implementations only need to support json-serializable data types.
+In :app:`Pyramid` 2.0 the :class:`pyramid.interfaces.ISession` interface will be changing to require that session implementations only need to support JSON-serializable data types.
 This is a stricter contract than the current requirement that all objects be pickleable and it is being done for security purposes.
 This is a backward-incompatible change.
 Currently, if a client-side session implementation is compromised, it leaves the application vulnerable to remote code execution attacks using specially-crafted sessions that execute code when deserialized.
@@ -104,7 +107,7 @@ Remember that sessions should be short-lived and thus the number of clients affe
         def dumps(self, value):
             # maybe catch serialization errors here and keep using pickle
             # while finding spots in your app that are not storing
-            # json-serializable objects, falling back to pickle
+            # JSON-serializable objects, falling back to pickle
             return self.json.dumps(value)
 
         def loads(self, value):
@@ -173,7 +176,7 @@ Some gotchas:
   that they are instances of basic types of objects, such as strings, lists,
   dictionaries, tuples, integers, etc.  If you place an object in a session
   data key or value that is not pickleable, an error will be raised when the
-  session is serialized.
+  session is serialized. Please also see :ref:`pickle_session_deprecation`.
 
 - If you place a mutable value (for example, a list or a dictionary) in a
   session object, and you subsequently mutate that value, you must call the

--- a/pyramid/interfaces.py
+++ b/pyramid/interfaces.py
@@ -960,6 +960,14 @@ class ISession(IDict):
 
     Keys and values of a session must be pickleable.
 
+    .. warning::
+
+       In :app:`Pyramid` 2.0 the session will only be required to support
+       types that can be serialized using JSON. It's recommended to switch any
+       session implementations to support only JSON and to only store primitive
+       types in sessions. See :ref:`pickle_session_deprecation` for more
+       information about why this change is being made.
+
     .. versionchanged:: 1.9
 
        Sessions are no longer required to implement ``get_csrf_token`` and

--- a/pyramid/session.py
+++ b/pyramid/session.py
@@ -64,6 +64,14 @@ def signed_serialize(data, secret):
 
        cookieval = signed_serialize({'a':1}, 'secret')
        response.set_cookie('signed_cookie', cookieval)
+
+    .. deprecated:: 1.10
+
+       This function will be removed in :app:`Pyramid` 2.0. It is using
+       pickle-based serialization, which is considered vulnerable to remote
+       code execution attacks and will no longer be used by the default
+       session factories at that time.
+
     """
     pickled = pickle.dumps(data, pickle.HIGHEST_PROTOCOL)
     try:
@@ -73,6 +81,13 @@ def signed_serialize(data, secret):
         secret = bytes_(secret, 'utf-8')
     sig = hmac.new(secret, pickled, hashlib.sha1).hexdigest()
     return sig + native_(base64.b64encode(pickled))
+
+deprecated(
+    'signed_serialize',
+    'This function will be removed in Pyramid 2.0. It is using pickle-based '
+    'serialization, which is considered vulnerable to remote code execution '
+    'attacks.',
+)
 
 def signed_deserialize(serialized, secret, hmac=hmac):
     """ Deserialize the value returned from ``signed_serialize``.  If
@@ -86,6 +101,13 @@ def signed_deserialize(serialized, secret, hmac=hmac):
 
        cookieval = request.cookies['signed_cookie']
        data = signed_deserialize(cookieval, 'secret')
+
+    .. deprecated:: 1.10
+
+       This function will be removed in :app:`Pyramid` 2.0. It is using
+       pickle-based serialization, which is considered vulnerable to remote
+       code execution attacks and will no longer be used by the default
+       session factories at that time.
     """
     # hmac parameterized only for unit tests
     try:
@@ -108,6 +130,13 @@ def signed_deserialize(serialized, secret, hmac=hmac):
         raise ValueError('Invalid signature')
 
     return pickle.loads(pickled)
+
+deprecated(
+    'signed_deserialize',
+    'This function will be removed in Pyramid 2.0. It is using pickle-based '
+    'serialization, which is considered vulnerable to remote code execution '
+    'attacks.',
+)
 
 
 class PickleSerializer(object):


### PR DESCRIPTION
This change is backward-compatible but emits deprecation warnings when using the default `PickleSerializer` with `SignedCookieSessionFactory`.

I was also going to deprecate it in `UnencryptedCookieSessionFactoryConfig` but that entire thing has been deprecated since 1.5 and is definitely getting removed in 2.0 wholesale, so there's no point in deprecating a small part of it.

replaces #3341 
related #2709 