### PR TITLE
deprecate PickleSerializer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ unreleased
 Features
 --------
 
+- Deprecated ``pyramid.session.PickleSerializer``.
+
 - Changed the default ``serializer`` on
   ``pyramid.session.SignedCookieSessionFactory`` to use
   ``pyramid.session.JSONSerializer`` instead of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Features
 --------
 
 - Deprecated ``pyramid.session.PickleSerializer``.
+  See https://github.com/pylons/pyramid/issues/2709
+  and https://github.com/pylons/pyramid/pull/3353
+  and https://github.com/pylons/pyramid/pull/3413
 
 - Changed the default ``serializer`` on
   ``pyramid.session.SignedCookieSessionFactory`` to use

--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -85,6 +85,12 @@ This is a stricter contract than the previous requirement that all objects be pi
 This is a backward-incompatible change.
 Previously, if a client-side session implementation was compromised, it left the application vulnerable to remote code execution attacks using specially-crafted sessions that execute code when deserialized.
 
+Please reference the following tickets if detailed information on these changes is needed:
+
+* `2.0 feature request: Require that sessions are JSON serializable #2709 <https://github.com/pylons/pyramid/issues/2709>`_.
+* `deprecate pickleable sessions, recommend json #3353 <https://github.com/pylons/pyramid/pull/3353>`_.
+* `change to use JSONSerializer for SignedCookieSessionFactory #3413 <https://github.com/pylons/pyramid/pull/3413>`_.
+
 For users with compatibility concerns, it's possible to craft a serializer that can handle both formats until you are satisfied that clients have had time to reasonably upgrade.
 Remember that sessions should be short-lived and thus the number of clients affected should be small (no longer than an auth token, at a maximum). An example serializer:
 

--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -101,10 +101,14 @@ Remember that sessions should be short-lived and thus the number of clients affe
             self.json = JSONSerializer()
 
         def dumps(self, appstruct):
-            """Accept a Python object and return bytes."""
-            # maybe catch serialization errors here and keep using pickle
-            # while finding spots in your app that are not storing
-            # JSON-serializable objects, falling back to pickle
+            """
+            Accept a Python object and return bytes.
+
+            During a migration, you may want to catch serialization errors here,
+            and keep using pickle while finding spots in your app that are not
+            storing JSON-serializable objects. You may also want to integrate
+            a fall-back to picke serialization here as well.
+            """
             return self.json.dumps(appstruct)
 
         def loads(self, bstruct):
@@ -114,8 +118,9 @@ Remember that sessions should be short-lived and thus the number of clients affe
             except ValueError:
                 try:
                     return pickle.loads(bstruct)
-                # at least ValueError, AttributeError, ImportError but more to be safe
                 except Exception:
+					# this block should catch at least:
+					# ValueError, AttributeError, ImportError; but more to be safe
                     raise ValueError
 
     # somewhere in your configuration code

--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -113,7 +113,7 @@ Remember that sessions should be short-lived and thus the number of clients affe
             During a migration, you may want to catch serialization errors here,
             and keep using pickle while finding spots in your app that are not
             storing JSON-serializable objects. You may also want to integrate
-            a fall-back to picke serialization here as well.
+            a fall-back to pickle serialization here as well.
             """
             return self.json.dumps(appstruct)
 
@@ -125,8 +125,8 @@ Remember that sessions should be short-lived and thus the number of clients affe
                 try:
                     return pickle.loads(bstruct)
                 except Exception:
-					# this block should catch at least:
-					# ValueError, AttributeError, ImportError; but more to be safe
+                    # this block should catch at least:
+                    # ValueError, AttributeError, ImportError; but more to be safe
                     raise ValueError
 
     # somewhere in your configuration code

--- a/src/pyramid/session.py
+++ b/src/pyramid/session.py
@@ -57,17 +57,6 @@ class PickleSerializer(object):
 
         Please see :ref:`pickle_session_deprecation`.
 
-        Also, please see these tickets: 
-
-        * 2.0 feature request: Require that sessions are JSON serializable #2709
-          https://github.com/pylons/pyramid/issues/2709
-
-        * deprecate pickleable sessions, recommend json #3353
-          https://github.com/Pylons/pyramid/pull/3353
-
-        * change to use JSONSerializer for SignedCookieSessionFactory #3413
-          https://github.com/Pylons/pyramid/pull/3413
-
     A serializer that uses the pickle protocol to dump Python data to bytes.
 
     This was the default serializer used by Pyramid, but has been deprecated.

--- a/src/pyramid/session.py
+++ b/src/pyramid/session.py
@@ -49,15 +49,24 @@ class PickleSerializer(object):
 
     .. warning::
 
-    In :app:`Pyramid` 2.0 the default ``serializer`` option changed to
-    use :class:`pyramid.session.JSONSerializer`, and ``PickleSerializer`
-    has been been removed from active Pyramid code.
+        In :app:`Pyramid` 2.0 the default ``serializer`` option changed to
+        use :class:`pyramid.session.JSONSerializer`, and ``PickleSerializer`
+        has been been removed from active Pyramid code.
 
-    Pyramid will require JSON-serializable objects in :app:`Pyramid` 2.0.
+        Pyramid will require JSON-serializable objects in :app:`Pyramid` 2.0.
 
-    Please see :ref:`pickle_session_deprecation`.
+        Please see :ref:`pickle_session_deprecation`.
 
-    Also, please see: #2709, #3353, #3413
+        Also, please see these tickets: 
+
+        * 2.0 feature request: Require that sessions are JSON serializable #2709
+          https://github.com/pylons/pyramid/issues/2709
+
+        * deprecate pickleable sessions, recommend json #3353
+          https://github.com/Pylons/pyramid/pull/3353
+
+        * change to use JSONSerializer for SignedCookieSessionFactory #3413
+          https://github.com/Pylons/pyramid/pull/3413
 
     A serializer that uses the pickle protocol to dump Python data to bytes.
 
@@ -75,8 +84,9 @@ class PickleSerializer(object):
         """Accept bytes and return a Python object."""
         try:
             return pickle.loads(bstruct)
-        # at least ValueError, AttributeError, ImportError but more to be safe
         except Exception:
+            # this block should catch at least:
+            # ValueError, AttributeError, ImportError; but more to be safe
             raise ValueError
 
     def dumps(self, appstruct):
@@ -452,10 +462,10 @@ def SignedCookieSessionFactory(
 
     .. warning::
 
-       In :app:`Pyramid` 2.0 the default ``serializer`` option changed to
-       use :class:`pyramid.session.JSONSerializer`. See
-       :ref:`pickle_session_deprecation` for more information about why this
-       change was made.
+        In :app:`Pyramid` 2.0 the default ``serializer`` option changed to
+        use :class:`pyramid.session.JSONSerializer`. See
+        :ref:`pickle_session_deprecation` for more information about why this
+        change was made.
 
     .. versionadded: 1.5a3
 

--- a/src/pyramid/session.py
+++ b/src/pyramid/session.py
@@ -50,7 +50,7 @@ class PickleSerializer(object):
     .. warning::
 
         In :app:`Pyramid` 2.0 the default ``serializer`` option changed to
-        use :class:`pyramid.session.JSONSerializer`, and ``PickleSerializer`
+        use :class:`pyramid.session.JSONSerializer`, and ``PickleSerializer``
         has been been removed from active Pyramid code.
 
         Pyramid will require JSON-serializable objects in :app:`Pyramid` 2.0.
@@ -74,7 +74,6 @@ class PickleSerializer(object):
 
     ``protocol`` may be specified to control the version of pickle used.
     Defaults to :attr:`pickle.HIGHEST_PROTOCOL`.
-
     """
 
     def __init__(self, protocol=pickle.HIGHEST_PROTOCOL):

--- a/src/pyramid/session.py
+++ b/src/pyramid/session.py
@@ -44,10 +44,24 @@ def manage_changed(wrapped):
 
 
 class PickleSerializer(object):
-    """ A serializer that uses the pickle protocol to dump Python
-    data to bytes.
+    """
+    .. deprecated:: 2.0
 
-    This is the default serializer used by Pyramid.
+    .. warning::
+
+    In :app:`Pyramid` 2.0 the default ``serializer`` option changed to
+    use :class:`pyramid.session.JSONSerializer`, and ``PickleSerializer`
+    has been been removed from active Pyramid code.
+
+    Pyramid will require JSON-serializable objects in :app:`Pyramid` 2.0.
+
+    Please see :ref:`pickle_session_deprecation`.
+
+    Also, please see: #2709, #3353, #3413
+
+    A serializer that uses the pickle protocol to dump Python data to bytes.
+
+    This was the default serializer used by Pyramid, but has been deprecated.
 
     ``protocol`` may be specified to control the version of pickle used.
     Defaults to :attr:`pickle.HIGHEST_PROTOCOL`.

--- a/src/pyramid/session.py
+++ b/src/pyramid/session.py
@@ -82,6 +82,14 @@ class PickleSerializer(object):
         return pickle.dumps(appstruct, self.protocol)
 
 
+deprecated(
+    'PickleSerializer',
+    'pyramid.session.PickleSerializer is deprecated as of Pyramid 2.0 for '
+    'security concerns. Use pyramid.session.JSONSerializer or reference the '
+    'narrative documentation for information on building a migration tool.',
+)
+
+
 JSONSerializer = JSONSerializer  # api
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -564,6 +564,10 @@ class Test_manage_changed(unittest.TestCase):
 
 
 class TestPickleSerializer(unittest.TestCase):
+    """
+    .. deprecated:: 2.0
+    """
+
     def _makeOne(self):
         from pyramid.session import PickleSerializer
 


### PR DESCRIPTION
fixes #3511 

I updated the narrative docs to reflect this change:

* the fallback example recipe now reimplements the PickleSerializer logic, instead of importing the now-deprecated class.
* the fallback example uses the `appstruct`/`bstruct` terminology and docstrings of the now-deprecated PickleSerializer
