### PR TITLE
black 19.10b0 formatting

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -344,3 +344,5 @@ Contributors
 - Theron Luhn, 2019/03/30
 
 - Mandar Vaze, 2019/07/20
+
+- Jonathan Vanasco, 2019/11/05

--- a/src/pyramid/threadlocal.py
+++ b/src/pyramid/threadlocal.py
@@ -55,7 +55,7 @@ def get_current_request():
 
 
 def get_current_registry(
-    context=None
+    context=None,
 ):  # context required by getSiteManager API
     """
     Return the currently active :term:`application registry` or the

--- a/src/pyramid/traversal.py
+++ b/src/pyramid/traversal.py
@@ -708,8 +708,8 @@ class ResourceTreeTraverser(object):
 
 
 ModelGraphTraverser = (
-    ResourceTreeTraverser
-)  # b/w compat, not API, used in wild
+    ResourceTreeTraverser  # b/w compat, not API, used in wild
+)
 
 
 @implementer(IResourceURL)
@@ -744,8 +744,8 @@ class ResourceURL(object):
         self.physical_path = physical_path  # IResourceURL attr
         self.virtual_path_tuple = virtual_path_tuple  # IResourceURL attr (1.5)
         self.physical_path_tuple = (
-            physical_path_tuple
-        )  # IResourceURL attr (1.5)
+            physical_path_tuple  # IResourceURL attr (1.5)
+        )
 
 
 @lru_cache(1000)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -398,7 +398,7 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals_repoze_who_userid_is_unclean_Authenticated(
-        self
+        self,
     ):
         from pyramid.security import Everyone
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -434,7 +434,7 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(request.root, context)
 
     def test_call_view_registered_nonspecific_nondefault_path_and_subpath(
-        self
+        self,
     ):
         from pyramid.interfaces import IViewClassifier
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -55,7 +55,7 @@ class TestDummyResource(unittest.TestCase):
         return klass(name, parent, **kw)
 
     def test__setitem__and__getitem__and__delitem__and__contains__and_get(
-        self
+        self,
     ):
         class Dummy:
             pass

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -1270,8 +1270,8 @@ class DummyContext(object):
 class DummyRequest:
 
     application_url = (
-        'http://example.com:5432'
-    )  # app_url never ends with slash
+        'http://example.com:5432'  # app_url never ends with slash
+    )
     matchdict = None
     matched_route = None
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -940,7 +940,7 @@ class TestURLMethodsMixin(unittest.TestCase):
         self.assertEqual(result, 'http://example.com:8080')
 
     def test_partial_application_url_with_http_host_nondefault_port_https(
-        self
+        self,
     ):
         environ = {'wsgi.url_scheme': 'https', 'HTTP_HOST': 'example.com:4443'}
         request = self._makeOne(environ)


### PR DESCRIPTION
black 19.10b0 was released on 2019.10.28 and introduced several changes that affect Pyramid

this is just running the new `black` on master.  I could not find a reference in the Pyramid repo to specifying a version of black.

#3524