### PR TITLE
modify the default scan categories to be limited to only 'pyramid'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,12 @@ Backward Incompatibilities
   by the default execution policy.
   See https://github.com/Pylons/pyramid/pull/3496
 
+- ``pyramid.config.Configurator.scan`` will no longer, by default, execute
+  Venusian decorator callbacks registered for categories other than
+  ``'pyramid'``. To find any decorator regardless of category, specify
+  ``config.scan(..., categories=None)``.
+  See https://github.com/Pylons/pyramid/pull/3510
+
 Documentation Changes
 ---------------------
 

--- a/src/pyramid/config/__init__.py
+++ b/src/pyramid/config/__init__.py
@@ -805,7 +805,12 @@ class Configurator(
 
     # this is *not* an action method (uses caller_package)
     def scan(
-        self, package=None, categories=None, onerror=None, ignore=None, **kw
+        self,
+        package=None,
+        categories=('pyramid',),
+        onerror=None,
+        ignore=None,
+        **kw
     ):
         """Scan a Python package and any of its subpackages for objects
         marked with :term:`configuration decoration` such as
@@ -820,12 +825,12 @@ class Configurator(
         The ``categories`` argument, if provided, should be the
         :term:`Venusian` 'scan categories' to use during scanning.  Providing
         this argument is not often necessary; specifying scan categories is
-        an extremely advanced usage.  By default, ``categories`` is ``None``
-        which will execute *all* Venusian decorator callbacks including
-        :app:`Pyramid`-related decorators such as
-        :class:`pyramid.view.view_config`.  See the :term:`Venusian`
-        documentation for more information about limiting a scan by using an
-        explicit set of categories.
+        an extremely advanced usage.  By default, ``categories`` is
+        ``['pyramid']`` which will execute only :app:`Pyramid`-related Venusian
+        decorator callbacks such as from :class:`pyramid.view.view_config`.
+        See the :term:`Venusian` documentation for more information about
+        limiting a scan by using an explicit set of categories. Pass ``None``
+        to pick up *all* Venusian decorators.
 
         The ``onerror`` argument, if provided, should be a Venusian
         ``onerror`` callback function.  The onerror function is passed to
@@ -862,6 +867,10 @@ class Configurator(
 
         .. versionadded:: 1.3
            The ``ignore`` argument.
+
+        .. versionchanged:: 2.0
+           The ``categories`` argument now defaults to ``['pyramid']`` instead
+           of ``None`` to control which decorator callbacks are executed.
 
         """
         package = self.maybe_dotted(package)

--- a/tests/test_config/test_init.py
+++ b/tests/test_config/test_init.py
@@ -1104,7 +1104,7 @@ test_config.dummy_include2"""
 
     def test_scan_integration_with_extra_kw(self):
         config = self._makeOne(autocommit=True)
-        config.scan('tests.test_config.pkgs.scanextrakw', a=1)
+        config.scan('tests.test_config.pkgs.scanextrakw', a=1, categories=None)
         self.assertEqual(config.a, 1)
 
     def test_scan_integration_with_onerror(self):


### PR DESCRIPTION
fixes #3502 