### PR TITLE
add check_origin option and support an origin of null

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,8 +43,17 @@ Features
   ``pyramid.csrf.check_csrf_origin``. This option controls whether a
   request is rejected if it has no ``Origin`` or ``Referer`` header -
   often the result of a user configuring their browser not to send a
-  ``Referer`` header for privacy reasons.
+  ``Referer`` header for privacy reasons even on same-domain requests.
+  The default is to reject requests without a known origin. It is also
+  possible to allow the special ``Origin: null`` header by adding it to the
+  ``pyramid.csrf_trusted_origins`` list in the settings.
   See https://github.com/Pylons/pyramid/pull/3512
+  and https://github.com/Pylons/pyramid/pull/3518
+
+- A new parameter, ``check_origin``, was added to
+  ``pyramid.config.Configurator.set_default_csrf_options`` which disables
+  origin checking entirely.
+  See https://github.com/Pylons/pyramid/pull/3518
 
 - Added ``pyramid.interfaces.IPredicateInfo`` which defines the object passed
   to predicate factories as their second argument.

--- a/docs/narr/security.rst
+++ b/docs/narr/security.rst
@@ -885,7 +885,12 @@ is the current host, however additional origins may be configured by setting
 are non-standard). If a host in the list of domains starts with a ``.`` then
 that will allow all subdomains as well as the domain without the ``.``.  If no
 ``Referer`` or ``Origin`` header is present in an HTTPS request, the CSRF check
-will fail unless ``allow_no_origin`` is set.
+will fail unless ``allow_no_origin`` is set. The special ``Origin: null`` can
+be allowed by adding ``null`` to the ``pyramid.csrf_trusted_origins`` list.
+
+It is possible to opt out of checking the origin by passing
+``check_origin=False``. This is useful if the :term:`CSRF storage policy` is
+known to be secure such that the token cannot be easily used by an attacker.
 
 If CSRF checks fail then a :class:`pyramid.exceptions.BadCSRFToken` or
 :class:`pyramid.exceptions.BadCSRFOrigin` exception will be raised. This

--- a/src/pyramid/config/security.py
+++ b/src/pyramid/config/security.py
@@ -254,6 +254,7 @@ class SecurityConfiguratorMixin(object):
         token='csrf_token',
         header='X-CSRF-Token',
         safe_methods=('GET', 'HEAD', 'OPTIONS', 'TRACE'),
+        check_origin=True,
         allow_no_origin=False,
         callback=None,
     ):
@@ -279,8 +280,13 @@ class SecurityConfiguratorMixin(object):
         never be automatically checked for CSRF tokens.
         Default: ``('GET', 'HEAD', 'OPTIONS', TRACE')``.
 
-        ``allow_no_origin`` is a boolean.  If false, a request lacking both an
-        ``Origin`` and ``Referer`` header will fail the CSRF check.
+        ``check_origin`` is a boolean. If ``False``, the ``Origin`` and
+        ``Referer`` headers will not be validated as part of automated
+        CSRF checks.
+
+        ``allow_no_origin`` is a boolean.  If ``True``, a request lacking both
+        an ``Origin`` and ``Referer`` header will pass the CSRF check. This
+        option has no effect if ``check_origin`` is ``False``.
 
         If ``callback`` is set, it must be a callable accepting ``(request)``
         and returning ``True`` if the request should be checked for a valid
@@ -298,7 +304,7 @@ class SecurityConfiguratorMixin(object):
            Added the ``callback`` option.
 
         .. versionchanged:: 2.0
-           Added the ``allow_no_origin`` option.
+           Added the ``allow_no_origin`` and ``check_origin`` options.
 
         """
         options = DefaultCSRFOptions(
@@ -306,6 +312,7 @@ class SecurityConfiguratorMixin(object):
             token=token,
             header=header,
             safe_methods=safe_methods,
+            check_origin=check_origin,
             allow_no_origin=allow_no_origin,
             callback=callback,
         )
@@ -323,6 +330,8 @@ class SecurityConfiguratorMixin(object):
         intr['token'] = token
         intr['header'] = header
         intr['safe_methods'] = as_sorted_tuple(safe_methods)
+        intr['check_origin'] = allow_no_origin
+        intr['allow_no_origin'] = check_origin
         intr['callback'] = callback
 
         self.action(
@@ -362,6 +371,7 @@ class DefaultCSRFOptions(object):
         token,
         header,
         safe_methods,
+        check_origin,
         allow_no_origin,
         callback,
     ):
@@ -369,5 +379,6 @@ class DefaultCSRFOptions(object):
         self.token = token
         self.header = header
         self.safe_methods = frozenset(safe_methods)
+        self.check_origin = check_origin
         self.allow_no_origin = allow_no_origin
         self.callback = callback

--- a/src/pyramid/viewderivers.py
+++ b/src/pyramid/viewderivers.py
@@ -484,6 +484,7 @@ def csrf_view(view, info):
         token = 'csrf_token'
         header = 'X-CSRF-Token'
         safe_methods = frozenset(["GET", "HEAD", "OPTIONS", "TRACE"])
+        check_origin = True
         allow_no_origin = False
         callback = None
     else:
@@ -491,6 +492,7 @@ def csrf_view(view, info):
         token = defaults.token
         header = defaults.header
         safe_methods = defaults.safe_methods
+        check_origin = defaults.check_origin
         allow_no_origin = defaults.allow_no_origin
         callback = defaults.callback
 
@@ -510,9 +512,10 @@ def csrf_view(view, info):
             if request.method not in safe_methods and (
                 callback is None or callback(request)
             ):
-                check_csrf_origin(
-                    request, raises=True, allow_no_origin=allow_no_origin
-                )
+                if check_origin:
+                    check_csrf_origin(
+                        request, raises=True, allow_no_origin=allow_no_origin
+                    )
                 check_csrf_token(request, token, header, raises=True)
             return view(context, request)
 

--- a/tests/test_config/test_security.py
+++ b/tests/test_config/test_security.py
@@ -158,6 +158,7 @@ class ConfiguratorSecurityMethodsTests(unittest.TestCase):
             list(sorted(result.safe_methods)),
             ['GET', 'HEAD', 'OPTIONS', 'TRACE'],
         )
+        self.assertTrue(result.check_origin)
         self.assertFalse(result.allow_no_origin)
         self.assertTrue(result.callback is None)
 
@@ -174,7 +175,8 @@ class ConfiguratorSecurityMethodsTests(unittest.TestCase):
             token='DUMMY',
             header=None,
             safe_methods=('PUT',),
-            allow_no_origin=True,
+            check_origin=False,
+            allow_no_origin=False,
             callback=callback,
         )
         result = config.registry.getUtility(IDefaultCSRFOptions)
@@ -182,5 +184,6 @@ class ConfiguratorSecurityMethodsTests(unittest.TestCase):
         self.assertEqual(result.token, 'DUMMY')
         self.assertEqual(result.header, None)
         self.assertEqual(list(sorted(result.safe_methods)), ['PUT'])
-        self.assertTrue(result.allow_no_origin)
+        self.assertFalse(result.check_origin)
+        self.assertFalse(result.allow_no_origin)
         self.assertTrue(result.callback is callback)


### PR DESCRIPTION
1. Change ``allow_no_origin`` to default to ``True``.

2. Always allow ``Origin: null``.

3. Support a list of origins in the `Origin` header, per the RFC, and use the last one for validation.

I think probably the most controversial part of this PR would be handling `Origin: null`. Are people okay the way it is or should I tie its behavior to `allow_no_origin` as well? I can see arguments both directions and would be fine with either solution. I am slightly leaning toward tying it to `allow_no_origin` even though that's not what the PR currently does.

See discussion in https://github.com/Pylons/pyramid/pull/3512 as well.

**updated description**

1. Allow `csrf_trusted_origins` setting to specify a value of `null` to allow the special `Origin: null` header.

2. Support a list of origins and use the last one for validation.

3. Add a `check_origin` option to `set_default_csrf_options` to turn off origin checks entirely - default is to keep origin checks on.