### PR TITLE
set the minimum supported version at py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,13 @@ sudo: false
 
 matrix:
     include:
-        - python: 3.4
-          env: TOXENV=py34
-        - python: 3.5
-          env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
         - python: pypy3
           env: TOXENV=pypy3
         - python: 3.6
           env: TOXENV=py36-cover,coverage
-        - python: 3.5
+        - python: 3.6
           env: TOXENV=docs
         - python: 3.6
           env: TOXENV=lint
@@ -22,12 +18,10 @@ matrix:
           env: TOXENV=py37
           dist: xenial
           sudo: true
-        - python: 3.8-dev
+        - python: 3.8
           env: TOXENV=py38
           dist: xenial
           sudo: true
-    allow_failures:
-        - env: TOXENV=py38
 
 install:
   - travis_retry pip install tox

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -34,8 +34,7 @@ In order to add a feature to Pyramid:
 - The feature must be documented in both the API and narrative documentation
   (in `docs/`).
 
-- The feature must work fully on the following CPython versions: 3.4, 3.5, 3.6,
-  and 3.7 on both UNIX and Windows.
+- The feature must work fully on the following CPython versions: 3.6, 3.7, and 3.8 on both UNIX and Windows.
 
 - The feature must work on the latest version of PyPy3.
 
@@ -67,7 +66,7 @@ Running Tests
 
   This command will run tests on the latest version of Python 3 with coverage.
 
-    $ tox -e py3-cover,coverage
+    $ tox -e py36-cover,coverage
 
 - To run individual tests (i.e., during development), you can use `nosetests`
   syntax as follows, where `$VENV` is an environment variable set to the path

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,11 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python37"
-      TOXENV: "py37"
     - PYTHON: "C:\\Python36"
       TOXENV: "py36"
-    - PYTHON: "C:\\Python35"
-      TOXENV: "py35"
-    - PYTHON: "C:\\Python34"
-      TOXENV: "py34"
+    - PYTHON: "C:\\Python37"
+      TOXENV: "py37"
+    - PYTHON: "C:\\Python38"
+      TOXENV: "py38"
 
 cache:
     - '%LOCALAPPDATA%\pip\Cache'

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
-    python_requires='>=3.4',
+    python_requires='>=3.6',
     install_requires=install_requires,
     extras_require={'testing': testing_extras, 'docs': docs_extras},
     tests_require=tests_require,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py34,py35,py36,py37,pypy3,
+    py36,py37,pypy3,
     docs,py36-cover,coverage,
 
 [testenv]


### PR DESCRIPTION
I could use some help finishing this out. Need to track down other places (probably in the docs and tutorials) that python versions are referenced.