### PR TITLE
Adjust virtual env instruction line range reference.

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -332,3 +332,5 @@ Contributors
 - Kuzma Leshakov, 2018/09/07
 
 - Colin Dunklau, 2018/09/19
+
+- Alexandre Yukio Harano, 2018/10/05

--- a/contributing.md
+++ b/contributing.md
@@ -51,7 +51,7 @@ System](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/install.h
          git remote add upstream git@github.com:Pylons/pyramid.git
 
 5.  Create a virtual environment and set an environment variable as instructed in the
-    [prerequisites](https://github.com/Pylons/pyramid/blob/master/HACKING.txt#L55-L58).
+    [prerequisites](https://github.com/Pylons/pyramid/blob/master/HACKING.txt#L48-L56).
 
          # Mac and Linux
          $ export VENV=~/hack-on-pyramid/env


### PR DESCRIPTION
While setting up my development environment following [contributing.md's instruction](https://github.com/ayharano/pyramid/blob/master/contributing.md#building-documentation-for-a-pylons-project-project), verified that [HACKING.txt](https://github.com/Pylons/pyramid/blob/master/HACKING.txt)'s reference was strange, probably as a byproduct of commit [`0816999`](https://github.com/Pylons/pyramid/commit/081699993078baa817d0d1c220db6a0d87555a44).

This pull request is a small one that covers a line range to cover the original prerequisite instruction. 

Also adding myself to CONTRIBUTORS.txt as it is my first contribution.