### PR TITLE
security policy docs and legacy policy improvements

### DIFF
--- a/docs/designdefense.rst
+++ b/docs/designdefense.rst
@@ -199,11 +199,11 @@ Under its hood however, the implementation of ``authenticated_userid`` is this:
 
     def authenticated_userid(request):
         """ Return the userid of the currently authenticated user or
-        ``None`` if there is no authentication policy in effect or there
+        ``None`` if there is no security policy in effect or there
         is no currently authenticated user. """
 
         registry = request.registry # the ZCA component registry
-        policy = registry.queryUtility(IAuthenticationPolicy)
+        policy = registry.queryUtility(ISecurityPolicy)
         if policy is None:
             return None
         return policy.authenticated_userid(request)
@@ -264,19 +264,19 @@ instead of the rule.  So instead of:
 .. code-block:: python
     :linenos:
 
-    from pyramid.interfaces import IAuthenticationPolicy
+    from pyramid.interfaces import ISecurityPolicy
     from zope.component import getUtility
-    policy = getUtility(IAuthenticationPolicy)
+    policy = getUtility(ISecurityPolicy)
 
 :app:`Pyramid` code will usually do:
 
 .. code-block:: python
     :linenos:
 
-    from pyramid.interfaces import IAuthenticationPolicy
+    from pyramid.interfaces import ISecurityPolicy
     from pyramid.threadlocal import get_current_registry
     registry = get_current_registry()
-    policy = registry.getUtility(IAuthenticationPolicy)
+    policy = registry.getUtility(ISecurityPolicy)
 
 While the latter is more verbose, it also arguably makes it more obvious what's
 going on.  All of the :app:`Pyramid` core code uses this pattern rather than

--- a/docs/narr/advconfig.rst
+++ b/docs/narr/advconfig.rst
@@ -297,22 +297,22 @@ Methods Which Provide Conflict Detection
 
 These are the methods of the configurator which provide conflict detection:
 
-:meth:`~pyramid.config.Configurator.add_view`,
-:meth:`~pyramid.config.Configurator.add_route`,
-:meth:`~pyramid.config.Configurator.add_renderer`,
-:meth:`~pyramid.config.Configurator.add_request_method`,
-:meth:`~pyramid.config.Configurator.set_request_factory`,
-:meth:`~pyramid.config.Configurator.set_session_factory`,
-:meth:`~pyramid.config.Configurator.set_root_factory`,
-:meth:`~pyramid.config.Configurator.set_view_mapper`,
-:meth:`~pyramid.config.Configurator.set_authentication_policy`,
-:meth:`~pyramid.config.Configurator.set_authorization_policy`,
-:meth:`~pyramid.config.Configurator.set_security_policy`,
-:meth:`~pyramid.config.Configurator.set_locale_negotiator`,
-:meth:`~pyramid.config.Configurator.set_default_permission`,
-:meth:`~pyramid.config.Configurator.add_traverser`,
-:meth:`~pyramid.config.Configurator.add_resource_url_adapter`,
-and :meth:`~pyramid.config.Configurator.add_response_adapter`.
+- :meth:`~pyramid.config.Configurator.add_renderer`
+- :meth:`~pyramid.config.Configurator.add_request_method`
+- :meth:`~pyramid.config.Configurator.add_resource_url_adapter`
+- :meth:`~pyramid.config.Configurator.add_response_adapter`
+- :meth:`~pyramid.config.Configurator.add_route`
+- :meth:`~pyramid.config.Configurator.add_traverser`
+- :meth:`~pyramid.config.Configurator.add_view`
+- :meth:`~pyramid.config.Configurator.set_authentication_policy`
+- :meth:`~pyramid.config.Configurator.set_authorization_policy`
+- :meth:`~pyramid.config.Configurator.set_default_permission`
+- :meth:`~pyramid.config.Configurator.set_locale_negotiator`
+- :meth:`~pyramid.config.Configurator.set_request_factory`
+- :meth:`~pyramid.config.Configurator.set_root_factory`
+- :meth:`~pyramid.config.Configurator.set_security_policy`
+- :meth:`~pyramid.config.Configurator.set_session_factory`
+- :meth:`~pyramid.config.Configurator.set_view_mapper`
 
 :meth:`~pyramid.config.Configurator.add_static_view` also indirectly provides
 conflict detection, because it's implemented in terms of the conflict-aware

--- a/docs/narr/advconfig.rst
+++ b/docs/narr/advconfig.rst
@@ -307,6 +307,7 @@ These are the methods of the configurator which provide conflict detection:
 :meth:`~pyramid.config.Configurator.set_view_mapper`,
 :meth:`~pyramid.config.Configurator.set_authentication_policy`,
 :meth:`~pyramid.config.Configurator.set_authorization_policy`,
+:meth:`~pyramid.config.Configurator.set_security_policy`,
 :meth:`~pyramid.config.Configurator.set_locale_negotiator`,
 :meth:`~pyramid.config.Configurator.set_default_permission`,
 :meth:`~pyramid.config.Configurator.add_traverser`,

--- a/docs/narr/extconfig.rst
+++ b/docs/narr/extconfig.rst
@@ -271,6 +271,7 @@ Pre-defined Phases
 
 - :meth:`pyramid.config.Configurator.add_route`
 - :meth:`pyramid.config.Configurator.set_authentication_policy`
+- :meth:`pyramid.config.Configurator.set_security_policy`
 
 :const:`pyramid.config.PHASE3_CONFIG`
 

--- a/docs/narr/introspector.rst
+++ b/docs/narr/introspector.rst
@@ -302,6 +302,16 @@ introspectables in categories not described here.
      The :class:`pyramid.interfaces.IRoute` object that is used to perform
      matching and generation for this route.
 
+``security policy``
+
+  There will be one and only one introspectable in the ``security policy`` category.
+  It represents a call to the :meth:`pyramid.config.Configurator.set_security_policy` method (or its Configurator constructor equivalent).
+  It will have the following data:
+
+  ``policy``
+
+    The policy object (the resolved ``policy`` argument to ``set_security_policy``).
+
 ``authentication policy``
 
   There will be one and only one introspectable in the ``authentication

--- a/docs/narr/testing.rst
+++ b/docs/narr/testing.rst
@@ -278,7 +278,7 @@ In the above example, we create a ``MyTest`` test case that inherits from
 be found when ``pytest`` is run.  It has two test methods.
 
 The first test method, ``test_view_fn_forbidden`` tests the ``view_fn`` when
-the authentication policy forbids the current user the ``edit`` permission. Its
+the security policy forbids the current user the ``edit`` permission. Its
 third line registers a "dummy" "non-permissive" authorization policy using the
 :meth:`~pyramid.config.Configurator.testing_securitypolicy` method, which is a
 special helper method for unit testing.
@@ -288,13 +288,13 @@ WebOb request object API.  A :class:`pyramid.testing.DummyRequest` is a request
 object that requires less setup than a "real" :app:`Pyramid` request.  We call
 the function being tested with the manufactured request.  When the function is
 called, :meth:`pyramid.request.Request.has_permission` will call the "dummy"
-authentication policy we've registered through
+security policy we've registered through
 :meth:`~pyramid.config.Configurator.testing_securitypolicy`, which denies
 access.  We check that the view function raises a
 :exc:`~pyramid.httpexceptions.HTTPForbidden` error.
 
 The second test method, named ``test_view_fn_allowed``, tests the alternate
-case, where the authentication policy allows access.  Notice that we pass
+case, where the security policy allows access.  Notice that we pass
 different values to :meth:`~pyramid.config.Configurator.testing_securitypolicy`
 to obtain this result.  We assert at the end of this that the view function
 returns a value.

--- a/docs/narr/threadlocals.rst
+++ b/docs/narr/threadlocals.rst
@@ -32,11 +32,11 @@ various :app:`Pyramid` API functions.  For example, the implementation of the
 :mod:`pyramid.security` function named
 :func:`~pyramid.security.authenticated_userid` (deprecated as of 1.5) retrieves
 the thread local :term:`application registry` as a matter of course to find an
-:term:`authentication policy`.  It uses the
+:term:`security policy`.  It uses the
 :func:`pyramid.threadlocal.get_current_registry` function to retrieve the
-application registry, from which it looks up the authentication policy; it then
-uses the authentication policy to retrieve the authenticated user id.  This is
-how :app:`Pyramid` allows arbitrary authentication policies to be "plugged in".
+application registry, from which it looks up the security policy; it then
+uses the security policy to retrieve the authenticated user id.  This is
+how :app:`Pyramid` allows arbitrary security policies to be "plugged in".
 
 When they need to do so, :app:`Pyramid` internals use two API functions to
 retrieve the :term:`request` and :term:`application registry`:

--- a/src/pyramid/config/routes.py
+++ b/src/pyramid/config/routes.py
@@ -335,9 +335,10 @@ class RoutesConfiguratorMixin(object):
         if 'effective_principals' in predicates:
             warnings.warn(
                 (
-                    'The new security policy has removed the concept of '
-                    'principals. See "Upgrading Authentication/Authorization" '
-                    'in "What\'s New in Pyramid 2.0" for more information.'
+                    'The new security policy has deprecated '
+                    'effective_principals. See "Upgrading '
+                    'Authentication/Authorization" in "What\'s New in '
+                    'Pyramid 2.0" for more information.'
                 ),
                 DeprecationWarning,
                 stacklevel=3,

--- a/src/pyramid/config/routes.py
+++ b/src/pyramid/config/routes.py
@@ -338,7 +338,7 @@ class RoutesConfiguratorMixin(object):
                     'The new security policy has deprecated '
                     'effective_principals. See "Upgrading '
                     'Authentication/Authorization" in "What\'s New in '
-                    'Pyramid 2.0" for more information.'
+                    'Pyramid 2.0" of the documentation for more information.'
                 ),
                 DeprecationWarning,
                 stacklevel=3,

--- a/src/pyramid/config/security.py
+++ b/src/pyramid/config/security.py
@@ -81,7 +81,7 @@ class SecurityConfiguratorMixin(object):
             'Authentication and authorization policies have been deprecated '
             'in favor of security policies.  See "Upgrading '
             'Authentication/Authorization" in "What\'s New in Pyramid 2.0" '
-            'for more information.',
+            'of the documentation for more information.',
             DeprecationWarning,
             stacklevel=3,
         )
@@ -142,7 +142,7 @@ class SecurityConfiguratorMixin(object):
             'Authentication and authorization policies have been deprecated '
             'in favor of security policies.  See "Upgrading '
             'Authentication/Authorization" in "What\'s New in Pyramid 2.0" '
-            'for more information.',
+            'of the documentation for more information.',
             DeprecationWarning,
             stacklevel=3,
         )

--- a/src/pyramid/config/security.py
+++ b/src/pyramid/config/security.py
@@ -1,5 +1,5 @@
+import warnings
 from zope.interface import implementer
-from zope.deprecation import deprecate
 
 from pyramid.interfaces import (
     IAuthorizationPolicy,
@@ -57,13 +57,6 @@ class SecurityConfiguratorMixin(object):
             introspectables=(intr,),
         )
 
-    @deprecate(
-        'Authentication and authorization policies have been deprecated in '
-        'favor of security policies.  See '
-        'https://docs.pylonsproject.org/projects/pyramid/en/latest'
-        '/whatsnew-2.0.html#upgrading-authentication-authorization '
-        'for more information.'
-    )
     @action_method
     def set_authentication_policy(self, policy):
         """
@@ -84,6 +77,14 @@ class SecurityConfiguratorMixin(object):
            achieve the same purpose.
 
         """
+        warnings.warn(
+            'Authentication and authorization policies have been deprecated '
+            'in favor of security policies.  See "Upgrading '
+            'Authentication/Authorization" in "What\'s New in Pyramid 2.0" '
+            'for more information.',
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
         def register():
             self.registry.registerUtility(policy, IAuthenticationPolicy)
@@ -137,6 +138,14 @@ class SecurityConfiguratorMixin(object):
            achieve the same purpose.
 
         """
+        warnings.warn(
+            'Authentication and authorization policies have been deprecated '
+            'in favor of security policies.  See "Upgrading '
+            'Authentication/Authorization" in "What\'s New in Pyramid 2.0" '
+            'for more information.',
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
         def register():
             self.registry.registerUtility(policy, IAuthorizationPolicy)

--- a/src/pyramid/config/views.py
+++ b/src/pyramid/config/views.py
@@ -797,7 +797,7 @@ class ViewsConfiguratorMixin(object):
                     'The new security policy has deprecated '
                     'effective_principals. See "Upgrading '
                     'Authentication/Authorization" in "What\'s New in '
-                    'Pyramid 2.0" for more information.'
+                    'Pyramid 2.0" of the documentation for more information.'
                 ),
                 DeprecationWarning,
                 stacklevel=4,

--- a/src/pyramid/config/views.py
+++ b/src/pyramid/config/views.py
@@ -794,9 +794,10 @@ class ViewsConfiguratorMixin(object):
         if 'effective_principals' in view_options:
             warnings.warn(
                 (
-                    'The new security policy has removed the concept of '
-                    'principals. See "Upgrading Authentication/Authorization" '
-                    'in "What\'s New in Pyramid 2.0" for more information.'
+                    'The new security policy has deprecated '
+                    'effective_principals. See "Upgrading '
+                    'Authentication/Authorization" in "What\'s New in '
+                    'Pyramid 2.0" for more information.'
                 ),
                 DeprecationWarning,
                 stacklevel=4,

--- a/src/pyramid/security.py
+++ b/src/pyramid/security.py
@@ -138,7 +138,7 @@ deprecated(
     'principals_allowed_by_permission',
     'The new security policy has removed the concept of principals.  See '
     '"Upgrading Authentication/Authorization" in "What\'s New in Pyramid 2.0" '
-    'for more information.',
+    'of the documentation for more information.',
 )
 
 
@@ -384,7 +384,7 @@ class AuthenticationAPIMixin(object):
         (
             'The new security policy has deprecated unauthenticated_userid. '
             'See "Upgrading Authentication/Authorization" in "What\'s New in '
-            'Pyramid 2.0" for more information.'
+            'Pyramid 2.0" of the documentation for more information.'
         ),
     )
 
@@ -413,7 +413,7 @@ class AuthenticationAPIMixin(object):
         (
             'The new security policy has deprecated effective_principals. '
             'See "Upgrading Authentication/Authorization" in "What\'s New in '
-            'Pyramid 2.0" for more information.'
+            'Pyramid 2.0" of the documentation for more information.'
         ),
     )
 

--- a/src/pyramid/view.py
+++ b/src/pyramid/view.py
@@ -102,7 +102,7 @@ def render_view_to_iterable(context, request, name='', secure=True):
     If ``secure`` is ``True``, and the view is protected by a permission, the
     permission will be checked before the view function is invoked.  If the
     permission check disallows view execution (based on the current
-    :term:`authentication policy`), a
+    :term:`security policy`), a
     :exc:`pyramid.httpexceptions.HTTPForbidden` exception will be raised; its
     ``args`` attribute explains why the view access was disallowed.
 

--- a/tests/test_config/test_routes.py
+++ b/tests/test_config/test_routes.py
@@ -316,7 +316,7 @@ class RoutesConfiguratorMixinTests(unittest.TestCase):
             warnings.simplefilter('always', DeprecationWarning)
             config.add_route('foo', '/bar', effective_principals=['any'])
             self.assertIn(
-                'removed the concept of principals', str(w[-1].message)
+                'deprecated effective_principals', str(w[-1].message)
             )
 
 

--- a/tests/test_config/test_views.py
+++ b/tests/test_config/test_views.py
@@ -2933,7 +2933,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             warnings.simplefilter('always', DeprecationWarning)
             config.add_view(lambda: None, effective_principals=['any'])
             self.assertIn(
-                'removed the concept of principals', str(w[-1].message)
+                'deprecated effective_principals', str(w[-1].message)
             )
 
 

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -454,8 +454,9 @@ class Test_EffectivePrincipalsPredicate(unittest.TestCase):
         return EffectivePrincipalsPredicate(val, config)
 
     def _testing_authn_policy(self, userid, groupids=tuple()):
-        from pyramid.interfaces import IAuthenticationPolicy
+        from pyramid.interfaces import IAuthenticationPolicy, ISecurityPolicy
         from pyramid.security import Everyone, Authenticated
+        from pyramid.security import LegacySecurityPolicy
 
         class DummyPolicy:
             def effective_principals(self, request):
@@ -468,6 +469,7 @@ class Test_EffectivePrincipalsPredicate(unittest.TestCase):
 
         registry = self.config.registry
         registry.registerUtility(DummyPolicy(), IAuthenticationPolicy)
+        registry.registerUtility(LegacySecurityPolicy(), ISecurityPolicy)
 
     def test_text(self):
         inst = self._makeOne(('verna', 'fred'), None)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1699,10 +1699,6 @@ class DummyResponse(object):
         return self.app_iter
 
 
-class DummyAuthenticationPolicy:
-    pass
-
-
 class DummyLogger:
     def __init__(self):
         self.messages = []


### PR DESCRIPTION
- Added `set_security_policy`` to more places in the docs.
- Ensure that the authn/authz policies are not used at all if the legacy
  policy is not in effect to avoid edge cases where the code would skip
  the security policy and use the authn/authz policy on accident.
- Change deprecation warnings in code to reference the docs by name
  instead of by URL.

The only code/behavior changes are in `request.effective_principals` and `request.unauthenticated_userid`.

I am working on the tutorials in a followup PR.

cc @luhn @merwok 