### PR TITLE
replace ZopeTransactionExtension with zope.sqlalchemy.register

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -348,3 +348,5 @@ Contributors
 - Jonathan Vanasco, 2019/11/05
 
 - Jan Likar, 2019/11/07
+
+- Andrea Borghi, 2019/11/11

--- a/docs/quick_tutorial/databases/tutorial/models.py
+++ b/docs/quick_tutorial/databases/tutorial/models.py
@@ -13,10 +13,10 @@ from sqlalchemy.orm import (
     sessionmaker,
     )
 
-from zope.sqlalchemy import ZopeTransactionExtension
+from zope.sqlalchemy import register
 
-DBSession = scoped_session(
-    sessionmaker(extension=ZopeTransactionExtension()))
+DBSession = scoped_session(sessionmaker(autoflush=False))
+register(DBSession)
 Base = declarative_base()
 
 

--- a/docs/quick_tutorial/databases/tutorial/models.py
+++ b/docs/quick_tutorial/databases/tutorial/models.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import (
 
 from zope.sqlalchemy import register
 
-DBSession = scoped_session(sessionmaker(autoflush=False))
+DBSession = scoped_session(sessionmaker())
 register(DBSession)
 Base = declarative_base()
 


### PR DESCRIPTION
Zope has removed `ZopeTransactionExtension`

This affects the tutorial, I have fixed the tutorials following [the officially suggested method](https://github.com/zopefoundation/zope.sqlalchemy/pull/38)

NB: this is the second PR I make for this topic, since I did not base my old one on `master` and there seemed to be some conflicts.