### PR TITLE
call fix_registry so that queryAdapterOrSelf is available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+unreleased
+==========
+
+- Fix an issue when passing a duck-typed registry object into
+  ``pyramid.testing.setUp(registry=...)`` in which the registry wasn't
+  properly fixed prior to invoking actions.
+  See https://github.com/Pylons/pyramid/pull/3418
+
 1.10 (2018-10-31)
 =================
 

--- a/src/pyramid/testing.py
+++ b/src/pyramid/testing.py
@@ -509,6 +509,7 @@ def setUp(
     )
     if settings is None:
         settings = {}
+    config._fix_registry()
     if getattr(registry, 'settings', None) is None:
         config._set_settings(settings)
     if hasattr(registry, 'registerUtility'):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -434,6 +434,20 @@ class Test_setUp(unittest.TestCase):
         config = self._callFUT(hook_zca=False, settings=dict(a=1))
         self.assertEqual(config.registry.settings['a'], 1)
 
+    def test_it_with_unpatched_registry(self):
+        from zope.interface.registry import Components
+
+        class DummyRegistry(Components, dict):
+            pass
+
+        dummy_registry = DummyRegistry()
+        config = self._callFUT(
+            registry=dummy_registry, hook_zca=False, settings=dict(a=1)
+        )
+        self.assertEqual(config.registry.settings['a'], 1)
+        dummy = DummyEvent()
+        self.assertIs(dummy_registry.queryAdapterOrSelf(dummy, IDummy), dummy)
+
 
 class Test_cleanUp(Test_setUp):
     def _callFUT(self, *arg, **kw):


### PR DESCRIPTION
fixes #3416