### PR TITLE
Fix name and path of views file in Quick Tour's Session section

### DIFF
--- a/docs/quick_tour.rst
+++ b/docs/quick_tour.rst
@@ -828,7 +828,7 @@ Now make a "factory" and pass it to the :term:`configurator`'s
     :emphasize-lines: 2-3
 
 Pyramid's :term:`request` object now has a ``session`` attribute that we can
-use in our view code in ``views.py``:
+use in our view code in ``views/default.py``:
 
 .. literalinclude:: quick_tour/sessions/hello_world/views/default.py
     :language: python


### PR DESCRIPTION
The views file name and path is wrong in [Sessions section](https://docs.pylonsproject.org/projects/pyramid/en/1.10-branch/quick_tour.html#sessions).