### PR TITLE
do not configure logging in the master process when using the reloader

### DIFF
--- a/src/pyramid/scripts/pserve.py
+++ b/src/pyramid/scripts/pserve.py
@@ -182,7 +182,11 @@ class PServeCommand(object):
         app_name = self.args.app_name
 
         loader = self._get_config_loader(config_uri)
-        loader.setup_logging(config_vars)
+
+        # setup logging only in the worker process incase the logging config
+        # opens files which should not be opened by multiple processes at once
+        if not self.args.reload or hupper.is_active():
+            loader.setup_logging(config_vars)
 
         self.pserve_file_config(loader, global_conf=config_vars)
 


### PR DESCRIPTION
fixes #3455 