### PR TITLE
Add registry arg to pyramid.renderers.get_renderer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Features
 - Add support for Python 3.7. Add testing on Python 3.8 with allowed failures.
   See https://github.com/Pylons/pyramid/pull/3333
 
+- Add a ``registry`` argument to ``pyramid.renderers.get_renderer``
+  to allow users to avoid threadlocals during renderer lookup.
+  See https://github.com/Pylons/pyramid/pull/3358
+
 Bug Fixes
 ---------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -331,3 +331,4 @@ Contributors
 
 - Kuzma Leshakov, 2018/09/07
 
+- Colin Dunklau, 2018/09/19

--- a/pyramid/renderers.py
+++ b/pyramid/renderers.py
@@ -147,7 +147,7 @@ def render_to_response(renderer_name,
 
     return result
 
-def get_renderer(renderer_name, package=None):
+def get_renderer(renderer_name, package=None, registry=None):
     """ Return the renderer object for the renderer ``renderer_name``.
 
     You may supply a relative asset spec as ``renderer_name``.  If
@@ -157,10 +157,16 @@ def get_renderer(renderer_name, package=None):
     asset specification ``renderer_name``.  If ``package`` is ``None``
     (the default), the package name of the *caller* of this function
     will be used as the package.
+
+    You may directly supply an :term:`application registry` using the
+    ``registry`` argument, and it will be used to look up the renderer.
+    Otherwise, the current thread-local registry (obtained via
+    :func:`~pyramid.threadlocal.get_current_registry`) will be used.
     """
     if package is None:
         package = caller_package()
-    helper = RendererHelper(name=renderer_name, package=package)
+    helper = RendererHelper(name=renderer_name, package=package,
+                            registry=registry)
     return helper.renderer
 
 # concrete renderer factory implementations (also API)

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -624,6 +624,12 @@ class Test_get_renderer(unittest.TestCase):
         result = self._callFUT('abc/def.pt', package=pyramid.tests)
         self.assertEqual(result, renderer)
 
+    def test_it_with_registry(self):
+        renderer = self.config.testing_add_renderer(
+            'pyramid.tests:abc/def.pt')
+        result = self._callFUT('abc/def.pt', registry=self.config.registry)
+        self.assertEqual(result, renderer)
+
 class TestJSONP(unittest.TestCase):
     def _makeOne(self, param_name='callback'):
         from pyramid.renderers import JSONP

--- a/pyramid/tests/test_renderers.py
+++ b/pyramid/tests/test_renderers.py
@@ -630,6 +630,14 @@ class Test_get_renderer(unittest.TestCase):
         result = self._callFUT('abc/def.pt', registry=self.config.registry)
         self.assertEqual(result, renderer)
 
+    def test_it_with_isolated_registry(self):
+        from pyramid.config import Configurator
+        isolated_config = Configurator()
+        renderer = isolated_config.testing_add_renderer(
+            'pyramid.tests:abc/def.pt')
+        result = self._callFUT('abc/def.pt', registry=isolated_config.registry)
+        self.assertEqual(result, renderer)
+
 class TestJSONP(unittest.TestCase):
     def _makeOne(self, param_name='callback'):
         from pyramid.renderers import JSONP


### PR DESCRIPTION
Fixes #3354 

This *seems* pretty straightforward, but I wonder if it can/should be tested more extensively?