### PR TITLE
Refactor base_version to major_version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,11 @@ testing_extras = tests_require + [
     'virtualenv',  # for scaffolding tests
 ]
 
-major_version = ".".join(VERSION.split(".")[:2])
+branch_version = ".".join(VERSION.split(".")[:2])
 
 # black is refusing to make anything under 80 chars so just splitting it up
 docs_fmt = 'https://docs.pylonsproject.org/projects/pyramid/en/{}-branch/'
-docs_url = docs_fmt.format(major_version)
+docs_url = docs_fmt.format(branch_version)
 
 setup(
     name='pyramid',
@@ -92,7 +92,7 @@ setup(
     url="https://trypyramid.com",
     project_urls={
         'Documentation': docs_url,
-        'Changelog': '{}whatsnew-{}.html'.format(docs_url, major_version),
+        'Changelog': '{}whatsnew-{}.html'.format(docs_url, branch_version),
         'Issue Tracker': 'https://github.com/Pylons/pyramid/issues',
     },
     license="BSD-derived (http://www.repoze.org/LICENSE.txt)",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 #
 ##############################################################################
 from setuptools import find_packages, setup
-from pkg_resources import parse_version
 
 
 def readfile(name):

--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,13 @@ testing_extras = tests_require + [
     'virtualenv',  # for scaffolding tests
 ]
 
-base_version = parse_version(VERSION).base_version
+major_version = ".".join(
+    str(v) for v in parse_version(VERSION)._version.release[:2]
+)
 
 # black is refusing to make anything under 80 chars so just splitting it up
 docs_fmt = 'https://docs.pylonsproject.org/projects/pyramid/en/{}-branch/'
-docs_url = docs_fmt.format(base_version)
+docs_url = docs_fmt.format(major_version)
 
 setup(
     name='pyramid',
@@ -92,7 +94,7 @@ setup(
     url="https://trypyramid.com",
     project_urls={
         'Documentation': docs_url,
-        'Changelog': '{}whatsnew-{}.html'.format(docs_url, base_version),
+        'Changelog': '{}whatsnew-{}.html'.format(docs_url, major_version),
         'Issue Tracker': 'https://github.com/Pylons/pyramid/issues',
     },
     license="BSD-derived (http://www.repoze.org/LICENSE.txt)",

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,7 @@ testing_extras = tests_require + [
     'virtualenv',  # for scaffolding tests
 ]
 
-major_version = ".".join(
-    str(v) for v in parse_version(VERSION)._version.release[:2]
-)
+major_version = ".".join(VERSION.split(".")[:2])
 
 # black is refusing to make anything under 80 chars so just splitting it up
 docs_fmt = 'https://docs.pylonsproject.org/projects/pyramid/en/{}-branch/'


### PR DESCRIPTION
- base_version includes the minor version number, and we want the major version which is only the first two bits of the version number.

(cherry picked from commit 13ebfe393175a44b263058da0aa9e81423984345)

Backport of #3486