### PR TITLE
isort

### DIFF
--- a/HACKING.txt
+++ b/HACKING.txt
@@ -48,7 +48,7 @@ In order to add a feature to Pyramid:
 Coding Style
 ------------
 
-- Pyramid uses Black (https://pypi.org/project/black/) and isort (https://pypi.org/project/black/) for code formatting style.
+- Pyramid uses Black (https://pypi.org/project/black/) and isort (https://pypi.org/project/isort/) for code formatting style.
   To run formatters:
 
     $ tox -e format

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -48,11 +48,10 @@ In order to add a feature to Pyramid:
 Coding Style
 ------------
 
-- Pyramid uses Black for code formatting style.
-  https://pypi.org/project/black/
-  To run Black:
+- Pyramid uses Black (https://pypi.org/project/black/) and isort (https://pypi.org/project/black/) for code formatting style.
+  To run formatters:
 
-    $ tox -e black
+    $ tox -e format
 
 
 Running Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ exclude = '''
 [tool.isort]
 multi_line_output = 3
 include_trailing_comma = true
-force_grid_wrap = 0
+force_grid_wrap = false
 combine_as_imports = true
+use_parenthesis = true
 line_length = 79
+force_sort_within_sections = true
+no_lines_before = "THIRDPARTY"
+sections = "FUTURE,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
+default_section = "THIRDPARTY"
+known_first_party = "pyramid"

--- a/src/pyramid/asset.py
+++ b/src/pyramid/asset.py
@@ -1,7 +1,7 @@
 import os
 import pkg_resources
 
-from pyramid.path import package_path, package_name
+from pyramid.path import package_name, package_path
 
 
 def resolve_asset_spec(spec, pname='__main__'):

--- a/src/pyramid/authentication.py
+++ b/src/pyramid/authentication.py
@@ -1,24 +1,24 @@
+import base64
 import binascii
-from codecs import utf_8_decode
-from codecs import utf_8_encode
+from codecs import utf_8_decode, utf_8_encode
 from collections import namedtuple
 import hashlib
-import base64
 import re
 import time as time_mod
 from urllib.parse import quote, unquote
 import warnings
-
+from webob.cookies import CookieProfile
 from zope.interface import implementer
 
-from webob.cookies import CookieProfile
-
 from pyramid.interfaces import IAuthenticationPolicy, IDebugLogger
-
 from pyramid.security import Authenticated, Everyone
-
-from pyramid.util import strings_differ, bytes_, ascii_, text_
-from pyramid.util import SimpleSerializer
+from pyramid.util import (
+    SimpleSerializer,
+    ascii_,
+    bytes_,
+    strings_differ,
+    text_,
+)
 
 VALID_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9+_-]*$")
 

--- a/src/pyramid/authorization.py
+++ b/src/pyramid/authorization.py
@@ -1,11 +1,8 @@
 from zope.interface import implementer
 
 from pyramid.interfaces import IAuthorizationPolicy
-
 from pyramid.location import lineage
-
 from pyramid.security import ACLAllowed, ACLDenied, Allow, Deny, Everyone
-
 from pyramid.util import is_nonstr_iter
 
 

--- a/src/pyramid/config/__init__.py
+++ b/src/pyramid/config/__init__.py
@@ -3,49 +3,20 @@ import logging
 import os
 import threading
 import venusian
-
 from webob.exc import WSGIHTTPException as WebobWSGIHTTPException
 
-from pyramid.interfaces import (
-    IDebugLogger,
-    IExceptionResponse,
-    PHASE0_CONFIG,
-    PHASE1_CONFIG,
-    PHASE2_CONFIG,
-    PHASE3_CONFIG,
-)
-
 from pyramid.asset import resolve_asset_spec
-
 from pyramid.authorization import ACLAuthorizationPolicy
-
-from pyramid.events import ApplicationCreated
-
-from pyramid.exceptions import ConfigurationError
-
-from pyramid.httpexceptions import default_exceptionresponse_view
-
-from pyramid.path import caller_package, package_of
-
-from pyramid.registry import Introspectable, Introspector, Registry
-
-from pyramid.router import Router
-
-from pyramid.settings import aslist
-
-from pyramid.threadlocal import manager
-
-from pyramid.util import WeakOrderedSet, get_callable_name, object_description
-
-from pyramid.config.actions import action_method, ActionState
-from pyramid.config.predicates import not_
-
-from pyramid.config.actions import ActionConfiguratorMixin
+from pyramid.config.actions import (
+    ActionConfiguratorMixin,
+    ActionState,
+    action_method,
+)
 from pyramid.config.adapters import AdaptersConfiguratorMixin
 from pyramid.config.assets import AssetsConfiguratorMixin
 from pyramid.config.factories import FactoriesConfiguratorMixin
 from pyramid.config.i18n import I18NConfiguratorMixin
-from pyramid.config.predicates import PredicateConfiguratorMixin
+from pyramid.config.predicates import PredicateConfiguratorMixin, not_
 from pyramid.config.rendering import RenderingConfiguratorMixin
 from pyramid.config.routes import RoutesConfiguratorMixin
 from pyramid.config.security import SecurityConfiguratorMixin
@@ -54,8 +25,23 @@ from pyramid.config.testing import TestingConfiguratorMixin
 from pyramid.config.tweens import TweensConfiguratorMixin
 from pyramid.config.views import ViewsConfiguratorMixin
 from pyramid.config.zca import ZCAConfiguratorMixin
-
-from pyramid.path import DottedNameResolver
+from pyramid.events import ApplicationCreated
+from pyramid.exceptions import ConfigurationError
+from pyramid.httpexceptions import default_exceptionresponse_view
+from pyramid.interfaces import (
+    PHASE0_CONFIG,
+    PHASE1_CONFIG,
+    PHASE2_CONFIG,
+    PHASE3_CONFIG,
+    IDebugLogger,
+    IExceptionResponse,
+)
+from pyramid.path import DottedNameResolver, caller_package, package_of
+from pyramid.registry import Introspectable, Introspector, Registry
+from pyramid.router import Router
+from pyramid.settings import aslist
+from pyramid.threadlocal import manager
+from pyramid.util import WeakOrderedSet, get_callable_name, object_description
 
 _marker = object()
 

--- a/src/pyramid/config/actions.py
+++ b/src/pyramid/config/actions.py
@@ -12,8 +12,7 @@ from pyramid.exceptions import (
 )
 from pyramid.interfaces import IActionInfo
 from pyramid.registry import undefer
-from pyramid.util import is_nonstr_iter
-from pyramid.util import reraise
+from pyramid.util import is_nonstr_iter, reraise
 
 
 class ActionConfiguratorMixin(object):

--- a/src/pyramid/config/adapters.py
+++ b/src/pyramid/config/adapters.py
@@ -1,14 +1,10 @@
-from webob import Response as WebobResponse
-
 from functools import update_wrapper
-
+from webob import Response as WebobResponse
 from zope.interface import Interface
 
-from pyramid.interfaces import IResponse, ITraverser, IResourceURL
-
-from pyramid.util import takes_one_arg
-
 from pyramid.config.actions import action_method
+from pyramid.interfaces import IResourceURL, IResponse, ITraverser
+from pyramid.util import takes_one_arg
 
 
 class AdaptersConfiguratorMixin(object):

--- a/src/pyramid/config/assets.py
+++ b/src/pyramid/config/assets.py
@@ -1,15 +1,12 @@
 import os
 import pkg_resources
 import sys
-
 from zope.interface import implementer
 
-from pyramid.interfaces import IPackageOverrides, PHASE1_CONFIG
-
-from pyramid.exceptions import ConfigurationError
-from pyramid.threadlocal import get_current_registry
-
 from pyramid.config.actions import action_method
+from pyramid.exceptions import ConfigurationError
+from pyramid.interfaces import PHASE1_CONFIG, IPackageOverrides
+from pyramid.threadlocal import get_current_registry
 
 
 class OverrideProvider(pkg_resources.DefaultProvider):

--- a/src/pyramid/config/factories.py
+++ b/src/pyramid/config/factories.py
@@ -1,21 +1,18 @@
 from zope.interface import implementer
 
+from pyramid.config.actions import action_method
 from pyramid.interfaces import (
     IDefaultRootFactory,
     IExecutionPolicy,
+    IRequestExtensions,
     IRequestFactory,
     IResponseFactory,
-    IRequestExtensions,
     IRootFactory,
     ISessionFactory,
 )
-
 from pyramid.router import default_execution_policy
 from pyramid.traversal import DefaultRootFactory
-
-from pyramid.util import get_callable_name, InstancePropertyHelper
-
-from pyramid.config.actions import action_method
+from pyramid.util import InstancePropertyHelper, get_callable_name
 
 
 class FactoriesConfiguratorMixin(object):

--- a/src/pyramid/config/i18n.py
+++ b/src/pyramid/config/i18n.py
@@ -1,9 +1,7 @@
-from pyramid.interfaces import ILocaleNegotiator, ITranslationDirectories
-
-from pyramid.exceptions import ConfigurationError
-from pyramid.path import AssetResolver
-
 from pyramid.config.actions import action_method
+from pyramid.exceptions import ConfigurationError
+from pyramid.interfaces import ILocaleNegotiator, ITranslationDirectories
+from pyramid.path import AssetResolver
 
 
 class I18NConfiguratorMixin(object):

--- a/src/pyramid/config/predicates.py
+++ b/src/pyramid/config/predicates.py
@@ -2,12 +2,10 @@ from hashlib import md5
 from webob.acceptparse import Accept
 
 from pyramid.exceptions import ConfigurationError
-from pyramid.interfaces import IPredicateList, PHASE1_CONFIG
+from pyramid.interfaces import PHASE1_CONFIG, IPredicateList
 from pyramid.predicates import Notted
 from pyramid.registry import predvalseq
-from pyramid.util import TopologicalSorter
-from pyramid.util import is_nonstr_iter, bytes_
-
+from pyramid.util import TopologicalSorter, bytes_, is_nonstr_iter
 
 MAX_ORDER = 1 << 30
 DEFAULT_PHASH = md5().hexdigest()

--- a/src/pyramid/config/rendering.py
+++ b/src/pyramid/config/rendering.py
@@ -1,7 +1,6 @@
-from pyramid.interfaces import IRendererFactory, PHASE1_CONFIG
-
 from pyramid import renderers
 from pyramid.config.actions import action_method
+from pyramid.interfaces import PHASE1_CONFIG, IRendererFactory
 
 DEFAULT_RENDERERS = (
     ('json', renderers.json_renderer_factory),

--- a/src/pyramid/config/routes.py
+++ b/src/pyramid/config/routes.py
@@ -2,22 +2,19 @@ import contextlib
 from urllib.parse import urlparse
 import warnings
 
+from pyramid.config.actions import action_method
+from pyramid.config.predicates import normalize_accept_offer, predvalseq
+from pyramid.exceptions import ConfigurationError
 from pyramid.interfaces import (
+    PHASE2_CONFIG,
     IRequest,
     IRouteRequest,
     IRoutesMapper,
-    PHASE2_CONFIG,
 )
-
-from pyramid.exceptions import ConfigurationError
 import pyramid.predicates
 from pyramid.request import route_request_iface
 from pyramid.urldispatch import RoutesMapper
-
 from pyramid.util import as_sorted_tuple, is_nonstr_iter
-
-from pyramid.config.actions import action_method
-from pyramid.config.predicates import normalize_accept_offer, predvalseq
 
 
 class RoutesConfiguratorMixin(object):

--- a/src/pyramid/config/security.py
+++ b/src/pyramid/config/security.py
@@ -1,23 +1,21 @@
 import warnings
 from zope.interface import implementer
 
+from pyramid.config.actions import action_method
+from pyramid.csrf import LegacySessionCSRFStoragePolicy
+from pyramid.exceptions import ConfigurationError
 from pyramid.interfaces import (
-    IAuthorizationPolicy,
+    PHASE1_CONFIG,
+    PHASE2_CONFIG,
     IAuthenticationPolicy,
+    IAuthorizationPolicy,
     ICSRFStoragePolicy,
     IDefaultCSRFOptions,
     IDefaultPermission,
     ISecurityPolicy,
-    PHASE1_CONFIG,
-    PHASE2_CONFIG,
 )
-
-from pyramid.csrf import LegacySessionCSRFStoragePolicy
-from pyramid.exceptions import ConfigurationError
-from pyramid.util import as_sorted_tuple
 from pyramid.security import LegacySecurityPolicy
-
-from pyramid.config.actions import action_method
+from pyramid.util import as_sorted_tuple
 
 
 class SecurityConfiguratorMixin(object):

--- a/src/pyramid/config/testing.py
+++ b/src/pyramid/config/testing.py
@@ -1,12 +1,9 @@
 from zope.interface import Interface
 
-from pyramid.interfaces import ITraverser, ISecurityPolicy, IRendererFactory
-
-from pyramid.renderers import RendererHelper
-
-from pyramid.traversal import split_path_info
-
 from pyramid.config.actions import action_method
+from pyramid.interfaces import IRendererFactory, ISecurityPolicy, ITraverser
+from pyramid.renderers import RendererHelper
+from pyramid.traversal import split_path_info
 
 
 class TestingConfiguratorMixin(object):

--- a/src/pyramid/config/tweens.py
+++ b/src/pyramid/config/tweens.py
@@ -1,18 +1,14 @@
 from zope.interface import implementer
 
-from pyramid.interfaces import ITweens
-
+from pyramid.config.actions import action_method
 from pyramid.exceptions import ConfigurationError
-
-from pyramid.tweens import MAIN, INGRESS, EXCVIEW
-
+from pyramid.interfaces import ITweens
+from pyramid.tweens import EXCVIEW, INGRESS, MAIN
 from pyramid.util import (
+    TopologicalSorter,
     is_nonstr_iter,
     is_string_or_iterable,
-    TopologicalSorter,
 )
-
-from pyramid.config.actions import action_method
 
 
 class TweensConfiguratorMixin(object):

--- a/src/pyramid/config/views.py
+++ b/src/pyramid/config/views.py
@@ -1,19 +1,36 @@
 import functools
 import inspect
-import posixpath
 import operator
 import os
-import warnings
-
+import posixpath
 from urllib.parse import quote, urljoin, urlparse, urlunparse
+import warnings
 from webob.acceptparse import Accept
 from zope.interface import Interface, implementedBy, implementer
 from zope.interface.interfaces import IInterface
 
+from pyramid import renderers
+from pyramid.asset import resolve_asset_spec
+from pyramid.config.actions import action_method
+from pyramid.config.predicates import (
+    DEFAULT_PHASH,
+    MAX_ORDER,
+    normalize_accept_offer,
+    predvalseq,
+    sort_accept_offers,
+)
+from pyramid.decorator import reify
+from pyramid.exceptions import ConfigurationError, PredicateMismatch
+from pyramid.httpexceptions import (
+    HTTPForbidden,
+    HTTPNotFound,
+    default_exceptionresponse_view,
+)
 from pyramid.interfaces import (
+    PHASE1_CONFIG,
     IAcceptOrder,
-    IExceptionViewClassifier,
     IException,
+    IExceptionViewClassifier,
     IMultiView,
     IPackageOverrides,
     IRendererFactory,
@@ -24,62 +41,31 @@ from pyramid.interfaces import (
     IStaticURLInfo,
     IView,
     IViewClassifier,
-    IViewDerivers,
     IViewDeriverInfo,
+    IViewDerivers,
     IViewMapperFactory,
-    PHASE1_CONFIG,
 )
-
-from pyramid import renderers
-
-from pyramid.asset import resolve_asset_spec
-
-from pyramid.decorator import reify
-
-from pyramid.exceptions import ConfigurationError, PredicateMismatch
-
-from pyramid.httpexceptions import (
-    HTTPForbidden,
-    HTTPNotFound,
-    default_exceptionresponse_view,
-)
-
+import pyramid.predicates
 from pyramid.registry import Deferred
-
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.static import static_view
-
 from pyramid.url import parse_url_overrides
-
-from pyramid.view import AppendSlashNotFoundViewFactory
-
 from pyramid.util import (
+    WIN,
+    TopologicalSorter,
     as_sorted_tuple,
     is_nonstr_iter,
-    TopologicalSorter,
-    WIN,
 )
-
-import pyramid.predicates
+from pyramid.view import AppendSlashNotFoundViewFactory
 import pyramid.viewderivers
-
 from pyramid.viewderivers import (
     INGRESS,
     VIEW,
-    preserve_view_attrs,
-    view_description,
-    requestonly,
     DefaultViewMapper,
+    preserve_view_attrs,
+    requestonly,
+    view_description,
     wraps_view,
-)
-
-from pyramid.config.actions import action_method
-from pyramid.config.predicates import (
-    DEFAULT_PHASH,
-    MAX_ORDER,
-    normalize_accept_offer,
-    predvalseq,
-    sort_accept_offers,
 )
 
 DefaultViewMapper = DefaultViewMapper  # bw-compat

--- a/src/pyramid/csrf.py
+++ b/src/pyramid/csrf.py
@@ -1,18 +1,16 @@
 from urllib.parse import urlparse
 import uuid
-
 from webob.cookies import CookieProfile
 from zope.interface import implementer
-
 
 from pyramid.exceptions import BadCSRFOrigin, BadCSRFToken
 from pyramid.interfaces import ICSRFStoragePolicy
 from pyramid.settings import aslist
 from pyramid.util import (
     SimpleSerializer,
+    bytes_,
     is_same_domain,
     strings_differ,
-    bytes_,
     text_,
 )
 

--- a/src/pyramid/encode.py
+++ b/src/pyramid/encode.py
@@ -1,5 +1,4 @@
-from urllib.parse import quote as _url_quote
-from urllib.parse import quote_plus as _quote_plus
+from urllib.parse import quote as _url_quote, quote_plus as _quote_plus
 
 from pyramid.util import is_nonstr_iter
 

--- a/src/pyramid/events.py
+++ b/src/pyramid/events.py
@@ -1,14 +1,13 @@
 import venusian
-
-from zope.interface import implementer, Interface
+from zope.interface import Interface, implementer
 
 from pyramid.interfaces import (
-    IContextFound,
-    INewRequest,
-    INewResponse,
     IApplicationCreated,
     IBeforeRender,
     IBeforeTraversal,
+    IContextFound,
+    INewRequest,
+    INewResponse,
 )
 
 

--- a/src/pyramid/exceptions.py
+++ b/src/pyramid/exceptions.py
@@ -1,4 +1,4 @@
-from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound, HTTPForbidden
+from pyramid.httpexceptions import HTTPBadRequest, HTTPForbidden, HTTPNotFound
 
 NotFound = HTTPNotFound  # bw compat
 Forbidden = HTTPForbidden  # bw compat

--- a/src/pyramid/httpexceptions.py
+++ b/src/pyramid/httpexceptions.py
@@ -129,13 +129,10 @@ subclasses have one additional keyword argument: ``location``,
 which indicates the location to which to redirect.
 """
 import json
-
 from string import Template
-
-from zope.interface import implementer
-
 from webob import html_escape as _html_escape
 from webob.acceptparse import create_accept_header
+from zope.interface import implementer
 
 from pyramid.interfaces import IExceptionResponse
 from pyramid.response import Response

--- a/src/pyramid/i18n.py
+++ b/src/pyramid/i18n.py
@@ -1,21 +1,15 @@
 import gettext
 import os
-
-from translationstring import (
-    Translator,
-    Pluralizer,
-    TranslationString,  # API
-    TranslationStringFactory,  # API
-)
+from translationstring import Pluralizer, Translator
+from translationstring import TranslationString  # API
+from translationstring import TranslationStringFactory  # API
 
 from pyramid.decorator import reify
-
 from pyramid.interfaces import (
+    ILocaleNegotiator,
     ILocalizer,
     ITranslationDirectories,
-    ILocaleNegotiator,
 )
-
 from pyramid.threadlocal import get_current_registry
 
 TranslationString = TranslationString  # PyFlakes

--- a/src/pyramid/path.py
+++ b/src/pyramid/path.py
@@ -2,7 +2,6 @@ from importlib.machinery import SOURCE_SUFFIXES
 import os
 import pkg_resources
 import sys
-
 from zope.interface import implementer
 
 from pyramid.interfaces import IAssetDescriptor

--- a/src/pyramid/predicates.py
+++ b/src/pyramid/predicates.py
@@ -1,13 +1,11 @@
 import re
 
 from pyramid.exceptions import ConfigurationError
-
 from pyramid.traversal import (
     find_interface,
-    traversal_path,
     resource_path_tuple,
+    traversal_path,
 )
-
 from pyramid.urldispatch import _compile_route
 from pyramid.util import as_sorted_tuple, is_nonstr_iter, object_description
 

--- a/src/pyramid/registry.py
+++ b/src/pyramid/registry.py
@@ -1,13 +1,10 @@
 import operator
 import threading
-
 from zope.interface import implementer
 from zope.interface.registry import Components
 
 from pyramid.decorator import reify
-
-from pyramid.interfaces import IIntrospector, IIntrospectable, ISettings
-
+from pyramid.interfaces import IIntrospectable, IIntrospector, ISettings
 from pyramid.path import CALLER_PACKAGE, caller_package
 
 

--- a/src/pyramid/renderers.py
+++ b/src/pyramid/renderers.py
@@ -2,21 +2,15 @@ from functools import partial
 import json
 import os
 import re
-
 from zope.interface import implementer, providedBy
 from zope.interface.registry import Components
 
-from pyramid.interfaces import IJSONAdapter, IRendererFactory, IRendererInfo
-
 from pyramid.csrf import get_csrf_token
 from pyramid.decorator import reify
-
 from pyramid.events import BeforeRender
-
 from pyramid.httpexceptions import HTTPBadRequest
-
+from pyramid.interfaces import IJSONAdapter, IRendererFactory, IRendererInfo
 from pyramid.path import caller_package
-
 from pyramid.response import _get_response_factory
 from pyramid.threadlocal import get_current_registry
 from pyramid.util import hide_attrs

--- a/src/pyramid/request.py
+++ b/src/pyramid/request.py
@@ -1,27 +1,24 @@
 from collections import deque
-
+from webob import BaseRequest
 from zope.interface import implementer
 from zope.interface.interface import InterfaceClass
 
-from webob import BaseRequest
-
+from pyramid.decorator import reify
+from pyramid.i18n import LocalizerRequestMixin
 from pyramid.interfaces import (
     IRequest,
     IRequestExtensions,
     IResponse,
     ISessionFactory,
 )
-
-from pyramid.decorator import reify
-from pyramid.i18n import LocalizerRequestMixin
 from pyramid.response import Response, _get_response_factory
-from pyramid.security import SecurityAPIMixin, AuthenticationAPIMixin
+from pyramid.security import AuthenticationAPIMixin, SecurityAPIMixin
 from pyramid.url import URLMethodsMixin
 from pyramid.util import (
     InstancePropertyHelper,
     InstancePropertyMixin,
-    text_,
     bytes_,
+    text_,
 )
 from pyramid.view import ViewMethodsMixin
 

--- a/src/pyramid/response.py
+++ b/src/pyramid/response.py
@@ -1,10 +1,9 @@
 import mimetypes
 from os.path import getmtime, getsize
-
 import venusian
-
 from webob import Response as _Response
 from zope.interface import implementer
+
 from pyramid.interfaces import IResponse, IResponseFactory
 
 _BLOCK_SIZE = 4096 * 64  # 256K

--- a/src/pyramid/router.py
+++ b/src/pyramid/router.py
@@ -1,33 +1,29 @@
 from zope.interface import implementer, providedBy
 
+from pyramid.events import (
+    BeforeTraversal,
+    ContextFound,
+    NewRequest,
+    NewResponse,
+)
+from pyramid.httpexceptions import HTTPNotFound
 from pyramid.interfaces import (
     IDebugLogger,
     IExecutionPolicy,
     IRequest,
     IRequestExtensions,
-    IRootFactory,
-    IRouteRequest,
-    IRouter,
     IRequestFactory,
+    IRootFactory,
+    IRouter,
+    IRouteRequest,
     IRoutesMapper,
     ITraverser,
     ITweens,
 )
-
-from pyramid.events import (
-    ContextFound,
-    NewRequest,
-    NewResponse,
-    BeforeTraversal,
-)
-
-from pyramid.httpexceptions import HTTPNotFound
-from pyramid.request import Request
-from pyramid.view import _call_view
-from pyramid.request import apply_request_extensions
+from pyramid.request import Request, apply_request_extensions
 from pyramid.threadlocal import RequestContext
-
 from pyramid.traversal import DefaultRootFactory, ResourceTreeTraverser
+from pyramid.view import _call_view
 
 
 @implementer(IRouter)

--- a/src/pyramid/scripting.py
+++ b/src/pyramid/scripting.py
@@ -1,10 +1,7 @@
 from pyramid.config import global_registries
 from pyramid.exceptions import ConfigurationError
-
 from pyramid.interfaces import IRequestFactory, IRootFactory
-from pyramid.request import Request
-from pyramid.request import apply_request_extensions
-
+from pyramid.request import Request, apply_request_extensions
 from pyramid.threadlocal import RequestContext
 from pyramid.traversal import DefaultRootFactory
 

--- a/src/pyramid/scripts/pdistreport.py
+++ b/src/pyramid/scripts/pdistreport.py
@@ -1,8 +1,8 @@
-import sys
-import platform
-import pkg_resources
 import argparse
 from operator import itemgetter
+import pkg_resources
+import platform
+import sys
 
 
 def out(*args):  # pragma: no cover

--- a/src/pyramid/scripts/prequest.py
+++ b/src/pyramid/scripts/prequest.py
@@ -1,12 +1,11 @@
-import base64
 import argparse
+import base64
 import sys
 import textwrap
 from urllib.parse import unquote
 
 from pyramid.request import Request
-from pyramid.scripts.common import get_config_loader
-from pyramid.scripts.common import parse_vars
+from pyramid.scripts.common import get_config_loader, parse_vars
 
 
 def main(argv=sys.argv, quiet=False):

--- a/src/pyramid/scripts/proutes.py
+++ b/src/pyramid/scripts/proutes.py
@@ -1,20 +1,16 @@
-import fnmatch
 import argparse
+import fnmatch
+import re
 import sys
 import textwrap
-import re
-
 from zope.interface import Interface
 
-from pyramid.paster import bootstrap
-from pyramid.interfaces import IRouteRequest
 from pyramid.config import not_
-
-from pyramid.scripts.common import get_config_loader
-from pyramid.scripts.common import parse_vars
+from pyramid.interfaces import IRouteRequest
+from pyramid.paster import bootstrap
+from pyramid.scripts.common import get_config_loader, parse_vars
 from pyramid.static import static_view
 from pyramid.view import _find_views
-
 
 PAD = 3
 ANY_KEY = '*'

--- a/src/pyramid/scripts/pserve.py
+++ b/src/pyramid/scripts/pserve.py
@@ -9,6 +9,7 @@
 # lib/site.py
 
 import argparse
+import hupper
 import os
 import re
 import sys
@@ -17,11 +18,8 @@ import threading
 import time
 import webbrowser
 
-import hupper
-
-from pyramid.scripts.common import get_config_loader
-from pyramid.scripts.common import parse_vars
 from pyramid.path import AssetResolver
+from pyramid.scripts.common import get_config_loader, parse_vars
 from pyramid.settings import aslist
 
 

--- a/src/pyramid/scripts/pshell.py
+++ b/src/pyramid/scripts/pshell.py
@@ -1,19 +1,15 @@
+import argparse
 from code import interact
 from contextlib import contextmanager
-import argparse
 import os
+import pkg_resources
 import sys
 import textwrap
-import pkg_resources
 
-from pyramid.util import DottedNameResolver
-from pyramid.util import make_contextmanager
 from pyramid.paster import bootstrap
-
+from pyramid.scripts.common import get_config_loader, parse_vars
 from pyramid.settings import aslist
-
-from pyramid.scripts.common import get_config_loader
-from pyramid.scripts.common import parse_vars
+from pyramid.util import DottedNameResolver, make_contextmanager
 
 
 def main(argv=sys.argv, quiet=False):

--- a/src/pyramid/scripts/ptweens.py
+++ b/src/pyramid/scripts/ptweens.py
@@ -3,12 +3,9 @@ import sys
 import textwrap
 
 from pyramid.interfaces import ITweens
-
-from pyramid.tweens import MAIN
-from pyramid.tweens import INGRESS
-from pyramid.paster import bootstrap
-from pyramid.paster import setup_logging
+from pyramid.paster import bootstrap, setup_logging
 from pyramid.scripts.common import parse_vars
+from pyramid.tweens import INGRESS, MAIN
 
 
 def main(argv=sys.argv, quiet=False):

--- a/src/pyramid/scripts/pviews.py
+++ b/src/pyramid/scripts/pviews.py
@@ -3,8 +3,7 @@ import sys
 import textwrap
 
 from pyramid.interfaces import IMultiView
-from pyramid.paster import bootstrap
-from pyramid.paster import setup_logging
+from pyramid.paster import bootstrap, setup_logging
 from pyramid.request import Request
 from pyramid.scripts.common import parse_vars
 from pyramid.view import _find_views

--- a/src/pyramid/security.py
+++ b/src/pyramid/security.py
@@ -1,15 +1,14 @@
-from zope.interface import implementer, providedBy
 from zope.deprecation import deprecated
+from zope.interface import implementer, providedBy
 
 from pyramid.interfaces import (
-    ISecurityPolicy,
     IAuthenticationPolicy,
     IAuthorizationPolicy,
     ISecuredView,
+    ISecurityPolicy,
     IView,
     IViewClassifier,
 )
-
 from pyramid.threadlocal import get_current_registry
 
 Everyone = 'system.Everyone'

--- a/src/pyramid/session.py
+++ b/src/pyramid/session.py
@@ -2,17 +2,13 @@ import binascii
 import os
 import pickle
 import time
-
+from webob.cookies import JSONSerializer, SignedSerializer
 from zope.deprecation import deprecated
 from zope.interface import implementer
 
-from webob.cookies import JSONSerializer, SignedSerializer
-
 from pyramid.csrf import check_csrf_origin, check_csrf_token
-
 from pyramid.interfaces import ISession
-
-from pyramid.util import text_, bytes_
+from pyramid.util import bytes_, text_
 
 
 def manage_accessed(wrapped):

--- a/src/pyramid/static.py
+++ b/src/pyramid/static.py
@@ -3,19 +3,13 @@ from functools import lru_cache
 import json
 import mimetypes
 import os
-
-from os.path import getmtime, getsize, normcase, normpath, join, isdir, exists
-
+from os.path import exists, getmtime, getsize, isdir, join, normcase, normpath
 from pkg_resources import resource_exists, resource_filename, resource_isdir
 
 from pyramid.asset import abspath_from_asset_spec, resolve_asset_spec
-
-from pyramid.httpexceptions import HTTPNotFound, HTTPMovedPermanently
-
+from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
 from pyramid.path import caller_package
-
-from pyramid.response import _guess_type, FileResponse
-
+from pyramid.response import FileResponse, _guess_type
 from pyramid.traversal import traversal_path_info
 
 

--- a/src/pyramid/testing.py
+++ b/src/pyramid/testing.py
@@ -1,29 +1,22 @@
+from contextlib import contextmanager
 import copy
 import os
-from contextlib import contextmanager
-
 from webob.acceptparse import create_accept_header
-
-from zope.interface import implementer, alsoProvides
-
-from pyramid.interfaces import IRequest, ISession
+from zope.interface import alsoProvides, implementer
 
 from pyramid.config import Configurator
 from pyramid.decorator import reify
-from pyramid.path import caller_package
-from pyramid.response import _get_response_factory
-from pyramid.registry import Registry
-
-from pyramid.security import SecurityAPIMixin, AuthenticationAPIMixin
-
-from pyramid.threadlocal import get_current_registry, manager
-
 from pyramid.i18n import LocalizerRequestMixin
+from pyramid.interfaces import IRequest, ISession
+from pyramid.path import caller_package
+from pyramid.registry import Registry
 from pyramid.request import CallbackMethodsMixin
+from pyramid.response import _get_response_factory
+from pyramid.security import AuthenticationAPIMixin, SecurityAPIMixin
+from pyramid.threadlocal import get_current_registry, manager
 from pyramid.url import URLMethodsMixin
-from pyramid.util import InstancePropertyMixin, PYPY, text_
+from pyramid.util import PYPY, InstancePropertyMixin, text_
 from pyramid.view import ViewMethodsMixin
-
 
 _marker = object()
 

--- a/src/pyramid/traversal.py
+++ b/src/pyramid/traversal.py
@@ -1,18 +1,16 @@
 from functools import lru_cache
 from urllib.parse import unquote_to_bytes
-
 from zope.interface import implementer
 from zope.interface.interfaces import IInterface
 
-from pyramid.interfaces import (
-    IResourceURL,
-    IRequestFactory,
-    ITraverser,
-    VH_ROOT_KEY,
-)
-
 from pyramid.encode import url_quote
 from pyramid.exceptions import URLDecodeError
+from pyramid.interfaces import (
+    VH_ROOT_KEY,
+    IRequestFactory,
+    IResourceURL,
+    ITraverser,
+)
 from pyramid.location import lineage
 from pyramid.threadlocal import get_current_registry
 from pyramid.util import ascii_, is_nonstr_iter, text_

--- a/src/pyramid/url.py
+++ b/src/pyramid/url.py
@@ -3,19 +3,17 @@
 from functools import lru_cache
 import os
 
-from pyramid.interfaces import IResourceURL, IRoutesMapper, IStaticURLInfo
-
 from pyramid.encode import url_quote, urlencode
+from pyramid.interfaces import IResourceURL, IRoutesMapper, IStaticURLInfo
 from pyramid.path import caller_package
 from pyramid.threadlocal import get_current_registry
-from pyramid.util import bytes_
-
 from pyramid.traversal import (
-    ResourceURL,
-    quote_path_segment,
     PATH_SAFE,
     PATH_SEGMENT_SAFE,
+    ResourceURL,
+    quote_path_segment,
 )
+from pyramid.util import bytes_
 
 QUERY_SAFE = "/?:@!$&'()*+,;="  # RFC 3986
 ANCHOR_SAFE = QUERY_SAFE

--- a/src/pyramid/urldispatch.py
+++ b/src/pyramid/urldispatch.py
@@ -1,12 +1,9 @@
 import re
 from zope.interface import implementer
 
-from pyramid.interfaces import IRoutesMapper, IRoute
-
 from pyramid.exceptions import URLDecodeError
-
-from pyramid.traversal import quote_path_segment, split_path_info, PATH_SAFE
-
+from pyramid.interfaces import IRoute, IRoutesMapper
+from pyramid.traversal import PATH_SAFE, quote_path_segment, split_path_info
 from pyramid.util import is_nonstr_iter, text_
 
 _marker = object()

--- a/src/pyramid/view.py
+++ b/src/pyramid/view.py
@@ -1,33 +1,26 @@
+import inspect
 import itertools
 import sys
-import inspect
-
 import venusian
-
 from zope.interface import providedBy
 
-from pyramid.interfaces import (
-    IRoutesMapper,
-    IMultiView,
-    ISecuredView,
-    IView,
-    IViewClassifier,
-    IRequest,
-    IExceptionViewClassifier,
-)
-
 from pyramid.exceptions import ConfigurationError, PredicateMismatch
-
 from pyramid.httpexceptions import (
     HTTPNotFound,
     HTTPTemporaryRedirect,
     default_exceptionresponse_view,
 )
-
+from pyramid.interfaces import (
+    IExceptionViewClassifier,
+    IMultiView,
+    IRequest,
+    IRoutesMapper,
+    ISecuredView,
+    IView,
+    IViewClassifier,
+)
 from pyramid.threadlocal import get_current_registry, manager
-
-from pyramid.util import hide_attrs
-from pyramid.util import reraise as reraise_
+from pyramid.util import hide_attrs, reraise as reraise_
 
 _marker = object()
 

--- a/src/pyramid/viewderivers.py
+++ b/src/pyramid/viewderivers.py
@@ -1,31 +1,28 @@
 import inspect
-
 from zope.interface import implementer, provider
 
-from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid import renderers
 from pyramid.csrf import check_csrf_origin, check_csrf_token
-from pyramid.response import Response
-
+from pyramid.exceptions import ConfigurationError
+from pyramid.httpexceptions import HTTPForbidden
 from pyramid.interfaces import (
+    IDebugLogger,
     IDefaultCSRFOptions,
     IDefaultPermission,
-    IDebugLogger,
     IResponse,
     ISecurityPolicy,
     IViewMapper,
     IViewMapperFactory,
 )
-
-from pyramid.exceptions import ConfigurationError
-from pyramid.httpexceptions import HTTPForbidden
+from pyramid.response import Response
+from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.util import (
-    object_description,
-    takes_one_arg,
     is_bound_method,
     is_unbound_method,
+    object_description,
+    takes_one_arg,
 )
 from pyramid.view import render_view_to_response
-from pyramid import renderers
 
 
 def view_description(view):

--- a/src/pyramid/wsgi.py
+++ b/src/pyramid/wsgi.py
@@ -1,4 +1,5 @@
 from functools import wraps
+
 from pyramid.request import call_app_with_subpath_as_path_info
 
 

--- a/tests/pkgs/conflictapp/__init__.py
+++ b/tests/pkgs/conflictapp/__init__.py
@@ -1,6 +1,6 @@
-from pyramid.response import Response
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
+from pyramid.response import Response
 
 
 def aview(request):

--- a/tests/pkgs/defpermbugapp/__init__.py
+++ b/tests/pkgs/defpermbugapp/__init__.py
@@ -1,4 +1,5 @@
 from webob import Response
+
 from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.view import view_config
 

--- a/tests/pkgs/eventonly/__init__.py
+++ b/tests/pkgs/eventonly/__init__.py
@@ -1,5 +1,5 @@
-from pyramid.view import view_config
 from pyramid.events import subscriber
+from pyramid.view import view_config
 
 
 class Yup(object):

--- a/tests/pkgs/exceptionviewapp/views.py
+++ b/tests/pkgs/exceptionviewapp/views.py
@@ -1,6 +1,8 @@
 from webob import Response
-from .models import AnException
+
 from pyramid.httpexceptions import HTTPBadRequest
+
+from .models import AnException
 
 
 def no(request):

--- a/tests/pkgs/fixtureapp/views.py
+++ b/tests/pkgs/fixtureapp/views.py
@@ -1,5 +1,6 @@
-from zope.interface import Interface
 from webob import Response
+from zope.interface import Interface
+
 from pyramid.httpexceptions import HTTPForbidden
 
 

--- a/tests/pkgs/forbiddenapp/__init__.py
+++ b/tests/pkgs/forbiddenapp/__init__.py
@@ -1,4 +1,5 @@
 from webob import Response
+
 from pyramid.httpexceptions import HTTPForbidden
 from pyramid.util import bytes_
 

--- a/tests/pkgs/forbiddenview/__init__.py
+++ b/tests/pkgs/forbiddenview/__init__.py
@@ -1,7 +1,7 @@
-from pyramid.view import forbidden_view_config, view_config
-from pyramid.response import Response
 from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
+from pyramid.response import Response
+from pyramid.view import forbidden_view_config, view_config
 
 
 @forbidden_view_config(route_name='foo')

--- a/tests/pkgs/legacysecurityapp/__init__.py
+++ b/tests/pkgs/legacysecurityapp/__init__.py
@@ -1,5 +1,5 @@
-from pyramid.response import Response
 from pyramid.authentication import RemoteUserAuthenticationPolicy
+from pyramid.response import Response
 from pyramid.security import Allowed, Denied
 
 

--- a/tests/pkgs/notfoundview/__init__.py
+++ b/tests/pkgs/notfoundview/__init__.py
@@ -1,5 +1,5 @@
-from pyramid.view import notfound_view_config, view_config
 from pyramid.response import Response
+from pyramid.view import notfound_view_config, view_config
 
 
 @notfound_view_config(route_name='foo', append_slash=True)

--- a/tests/pkgs/permbugapp/__init__.py
+++ b/tests/pkgs/permbugapp/__init__.py
@@ -1,6 +1,7 @@
 from html import escape
-from pyramid.security import view_execution_permitted
+
 from pyramid.response import Response
+from pyramid.security import view_execution_permitted
 
 
 def x_view(request):  # pragma: no cover

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -1,5 +1,5 @@
-import unittest
 import os
+import unittest
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,8 +1,9 @@
 from http.cookies import SimpleCookie
 import unittest
 import warnings
+
 from pyramid import testing
-from pyramid.util import text_, bytes_
+from pyramid.util import bytes_, text_
 
 
 class TestCallbackAuthenticationPolicyDebugging(unittest.TestCase):

--- a/tests/test_config/__init__.py
+++ b/tests/test_config/__init__.py
@@ -1,7 +1,6 @@
 # package
 from functools import partial
-from zope.interface import implementer
-from zope.interface import Interface
+from zope.interface import Interface, implementer
 
 
 class IFactory(Interface):

--- a/tests/test_config/pkgs/scannable/__init__.py
+++ b/tests/test_config/pkgs/scannable/__init__.py
@@ -1,5 +1,5 @@
-from pyramid.view import view_config
 from pyramid.renderers import null_renderer
+from pyramid.view import view_config
 
 
 @view_config(renderer=null_renderer)

--- a/tests/test_config/pkgs/scannable/another.py
+++ b/tests/test_config/pkgs/scannable/another.py
@@ -1,5 +1,5 @@
-from pyramid.view import view_config
 from pyramid.renderers import null_renderer
+from pyramid.view import view_config
 
 
 @view_config(name='another', renderer=null_renderer)

--- a/tests/test_config/pkgs/scannable/pod/notinit.py
+++ b/tests/test_config/pkgs/scannable/pod/notinit.py
@@ -1,5 +1,5 @@
-from pyramid.view import view_config
 from pyramid.renderers import null_renderer
+from pyramid.view import view_config
 
 
 @view_config(name='pod_notinit', renderer=null_renderer)

--- a/tests/test_config/pkgs/scannable/subpackage/__init__.py
+++ b/tests/test_config/pkgs/scannable/subpackage/__init__.py
@@ -1,5 +1,5 @@
-from pyramid.view import view_config
 from pyramid.renderers import null_renderer
+from pyramid.view import view_config
 
 
 @view_config(name='subpackage_init', renderer=null_renderer)

--- a/tests/test_config/pkgs/scannable/subpackage/notinit.py
+++ b/tests/test_config/pkgs/scannable/subpackage/notinit.py
@@ -1,5 +1,5 @@
-from pyramid.view import view_config
 from pyramid.renderers import null_renderer
+from pyramid.view import view_config
 
 
 @view_config(name='subpackage_notinit', renderer=null_renderer)

--- a/tests/test_config/pkgs/scannable/subpackage/subsubpackage/__init__.py
+++ b/tests/test_config/pkgs/scannable/subpackage/subsubpackage/__init__.py
@@ -1,5 +1,5 @@
-from pyramid.view import view_config
 from pyramid.renderers import null_renderer
+from pyramid.view import view_config
 
 
 @view_config(name='subsubpackage_init', renderer=null_renderer)

--- a/tests/test_config/test_actions.py
+++ b/tests/test_config/test_actions.py
@@ -1,8 +1,9 @@
 import unittest
 
-from pyramid.exceptions import ConfigurationConflictError
-from pyramid.exceptions import ConfigurationExecutionError
-
+from pyramid.exceptions import (
+    ConfigurationConflictError,
+    ConfigurationExecutionError,
+)
 from pyramid.interfaces import IRequest
 
 

--- a/tests/test_config/test_assets.py
+++ b/tests/test_config/test_assets.py
@@ -1,5 +1,6 @@
 import os.path
 import unittest
+
 from pyramid.testing import cleanUp
 
 # we use this folder

--- a/tests/test_config/test_init.py
+++ b/tests/test_config/test_init.py
@@ -1,16 +1,19 @@
 import os
 import unittest
 
-from . import dummy_tween_factory
-from . import dummy_include
-from . import dummy_extend
-from . import dummy_extend2
-from . import DummyContext
-
-from pyramid.exceptions import ConfigurationExecutionError
-from pyramid.exceptions import ConfigurationConflictError
-
+from pyramid.exceptions import (
+    ConfigurationConflictError,
+    ConfigurationExecutionError,
+)
 from pyramid.interfaces import IRequest
+
+from . import (
+    DummyContext,
+    dummy_extend,
+    dummy_extend2,
+    dummy_include,
+    dummy_tween_factory,
+)
 
 
 class ConfiguratorTests(unittest.TestCase):

--- a/tests/test_config/test_routes.py
+++ b/tests/test_config/test_routes.py
@@ -1,9 +1,9 @@
 import unittest
 import warnings
 
-from . import dummyfactory
-from . import DummyContext
 from pyramid.util import text_
+
+from . import DummyContext, dummyfactory
 
 
 class RoutesConfiguratorMixinTests(unittest.TestCase):

--- a/tests/test_config/test_security.py
+++ b/tests/test_config/test_security.py
@@ -1,7 +1,6 @@
 import unittest
 
-from pyramid.exceptions import ConfigurationExecutionError
-from pyramid.exceptions import ConfigurationError
+from pyramid.exceptions import ConfigurationError, ConfigurationExecutionError
 
 
 class ConfiguratorSecurityMethodsTests(unittest.TestCase):

--- a/tests/test_config/test_testing.py
+++ b/tests/test_config/test_testing.py
@@ -1,8 +1,9 @@
 import unittest
 from zope.interface import implementer
 
-from pyramid.security import SecurityAPIMixin, AuthenticationAPIMixin
+from pyramid.security import AuthenticationAPIMixin, SecurityAPIMixin
 from pyramid.util import text_
+
 from . import IDummy
 
 

--- a/tests/test_config/test_tweens.py
+++ b/tests/test_config/test_tweens.py
@@ -1,9 +1,8 @@
 import unittest
 
-from . import dummy_tween_factory
-from . import dummy_tween_factory2
-
 from pyramid.exceptions import ConfigurationConflictError
+
+from . import dummy_tween_factory, dummy_tween_factory2
 
 
 class TestTweensConfiguratorMixin(unittest.TestCase):

--- a/tests/test_config/test_views.py
+++ b/tests/test_config/test_views.py
@@ -4,14 +4,15 @@ import warnings
 from zope.interface import implementer
 
 from pyramid import testing
-from pyramid.exceptions import ConfigurationError
-from pyramid.exceptions import ConfigurationExecutionError
-from pyramid.exceptions import ConfigurationConflictError
-from pyramid.interfaces import IResponse, IRequest, IMultiView
+from pyramid.exceptions import (
+    ConfigurationConflictError,
+    ConfigurationError,
+    ConfigurationExecutionError,
+)
+from pyramid.interfaces import IMultiView, IRequest, IResponse
 from pyramid.util import text_
 
-from . import IDummy
-from . import dummy_view
+from . import IDummy, dummy_view
 
 
 class TestViewsConfigurationMixin(unittest.TestCase):

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -1,4 +1,5 @@
 import unittest
+
 from pyramid.util import text_
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,4 +1,5 @@
 import unittest
+
 from pyramid import testing
 
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import unittest
+
 from pyramid import testing
 
 here = os.path.dirname(__file__)

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -1,5 +1,6 @@
 import unittest
 from zope.interface import implementer
+
 from pyramid.interfaces import ILocation
 
 

--- a/tests/test_paster.py
+++ b/tests/test_paster.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+
 from .test_scripts.dummy import DummyLoader
 
 here = os.path.dirname(__file__)

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,5 +1,5 @@
-import unittest
 import os
+import unittest
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -1,7 +1,6 @@
 import unittest
 
 from pyramid import testing
-
 from pyramid.util import text_
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,5 @@
 import unittest
-from zope.interface import Interface
-from zope.interface import implementer
+from zope.interface import Interface, implementer
 
 
 class TestRegistry(unittest.TestCase):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,8 +1,8 @@
 import unittest
-from pyramid import testing
 
-from pyramid.security import SecurityAPIMixin, AuthenticationAPIMixin
-from pyramid.util import text_, bytes_
+from pyramid import testing
+from pyramid.security import AuthenticationAPIMixin, SecurityAPIMixin
+from pyramid.util import bytes_, text_
 
 
 class TestRequest(unittest.TestCase):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -2,6 +2,7 @@ import io
 import mimetypes
 import os
 import unittest
+
 from pyramid import testing
 
 

--- a/tests/test_scripts/dummy.py
+++ b/tests/test_scripts/dummy.py
@@ -1,4 +1,5 @@
 from zope.interface import implementer
+
 from pyramid.interfaces import IMultiView
 
 

--- a/tests/test_scripts/test_prequest.py
+++ b/tests/test_scripts/test_prequest.py
@@ -1,5 +1,6 @@
 from io import StringIO
 import unittest
+
 from . import dummy
 
 

--- a/tests/test_scripts/test_proutes.py
+++ b/tests/test_scripts/test_proutes.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+
 from . import dummy
 
 

--- a/tests/test_scripts/test_pserve.py
+++ b/tests/test_scripts/test_pserve.py
@@ -1,8 +1,8 @@
 from io import StringIO
 import os
 import unittest
-from . import dummy
 
+from . import dummy
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_scripts/test_pshell.py
+++ b/tests/test_scripts/test_pshell.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+
 from . import dummy
 
 

--- a/tests/test_scripts/test_ptweens.py
+++ b/tests/test_scripts/test_ptweens.py
@@ -1,4 +1,5 @@
 import unittest
+
 from . import dummy
 
 

--- a/tests/test_scripts/test_pviews.py
+++ b/tests/test_scripts/test_pviews.py
@@ -1,4 +1,5 @@
 import unittest
+
 from . import dummy
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,7 @@ import base64
 import json
 import pickle
 import unittest
+
 from pyramid import testing
 
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,7 +1,7 @@
 import unittest
 from zope.component import getSiteManager
-from zope.interface import Interface
-from zope.interface import implementer
+from zope.interface import Interface, implementer
+
 from pyramid import testing
 
 

--- a/tests/test_threadlocal.py
+++ b/tests/test_threadlocal.py
@@ -1,5 +1,6 @@
-from pyramid import testing
 import unittest
+
+from pyramid import testing
 
 
 class TestThreadLocalManager(unittest.TestCase):

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -3,7 +3,6 @@ import unittest
 from urllib.parse import quote
 
 from pyramid.testing import cleanUp
-
 from pyramid.util import text_
 
 

--- a/tests/test_tweens.py
+++ b/tests/test_tweens.py
@@ -1,4 +1,5 @@
 import unittest
+
 from pyramid import testing
 
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -2,7 +2,6 @@ import os
 import unittest
 
 from pyramid import testing
-
 from pyramid.util import WIN, text_
 
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1,4 +1,5 @@
 import unittest
+
 from pyramid import testing
 from pyramid.util import text_
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 import sys
 import unittest
-from pyramid.util import text_, bytes_
+
+from pyramid.util import bytes_, text_
 
 
 class Test_InstancePropertyHelper(unittest.TestCase):

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -1,11 +1,9 @@
-import unittest
-from zope.interface import Interface
-from zope.interface import implementer
 import sys
+import unittest
+from zope.interface import Interface, implementer
 
 from pyramid import testing
-from pyramid.interfaces import IRequest
-from pyramid.interfaces import IResponse
+from pyramid.interfaces import IRequest, IResponse
 
 
 class BaseTest(object):

--- a/tests/test_viewderivers.py
+++ b/tests/test_viewderivers.py
@@ -3,7 +3,7 @@ from zope.interface import implementer
 
 from pyramid import testing
 from pyramid.exceptions import ConfigurationError
-from pyramid.interfaces import IResponse, IRequest
+from pyramid.interfaces import IRequest, IResponse
 
 
 class TestDeriveView(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -19,12 +19,14 @@ setenv =
 skip_install = true
 commands =
     flake8 src/pyramid tests setup.py
+    isort --check -rc src/pyramid tests setup.py
     black --check --diff src/pyramid tests setup.py
     python setup.py check -r -s -m
     check-manifest
 deps =
     flake8
     black
+    isort
     readme_renderer
     check-manifest
 
@@ -53,12 +55,14 @@ deps =
 setenv =
     COVERAGE_FILE=.coverage
 
-[testenv:black]
+[testenv:format]
 skip_install = true
 commands =
+    isort -rc src/pyramid tests setup.py
     black src/pyramid tests setup.py
 deps =
     black
+    isort
 
 [testenv:build]
 skip_install = true


### PR DESCRIPTION
This config basically does what we've done in the past and remains compatible with black. The main tweak is to group everything that isn't pyramid into one section at the top without attempting to differentiate stdlib vs third party as I think this fits the goal better in the face of things like polyfill libraries.

It changes the tox helper for black/isort to `tox -e format` and continues to maintain `tox -e lint` for checking in CI.