### PR TITLE
Fixes issue #1428  - make partial functions work as view callables

### DIFF
--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -1096,6 +1096,31 @@ class Test_takes_one_arg(unittest.TestCase):
         getattr(foo, '__annotations__', {}).update({'bar': 'baz'})
         self.assertTrue(self._callFUT(foo))
 
+    def test_partial_decorated_func(self):
+        from functools import partial
+
+        def func(a, b, c):
+            pass
+
+        self.assertFalse(self._callFUT(partial(func)))
+        self.assertFalse(self._callFUT(partial(func, 1)))
+        self.assertTrue(self._callFUT(partial(func, 1, 2)))
+        self.assertFalse(self._callFUT(partial(func, 1, 2, 3)))
+
+    def test_partial_decorated_method(self):
+        from functools import partial
+
+        class Foo:
+            def func(self, a, b, c):
+                pass
+
+        foo = Foo()
+        self.assertFalse(self._callFUT(partial(foo.func)))
+        self.assertFalse(self._callFUT(partial(foo.func, 1)))
+        self.assertTrue(self._callFUT(partial(foo.func, 1, 2)))
+        self.assertFalse(self._callFUT(partial(foo.func, 1, 2, 3)))
+
+
 
 class TestSimpleSerializer(unittest.TestCase):
     def _makeOne(self):

--- a/pyramid/tests/test_util.py
+++ b/pyramid/tests/test_util.py
@@ -1107,6 +1107,26 @@ class Test_takes_one_arg(unittest.TestCase):
         self.assertTrue(self._callFUT(partial(func, 1, 2)))
         self.assertFalse(self._callFUT(partial(func, 1, 2, 3)))
 
+        self.assertTrue(self._callFUT(partial(func, a=1, b=2)))
+        self.assertTrue(self._callFUT(partial(func, b=2, c=3)))
+        self.assertTrue(self._callFUT(partial(func, 2, c=3)))
+
+
+    def test_partial_decorated_func_with_argname(self):
+        from functools import partial
+
+        def func(a, b, c):
+            pass
+
+        self.assertFalse(self._callFUT(partial(func, 1, 2), argname='a'))
+        self.assertTrue(self._callFUT(partial(func, 1, 2), argname='c'))
+        self.assertFalse(self._callFUT(partial(func, a=1, c=3), argname='c'))
+        self.assertTrue(self._callFUT(partial(func, a=1, c=3), argname='b'))
+
+        self.assertFalse(self._callFUT(partial(func,), argname='a'))
+        self.assertFalse(self._callFUT(partial(func, a=1), argname='b'))
+        self.assertFalse(self._callFUT(partial(func, a=1, b=2), argname='b'))
+
     def test_partial_decorated_method(self):
         from functools import partial
 

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -639,10 +639,10 @@ def takes_one_arg(callee, attr=None, argname=None):
         return False
 
     if len(args) == 1:
-        return True
+        if not argname or argname in args:
+            return True
 
     if argname:
-
         defaults = argspec[3]
         if defaults is None:
             defaults = ()

--- a/pyramid/util.py
+++ b/pyramid/util.py
@@ -594,7 +594,14 @@ def make_contextmanager(fn):
 
 
 def takes_one_arg(callee, attr=None, argname=None):
+    ispartial = False
     ismethod = False
+    if isinstance(callee, functools.partial):
+        if attr:
+            raise TypeError('"attr" with a partial function does not make sense')
+        ispartial = True
+        callee_wrapper = callee
+        callee = callee.func
     if attr is None:
         attr = '__call__'
     if inspect.isroutine(callee):
@@ -623,6 +630,10 @@ def takes_one_arg(callee, attr=None, argname=None):
         if not args:
             return False
         args = args[1:]
+
+    if ispartial:
+        args = args[len(callee_wrapper.args):]
+        args = [arg for arg in args if arg not in callee_wrapper.keywords]
 
     if not args:
         return False


### PR DESCRIPTION
What: Fixes #1428

How: Treat objectes decorated with functools.partial as special cases in `pyramid.util.takes_one_arg`.

(This PR is part of the "Pyramid Samba Sprint" taking place at Geru, in Sao Paulo)