### PR TITLE
Fix performance regression in view_code changes (1.10)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 .. _changes_1.10.3:
 
+Unreleased
+==========
+
+- Fix performance regression in ``pyramid.view.view_config`` decorator.  See
+  https://github.com/Pylons/pyramid/pull/3490
+
 1.10.3 (2019-04-12)
 ===================
 

--- a/src/pyramid/view.py
+++ b/src/pyramid/view.py
@@ -223,9 +223,10 @@ class view_config(object):
 
     def _get_info(self):
         depth = self.__dict__.get('_depth', 0)
-        frameinfo = inspect.stack()[depth + 2]
-        sourceline = frameinfo[4][0].strip()
-        self._info = frameinfo[1], frameinfo[2], frameinfo[3], sourceline
+        frame = sys._getframe(depth + 2)
+        frameinfo = inspect.getframeinfo(frame)
+        sourceline = frameinfo[3][0].strip()
+        self._info = frameinfo[0], frameinfo[1], frameinfo[2], sourceline
 
     def __call__(self, wrapped):
         settings = self.__dict__.copy()


### PR DESCRIPTION
As discusssed in #3489

This uses `sys._getframe`, which was previously avoided because it's a cpython implementation detail (however, it is [supported in pypy](https://www.pypy.org/performance.html#micro-tuning-tips)).  It is used by venusian as well, so we already depend on the `sys._getframe`.

I'll port it to 2.0 if everybody is on board.