### PR TITLE
backport #3442 to 1.9-branch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+unreleased
+==========
+
+- Fix a bug in ``pyramid.testing.DummySecurityPolicy`` in which
+  ``principals_allows_by_permission`` would return all principals instead
+  of an empty list if ``permissive`` is ``False``.
+  See https://github.com/Pylons/pyramid/pull/3451
+
 .. _changes_1.9.3:
 
 1.9.3 (2018-10-31)

--- a/pyramid/testing.py
+++ b/pyramid/testing.py
@@ -93,7 +93,10 @@ class DummySecurityPolicy(object):
         return self.permissive
 
     def principals_allowed_by_permission(self, context, permission):
-        return self.effective_principals(None)
+        if self.permissive:
+            return self.effective_principals(None)
+        else:
+            return []
 
 class DummyTemplateRenderer(object):
     """

--- a/pyramid/tests/test_testing.py
+++ b/pyramid/tests/test_testing.py
@@ -51,6 +51,13 @@ class TestDummySecurityPolicy(unittest.TestCase):
         result = policy.principals_allowed_by_permission(None, None)
         self.assertEqual(result, [Everyone, Authenticated, 'user', 'group1'])
 
+    def test_principals_allowed_by_permission_not_permissive(self):
+        policy = self._makeOne('user', ('group1',))
+        policy.permissive = False
+
+        result = policy.principals_allowed_by_permission(None, None)
+        self.assertEqual(result, [])
+
     def test_forget(self):
         policy = self._makeOne()
         self.assertEqual(policy.forget(None), [])


### PR DESCRIPTION
principals_allowed_by_permission returned all principals regardless
if permissiv is true or false. It should return a empty list if
permissive is False.