### PR TITLE
changed  principals_allowed_by_permission to act differently if permissive is True or False

### DIFF
--- a/src/pyramid/testing.py
+++ b/src/pyramid/testing.py
@@ -94,7 +94,7 @@ class DummySecurityPolicy(object):
         if self.permissive:
             return self.effective_principals(None)
         else:
-            return None
+            return []
 
 
 class DummyTemplateRenderer(object):

--- a/src/pyramid/testing.py
+++ b/src/pyramid/testing.py
@@ -91,7 +91,10 @@ class DummySecurityPolicy(object):
         return self.permissive
 
     def principals_allowed_by_permission(self, context, permission):
-        return self.effective_principals(None)
+        if self.permissive:
+            return self.effective_principals(None)
+        else:
+            return None
 
 
 class DummyTemplateRenderer(object):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -63,6 +63,13 @@ class TestDummySecurityPolicy(unittest.TestCase):
         result = policy.principals_allowed_by_permission(None, None)
         self.assertEqual(result, [Everyone, Authenticated, 'user', 'group1'])
 
+    def test_principals_allowed_by_permission_not_permissive(self):
+        policy = self._makeOne('user', ('group1',))
+        policy.permissive = False
+
+        result = policy.principals_allowed_by_permission(None, None)
+        self.assertEqual(result, [])
+
     def test_forget(self):
         policy = self._makeOne()
         self.assertEqual(policy.forget(None), [])


### PR DESCRIPTION
principals_allowed_by_permission of the DummySecurityPolicy should return an empty list if permissive is set to False as no Principal is allowed