### PR TITLE
Fix docs build on Sphinx 2.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,3 +93,6 @@ Documentation Changes
 
 - Restore build of PDF on Read The Docs.
   See https://github.com/Pylons/pyramid/issues/3290
+
+- Fix docs build for Sphinx 2.0.
+  See https://github.com/Pylons/pyramid/pull/3480

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -338,3 +338,5 @@ Contributors
 - Alexandre Yukio Harano, 2018/10/05
 
 - Arijit Basu, 2019/02/19
+
+- Theron Luhn, 2019/03/30

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ from sphinx.writers.latex import LaTeXTranslator
 
 from docutils import nodes
 from docutils import utils
+from docutils.parsers.rst import Directive
 
 
 def raw(*arg):
@@ -326,7 +327,6 @@ _PREAMBLE = r"""
 
 latex_elements = {
     'preamble': _PREAMBLE,
-    'date': '',
     'releasename': 'Version',
     'title': r'The Pyramid Web Framework',
 #    'pointsize':'12pt', # uncomment for 12pt version
@@ -345,25 +345,25 @@ latex_elements = {
 #subparagraph  5
 
 
-def frontmatter(name, arguments, options, content, lineno,
-                content_offset, block_text, state, state_machine):
-    return [nodes.raw(
-        '',
-        format='latex')]
+class FrontMatter(Directive):
+    def run(self):
+        return [nodes.raw(
+            '',
+            format='latex')]
 
 
-def mainmatter(name, arguments, options, content, lineno,
-               content_offset, block_text, state, state_machine):
-    return [nodes.raw(
-        '',
-        format='latex')]
+class MainMatter(Directive):
+    def run(self):
+        return [nodes.raw(
+            '',
+            format='latex')]
 
 
-def backmatter(name, arguments, options, content, lineno,
-              content_offset, block_text, state, state_machine):
-    return [nodes.raw(
-        '',
-        format='latex')]
+class BackMatter(Directive):
+    def run(self):
+        return [nodes.raw(
+            '',
+            format='latex')]
 
 
 def app_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
@@ -378,9 +378,9 @@ def app_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
 
 def setup(app):
     app.add_role('app', app_role)
-    app.add_directive('frontmatter', frontmatter, 1, (0, 0, 0))
-    app.add_directive('mainmatter', mainmatter, 1, (0, 0, 0))
-    app.add_directive('backmatter', backmatter, 1, (0, 0, 0))
+    app.add_directive('frontmatter', FrontMatter, 1, (0, 0, 0))
+    app.add_directive('mainmatter', MainMatter, 1, (0, 0, 0))
+    app.add_directive('backmatter', BackMatter, 1, (0, 0, 0))
     app.connect('autodoc-process-signature', resig)
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -152,11 +152,9 @@ Comprehensive reference material for every public API exposed by
 :app:`Pyramid`:
 
 .. toctree::
-   :maxdepth: 1
-   :glob:
+   :maxdepth: 2
 
    api/index
-   api/*
 
 
 ``p*`` Scripts Documentation
@@ -165,11 +163,9 @@ Comprehensive reference material for every public API exposed by
 ``p*`` scripts included with :app:`Pyramid`.
 
 .. toctree::
-   :maxdepth: 1
-   :glob:
+   :maxdepth: 2
 
    pscripts/index
-   pscripts/*
 
 
 Change History

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ tests_require = [
 
 
 docs_extras = [
-    'Sphinx == 1.8.5',  # Current version for Read the Docs
+    'Sphinx >= 1.8.1',  # Unicode characters in tree diagrams
     'docutils',
     'pylons-sphinx-themes >= 1.0.8',  # Ethical Ads
     'pylons_sphinx_latesturl',

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ tests_require = [
 
 
 docs_extras = [
-    'Sphinx >= 1.8.1',  # Unicode characters in tree diagrams
+    'Sphinx == 1.8.5',  # Current version for Read the Docs
     'docutils',
     'pylons-sphinx-themes >= 1.0.8',  # Ethical Ads
     'pylons_sphinx_latesturl',


### PR DESCRIPTION
Sphinx 2.0.0 was released, which triggered some warnings when building
the docs and caused the build to fail.