### PR TITLE
Change all references of "py.test" to "pytest" in Pyramid documentation

### DIFF
--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -286,7 +286,7 @@ path to the module on which we want to run tests and coverage.
 
     $VENV/bin/pytest --cov=myproject myproject/tests.py -q
 
-.. seealso:: See pytest's documentation for :ref:`pytest:usage` or invoke
+.. seealso:: See ``pytest``'s documentation for :ref:`pytest:usage` or invoke
    ``pytest -h`` to see its full set of options.
 
 

--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -239,26 +239,26 @@ On Windows:
     %VENV%\Scripts\pip install -e ".[testing]"
 
 Once the testing requirements are installed, then you can run the tests using
-the ``py.test`` command that was just installed in the ``bin`` directory of
+the ``pytest`` command that was just installed in the ``bin`` directory of
 your virtual environment.
 
 On Unix:
 
 .. code-block:: bash
 
-    $VENV/bin/py.test -q
+    $VENV/bin/pytest -q
 
 On Windows:
 
 .. code-block:: doscon
 
-    %VENV%\Scripts\py.test -q
+    %VENV%\Scripts\pytest -q
 
 Here's sample output from a test run on Unix:
 
 .. code-block:: bash
 
-    $VENV/bin/py.test -q
+    $VENV/bin/pytest -q
     ..
     2 passed in 0.47 seconds
 
@@ -266,28 +266,28 @@ The tests themselves are found in the ``tests.py`` module in your ``cookiecutter
 
 .. note::
 
-    The ``-q`` option is passed to the ``py.test`` command to limit the output
+    The ``-q`` option is passed to the ``pytest`` command to limit the output
     to a stream of dots. If you don't pass ``-q``, you'll see verbose test
     result output (which normally isn't very useful).
 
 Alternatively, if you'd like to see test coverage, pass the ``--cov`` option
-to ``py.test``:
+to ``pytest``:
 
 .. code-block:: bash
 
-    $VENV/bin/py.test --cov -q
+    $VENV/bin/pytest --cov -q
 
-Cookiecutters include configuration defaults for ``py.test`` and test coverage.
+Cookiecutters include configuration defaults for ``pytest`` and test coverage.
 These configuration files are ``pytest.ini`` and ``.coveragerc``, located at
 the root of your package. Without these defaults, we would need to specify the
 path to the module on which we want to run tests and coverage.
 
 .. code-block:: bash
 
-    $VENV/bin/py.test --cov=myproject myproject/tests.py -q
+    $VENV/bin/pytest --cov=myproject myproject/tests.py -q
 
-.. seealso:: See py.test's documentation for :ref:`pytest:usage` or invoke
-   ``py.test -h`` to see its full set of options.
+.. seealso:: See pytest's documentation for :ref:`pytest:usage` or invoke
+   ``pytest -h`` to see its full set of options.
 
 
 .. index::
@@ -1042,7 +1042,7 @@ The ``tests.py`` module includes tests for your application.
    :linenos:
 
 This sample ``tests.py`` file has one unit test and one functional test defined
-within it. These tests are executed when you run ``py.test -q``. You may add
+within it. These tests are executed when you run ``pytest -q``. You may add
 more tests here as you build your application. You are not required to write
 tests to use :app:`Pyramid`. This file is simply provided for convenience and
 example.

--- a/docs/narr/testing.rst
+++ b/docs/narr/testing.rst
@@ -275,7 +275,7 @@ without needing to invoke the actual application configuration implied by its
            
 In the above example, we create a ``MyTest`` test case that inherits from
 :class:`unittest.TestCase`.  If it's in our :app:`Pyramid` application, it will
-be found when ``py.test`` is run.  It has two test methods.
+be found when ``pytest`` is run.  It has two test methods.
 
 The first test method, ``test_view_fn_forbidden`` tests the ``view_fn`` when
 the authentication policy forbids the current user the ``edit`` permission. Its
@@ -365,7 +365,7 @@ Functional tests test your literal application.
 
 In Pyramid, functional tests are typically written using the :term:`WebTest`
 package, which provides APIs for invoking HTTP(S) requests to your application.
-We also like ``py.test`` and ``pytest-cov`` to provide simple testing and
+We also like ``pytest`` and ``pytest-cov`` to provide simple testing and
 coverage reports.
 
 Regardless of which testing :term:`package` you use, be sure to add a

--- a/docs/quick_tour.rst
+++ b/docs/quick_tour.rst
@@ -676,7 +676,7 @@ the relevant ``.ini`` configuration file.
     :ref:`pyramid_debugtoolbar <toolbar:overview>`
 
 Unit tests and ``pytest``
-==========================
+=========================
 
 Yikes! We got this far and we haven't yet discussed tests. This is particularly
 egregious, as Pyramid has had a deep commitment to full test coverage since

--- a/docs/quick_tour.rst
+++ b/docs/quick_tour.rst
@@ -675,7 +675,7 @@ the relevant ``.ini`` configuration file.
     :ref:`Quick Tutorial pyramid_debugtoolbar <qtut_debugtoolbar>` and
     :ref:`pyramid_debugtoolbar <toolbar:overview>`
 
-Unit tests and ``py.test``
+Unit tests and ``pytest``
 ==========================
 
 Yikes! We got this far and we haven't yet discussed tests. This is particularly
@@ -684,7 +684,7 @@ before its release.
 
 Our ``pyramid-cookiecutter-starter`` cookiecutter generated a ``tests.py`` module with
 one unit test and one functional test in it. It also configured ``setup.py`` with test requirements:
-``py.test`` as the test runner, ``WebTest`` for running view tests, and the
+``pytest`` as the test runner, ``WebTest`` for running view tests, and the
 ``pytest-cov`` tool which yells at us for code that isn't tested:
 
 .. literalinclude:: quick_tour/package/setup.py
@@ -701,7 +701,7 @@ We already installed the test requirements when we ran the command ``$VENV/bin/p
 
 .. code-block:: bash
 
-    $VENV/bin/py.test --cov --cov-report=term-missing
+    $VENV/bin/pytest --cov --cov-report=term-missing
 
 This yields the following output.
 

--- a/docs/quick_tutorial/databases.rst
+++ b/docs/quick_tutorial/databases.rst
@@ -128,11 +128,11 @@ Steps
    .. literalinclude:: databases/tutorial/tests.py
        :linenos:
 
-#. Run the tests in your package using ``py.test``:
+#. Run the tests in your package using ``pytest``:
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ..
        2 passed in 1.41 seconds
 

--- a/docs/quick_tutorial/forms.rst
+++ b/docs/quick_tutorial/forms.rst
@@ -91,7 +91,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ..
        2 passed in 0.45 seconds
 

--- a/docs/quick_tutorial/jinja2.rst
+++ b/docs/quick_tutorial/jinja2.rst
@@ -50,7 +50,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ....
        4 passed in 0.40 seconds
 

--- a/docs/quick_tutorial/json.rst
+++ b/docs/quick_tutorial/json.rst
@@ -54,7 +54,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        .....
        5 passed in 0.47 seconds
 

--- a/docs/quick_tutorial/logging.rst
+++ b/docs/quick_tutorial/logging.rst
@@ -54,7 +54,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ....
        4 passed in 0.41 seconds
 

--- a/docs/quick_tutorial/more_view_classes.rst
+++ b/docs/quick_tutorial/more_view_classes.rst
@@ -105,7 +105,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ..
        2 passed in 0.40 seconds
 

--- a/docs/quick_tutorial/request_response.rst
+++ b/docs/quick_tutorial/request_response.rst
@@ -61,7 +61,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        .....
        5 passed in 0.30 seconds
 

--- a/docs/quick_tutorial/routing.rst
+++ b/docs/quick_tutorial/routing.rst
@@ -79,7 +79,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ..
        2 passed in 0.39 seconds
 

--- a/docs/quick_tutorial/sessions.rst
+++ b/docs/quick_tutorial/sessions.rst
@@ -60,7 +60,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ....
        4 passed in 0.42 seconds
 

--- a/docs/quick_tutorial/static_assets.rst
+++ b/docs/quick_tutorial/static_assets.rst
@@ -54,7 +54,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ....
        5 passed in 0.50 seconds
 

--- a/docs/quick_tutorial/templating.rst
+++ b/docs/quick_tutorial/templating.rst
@@ -92,7 +92,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ....
        4 passed in 0.46 seconds
 

--- a/docs/quick_tutorial/unit_testing.rst
+++ b/docs/quick_tutorial/unit_testing.rst
@@ -62,7 +62,7 @@ Steps
    .. code-block:: bash
 
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        .
        1 passed in 0.14 seconds
 
@@ -96,7 +96,7 @@ Extra credit
 ============
 
 #. Change the test to assert that the response status code should be ``404``
-   (meaning, not found). Run ``py.test`` again. Read the error report and see
+   (meaning, not found). Run ``pytest`` again. Read the error report and see
    if you can decipher what it is telling you.
 
 #. As a more realistic example, put the ``tests.py`` back as you found it, and

--- a/docs/quick_tutorial/view_classes.rst
+++ b/docs/quick_tutorial/view_classes.rst
@@ -61,7 +61,7 @@ Steps
 
    .. code-block:: bash
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ....
        4 passed in 0.34 seconds
 

--- a/docs/quick_tutorial/views.rst
+++ b/docs/quick_tutorial/views.rst
@@ -68,7 +68,7 @@ Steps
    .. code-block:: bash
 
 
-       $VENV/bin/py.test tutorial/tests.py -q
+       $VENV/bin/pytest tutorial/tests.py -q
        ....
        4 passed in 0.28 seconds
 

--- a/docs/tutorials/wiki/installation.rst
+++ b/docs/tutorials/wiki/installation.rst
@@ -195,7 +195,7 @@ Run the tests
 
 After you've installed the project in development mode as well as the testing
 requirements, you may run the tests for the project. The following commands
-provide options to `pytest` that specify the module for which its tests shall be
+provide options to ``pytest`` that specify the module for which its tests shall be
 run, and to run ``pytest`` in quiet mode.
 
 On Unix
@@ -299,7 +299,7 @@ On Windows
 tell ``pytest`` where to find the module on which we want to run tests and
 coverage.
 
-.. seealso:: See pytest's documentation for :ref:`pytest:usage` or invoke
+.. seealso:: See ``pytest``'s documentation for :ref:`pytest:usage` or invoke
    ``pytest -h`` to see its full set of options.
 
 

--- a/docs/tutorials/wiki/installation.rst
+++ b/docs/tutorials/wiki/installation.rst
@@ -195,7 +195,7 @@ Run the tests
 
 After you've installed the project in development mode as well as the testing
 requirements, you may run the tests for the project. The following commands
-provide options to :term:`pytest` that specify the module for which its tests shall be
+provide options to `pytest` that specify the module for which its tests shall be
 run, and to run ``pytest`` in quiet mode.
 
 On Unix

--- a/docs/tutorials/wiki/installation.rst
+++ b/docs/tutorials/wiki/installation.rst
@@ -195,22 +195,22 @@ Run the tests
 
 After you've installed the project in development mode as well as the testing
 requirements, you may run the tests for the project. The following commands
-provide options to py.test that specify the module for which its tests shall be
-run, and to run py.test in quiet mode.
+provide options to :term:`pytest` that specify the module for which its tests shall be
+run, and to run ``pytest`` in quiet mode.
 
 On Unix
 ^^^^^^^
 
 .. code-block:: bash
 
-    $VENV/bin/py.test -q
+    $VENV/bin/pytest -q
 
 On Windows
 ^^^^^^^^^^
 
 .. code-block:: doscon
 
-    %VENV%\Scripts\py.test -q
+    %VENV%\Scripts\pytest -q
 
 For a successful test run, you should see output that ends like this:
 
@@ -223,8 +223,8 @@ For a successful test run, you should see output that ends like this:
 Expose test coverage information
 --------------------------------
 
-You can run the ``py.test`` command to see test coverage information. This
-runs the tests in the same way that ``py.test`` does, but provides additional
+You can run the ``pytest`` command to see test coverage information. This
+runs the tests in the same way that ``pytest`` does, but provides additional
 :term:`coverage` information, exposing which lines of your project are covered by the
 tests.
 
@@ -236,14 +236,14 @@ On Unix
 
 .. code-block:: bash
 
-    $VENV/bin/py.test --cov --cov-report=term-missing
+    $VENV/bin/pytest --cov --cov-report=term-missing
 
 On Windows
 ^^^^^^^^^^
 
 .. code-block:: doscon
 
-    %VENV%\Scripts\py.test --cov --cov-report=term-missing
+    %VENV%\Scripts\pytest --cov --cov-report=term-missing
 
 If successful, you will see output something like this:
 
@@ -275,7 +275,7 @@ Our package doesn't quite have 100% test coverage.
 Test and coverage cookiecutter defaults
 ---------------------------------------
 
-Cookiecutters include configuration defaults for ``py.test`` and test coverage.
+Cookiecutters include configuration defaults for ``pytest`` and test coverage.
 These configuration files are ``pytest.ini`` and ``.coveragerc``, located at
 the root of your package. Without these defaults, we would need to specify the
 path to the module on which we want to run tests and coverage.
@@ -285,22 +285,22 @@ On Unix
 
 .. code-block:: bash
 
-    $VENV/bin/py.test --cov=tutorial tutorial/tests.py -q
+    $VENV/bin/pytest --cov=tutorial tutorial/tests.py -q
 
 On Windows
 ^^^^^^^^^^
 
 .. code-block:: doscon
 
-    %VENV%\Scripts\py.test --cov=tutorial tutorial\tests.py -q
+    %VENV%\Scripts\pytest --cov=tutorial tutorial\tests.py -q
 
-py.test follows :ref:`conventions for Python test discovery
+``pytest`` follows :ref:`conventions for Python test discovery
 <pytest:test discovery>`, and the configuration defaults from the cookiecutter
-tell ``py.test`` where to find the module on which we want to run tests and
+tell ``pytest`` where to find the module on which we want to run tests and
 coverage.
 
-.. seealso:: See py.test's documentation for :ref:`pytest:usage` or invoke
-   ``py.test -h`` to see its full set of options.
+.. seealso:: See pytest's documentation for :ref:`pytest:usage` or invoke
+   ``pytest -h`` to see its full set of options.
 
 
 .. _wiki-start-the-application:

--- a/docs/tutorials/wiki/tests.rst
+++ b/docs/tutorials/wiki/tests.rst
@@ -51,22 +51,22 @@ follows:
 Running the tests
 =================
 
-We can run these tests by using ``py.test`` similarly to how we did in
+We can run these tests by using ``pytest`` similarly to how we did in
 :ref:`running_tests`. Courtesy of the cookiecutter, our testing dependencies have
-already been satisfied and ``py.test`` and coverage have already been
+already been satisfied and ``pytest`` and coverage have already been
 configured, so we can jump right to running tests.
 
 On Unix:
 
 .. code-block:: bash
 
-    $VENV/bin/py.test -q
+    $VENV/bin/pytest -q
 
 On Windows:
 
 .. code-block:: doscon
 
-    %VENV%\Scripts\py.test -q
+    %VENV%\Scripts\pytest -q
 
 The expected result should look like the following:
 

--- a/docs/tutorials/wiki2/installation.rst
+++ b/docs/tutorials/wiki2/installation.rst
@@ -453,7 +453,7 @@ pytest follows :ref:`conventions for Python test discovery
 tell ``pytest`` where to find the module on which we want to run tests and
 coverage.
 
-.. seealso:: See pytest's documentation for :ref:`pytest:usage` or invoke
+.. seealso:: See ``pytest``'s documentation for :ref:`pytest:usage` or invoke
    ``pytest -h`` to see its full set of options.
 
 

--- a/docs/tutorials/wiki2/installation.rst
+++ b/docs/tutorials/wiki2/installation.rst
@@ -342,22 +342,22 @@ Run the tests
 
 After you've installed the project in development mode as well as the testing
 requirements, you may run the tests for the project. The following commands
-provide options to py.test that specify the module for which its tests shall be
-run, and to run py.test in quiet mode.
+provide options to ``pytest`` that specify the module for which its tests shall be
+run, and to run ``pytest`` in quiet mode.
 
 On Unix
 ^^^^^^^
 
 .. code-block:: bash
 
-    $VENV/bin/py.test -q
+    $VENV/bin/pytest -q
 
 On Windows
 ^^^^^^^^^^
 
 .. code-block:: doscon
 
-    %VENV%\Scripts\py.test -q
+    %VENV%\Scripts\pytest -q
 
 For a successful test run, you should see output that ends like this:
 
@@ -370,8 +370,8 @@ For a successful test run, you should see output that ends like this:
 Expose test coverage information
 --------------------------------
 
-You can run the ``py.test`` command to see test coverage information. This
-runs the tests in the same way that ``py.test`` does, but provides additional
+You can run the ``pytest`` command to see test coverage information. This
+runs the tests in the same way that ``pytest`` does, but provides additional
 :term:`coverage` information, exposing which lines of your project are covered by the
 tests.
 
@@ -383,14 +383,14 @@ On Unix
 
 .. code-block:: bash
 
-    $VENV/bin/py.test --cov --cov-report=term-missing
+    $VENV/bin/pytest --cov --cov-report=term-missing
 
 On Windows
 ^^^^^^^^^^
 
 .. code-block:: doscon
 
-    c:\tutorial> %VENV%\Scripts\py.test --cov --cov-report=term-missing
+    c:\tutorial> %VENV%\Scripts\pytest --cov --cov-report=term-missing
 
 If successful, you will see output something like this:
 
@@ -429,7 +429,7 @@ Our package doesn't quite have 100% test coverage.
 Test and coverage cookiecutter defaults
 ---------------------------------------
 
-Cookiecutters include configuration defaults for ``py.test`` and test coverage.
+Cookiecutters include configuration defaults for ``pytest`` and test coverage.
 These configuration files are ``pytest.ini`` and ``.coveragerc``, located at
 the root of your package. Without these defaults, we would need to specify the
 path to the module on which we want to run tests and coverage.
@@ -439,22 +439,22 @@ On Unix
 
 .. code-block:: bash
 
-    $VENV/bin/py.test --cov=tutorial tutorial/tests.py -q
+    $VENV/bin/pytest --cov=tutorial tutorial/tests.py -q
 
 On Windows
 ^^^^^^^^^^
 
 .. code-block:: doscon
 
-    %VENV%\Scripts\py.test --cov=tutorial tutorial\tests.py -q
+    %VENV%\Scripts\pytest --cov=tutorial tutorial\tests.py -q
 
-py.test follows :ref:`conventions for Python test discovery
+pytest follows :ref:`conventions for Python test discovery
 <pytest:test discovery>`, and the configuration defaults from the cookiecutter
-tell ``py.test`` where to find the module on which we want to run tests and
+tell ``pytest`` where to find the module on which we want to run tests and
 coverage.
 
-.. seealso:: See py.test's documentation for :ref:`pytest:usage` or invoke
-   ``py.test -h`` to see its full set of options.
+.. seealso:: See pytest's documentation for :ref:`pytest:usage` or invoke
+   ``pytest -h`` to see its full set of options.
 
 
 .. _wiki2-start-the-application:

--- a/docs/tutorials/wiki2/tests.rst
+++ b/docs/tutorials/wiki2/tests.rst
@@ -99,14 +99,14 @@ On Unix:
 .. code-block:: bash
 
     rm tutorial.sqlite
-    $VENV/bin/py.test -q
+    $VENV/bin/pytest -q
 
 On Windows:
 
 .. code-block:: doscon
 
     del tutorial.sqlite
-    %VENV%\Scripts\py.test -q
+    %VENV%\Scripts\pytest -q
 
 The expected result should look like the following:
 

--- a/docs/typographical-conventions.rst
+++ b/docs/typographical-conventions.rst
@@ -128,7 +128,7 @@ When a command that should be typed on one line is too long to fit on the displa
 
 .. code-block:: bash
 
-    $VENV/bin/py.test tutorial/tests.py --cov-report term-missing \
+    $VENV/bin/pytest tutorial/tests.py --cov-report term-missing \
         --cov=tutorial -q
 
 


### PR DESCRIPTION
in the Pytest 3.0 release (Aug '16), it is now recommended to use "pytest" instead of "py.test".  I've updated all of the Pyramid documentation, including the Quick Tour Tutorial, the ZODB + Traversal tutorial, SQLAlchemy + URL Dispatch tutorial, and narrative documentation to change all references of "py.test" to "pytest"

Please let me know if anything is incorrect or if any changes are needed.

Thanks!