### PR TITLE
support mounting routes without a trailing slash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,12 @@ Features
   documentation for more information about why this change was made.
   See https://github.com/Pylons/pyramid/pull/3413
 
+- It is now possible to declare a route to not contain a trailing slash
+  when it is mounted via ``config.include(..., route_prefix=...)`` or via
+  ``with config.route_prefix_context(...)`` by specifying a ``pattern`` of
+  ``''``. This change is backward incompatible, see the notes below.
+  See https://github.com/Pylons/pyramid/pull/3414
+
 Bug Fixes
 ---------
 
@@ -67,6 +73,15 @@ Backward Incompatibilities
   "Changes to ISession in Pyramid 2.0" in the "Sessions" chapter of the
   documentation for more information about why this change was made.
   See https://github.com/Pylons/pyramid/pull/3413
+
+- Changed the URL generation and matching for a route with a ``pattern`` of
+  ``''`` when the route is mounted with a ``route_prefix`` via either
+  ``config.include(..., route_prefix=...)`` or
+  ``with config.route_prefix_context(...)``. This route will now match a bare
+  URL without a trailing slash. To preserve the old behavior, set the
+  ``pattern`` to ``'/'`` instead of the empty string and the URL will contain
+  a trailing slash. This only affects mounted routes using ``route_prefix``.
+  See https://github.com/Pylons/pyramid/pull/3414
 
 Documentation Changes
 ---------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -230,7 +230,6 @@ Contributors
 - Antti Haapala, 2013/11/15
 
 - Amit Mane, 2014/01/23
-<<<<<<< HEAD
 
 - Fenton Travers, 2014/05/06
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -230,6 +230,7 @@ Contributors
 - Antti Haapala, 2013/11/15
 
 - Amit Mane, 2014/01/23
+<<<<<<< HEAD
 
 - Fenton Travers, 2014/05/06
 
@@ -296,6 +297,8 @@ Contributors
 - Martin Frlin, 2016/12/7
 
 - Kirill Kuzminykh, 2017/03/01
+
+- Charlie Choiniere, 2017/04/03
 
 - Aleph Melo, 2017/04/16
 

--- a/docs/narr/urldispatch.rst
+++ b/docs/narr/urldispatch.rst
@@ -998,6 +998,24 @@ then only match if the URL path is ``/users/show``, and when the
 :meth:`pyramid.request.Request.route_url` function is called with the route
 name ``show_users``, it will generate a URL with that same path.
 
+To create a prefixed route that matches requests to the ``route_prefix``
+without a trailing slash set the route ``pattern`` to an empty string.
+
+.. code-block:: python
+   :linenos:
+
+   from pyramid.config import Configurator
+
+   def users_include(config):
+       config.add_route('show_users', '')
+
+   def main(global_config, **settings):
+       config = Configurator()
+       config.include(users_include, route_prefix='/users')
+
+The above configuration will match ``/users`` instead of ``/users/`` if a slash
+had been supplied to the :meth:`pyramid.config.Configurator.add_route` function.
+
 Route prefixes are recursive, so if a callable executed via an include itself
 turns around and includes another callable, the second-level route prefix will
 be prepended with the first:

--- a/src/pyramid/config/routes.py
+++ b/src/pyramid/config/routes.py
@@ -364,7 +364,10 @@ class RoutesConfiguratorMixin(object):
             static = True
 
         elif self.route_prefix:
-            pattern = self.route_prefix.rstrip('/') + '/' + pattern.lstrip('/')
+            if pattern == '':
+                pattern = self.route_prefix.rstrip('/')
+            else:
+                pattern = self.route_prefix.rstrip('/') + '/' + pattern.lstrip('/')
 
         mapper = self.get_routes_mapper()
 

--- a/tests/test_config/test_routes.py
+++ b/tests/test_config/test_routes.py
@@ -54,6 +54,18 @@ class RoutesConfiguratorMixinTests(unittest.TestCase):
         config.add_route('name', 'path')
         self._assertRoute(config, 'name', 'root/path')
 
+    def test_add_route_with_empty_string_with_route_prefix(self):
+        config = self._makeOne(autocommit=True)
+        config.route_prefix = 'root'
+        config.add_route('name', '')
+        self._assertRoute(config, 'name', 'root')
+
+    def test_add_route_with_root_slash_with_route_prefix(self):
+        config = self._makeOne(autocommit=True)
+        config.route_prefix = 'root'
+        config.add_route('name', '/')
+        self._assertRoute(config, 'name', 'root/')
+
     def test_add_route_discriminator(self):
         config = self._makeOne()
         config.add_route('name', 'path')


### PR DESCRIPTION
This PR replaces #1639. Closes #406.

The gist is this snippet that was added to the docs.

```python
from pyramid.config import Configurator

def users_include(config):
    config.add_route('show_users', '')

def main(global_config, **settings):
    config = Configurator()
    config.include(users_include, route_prefix='/users')

The above configuration will match ``/users`` instead of ``/users/`` if a slash
had been supplied to the :meth:`pyramid.config.Configurator.add_route` function.
```

This is backward-incompatible for anyone mounting routes and using an empty string.

Alternative approaches that could maintain compatibility:

1) Support a sentinel value as the pattern. For example:

```python
from pyramid.config import NO_APPEND_SLASH

def users_include(config):
    config.add_route('show_users', NO_APPEND_SLASH)
```

This is somewhat cumbersome.

2) Add an option to `add_route` that a user could opt into.

```python
def users_include(config):
    config.add_route('show_users', '', route_prefix_append_slash=False)
```

I'm open to something like this and am curious what people think. Pyramid has a somewhat ingrained history of supporting `'' == '/'` and this makes them different, but only in a specific use case. When used from main or without a route_prefix, they are still equivalent and result in a trailing slash. I'm not convinced it's worth the incompatibility.

ping @nek4life 