### PR TITLE
Keep the localizer property from showing up twice in the docs

### DIFF
--- a/docs/api/request.rst
+++ b/docs/api/request.rst
@@ -14,7 +14,7 @@
                      model_url, resource_url, resource_path, set_property, 
                      effective_principals, authenticated_userid,
                      unauthenticated_userid, has_permission,
-                     invoke_exception_view
+                     invoke_exception_view, localizer
 
    .. attribute:: context
 


### PR DESCRIPTION
Works.  I don't know enough to say if this is really the right way to do this.