### PR TITLE
backport #3442 to 1.10-branch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+unreleased
+==========
+
+- Fix a bug in ``pyramid.testing.DummySecurityPolicy`` in which
+  ``principals_allows_by_permission`` would return all principals instead
+  of an empty list if ``permissive`` is ``False``.
+  See https://github.com/Pylons/pyramid/pull/3450
+
 .. _changes_1.10.1:
 
 1.10.1 (2018-11-06)
@@ -15,9 +23,6 @@
 
 1.10b1 (2018-10-28)
 ===================
-
-Bug Fixes
----------
 
 - Fix the ``pyramid.testing.DummyRequest`` to support the new
   ``request.accept`` API so that ``acceptable_offers`` is available even

--- a/src/pyramid/testing.py
+++ b/src/pyramid/testing.py
@@ -91,7 +91,10 @@ class DummySecurityPolicy(object):
         return self.permissive
 
     def principals_allowed_by_permission(self, context, permission):
-        return self.effective_principals(None)
+        if self.permissive:
+            return self.effective_principals(None)
+        else:
+            return []
 
 
 class DummyTemplateRenderer(object):

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -63,6 +63,13 @@ class TestDummySecurityPolicy(unittest.TestCase):
         result = policy.principals_allowed_by_permission(None, None)
         self.assertEqual(result, [Everyone, Authenticated, 'user', 'group1'])
 
+    def test_principals_allowed_by_permission_not_permissive(self):
+        policy = self._makeOne('user', ('group1',))
+        policy.permissive = False
+
+        result = policy.principals_allowed_by_permission(None, None)
+        self.assertEqual(result, [])
+
     def test_forget(self):
         policy = self._makeOne()
         self.assertEqual(policy.forget(None), [])


### PR DESCRIPTION
principals_allowed_by_permission returned all principals regardless
if permissiv is true or false. It should return a empty list if
permissive is False.