### PR TITLE
allow overriding synthesized properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,13 @@ Features
 - Fix ``DeprecationWarning`` emitted by using the ``imp`` module.
   See https://github.com/Pylons/pyramid/pull/3553
 
+- Properties created via ``config.add_request_method(..., property=True)`` or
+  ``request.set_property`` used to be readonly. They can now be overridden
+  via ``request.foo = ...`` and until the value is deleted it will return
+  the overridden value. This is most useful when mocking request properties
+  in testing.
+  See https://github.com/Pylons/pyramid/pull/3559
+
 Deprecations
 ------------
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -103,25 +103,26 @@ class Test_InstancePropertyHelper(unittest.TestCase):
         )
 
     def test_override_property(self):
-        def worker(obj):  # pragma: no cover
+        def worker(obj):
             pass
 
         foo = Dummy()
         helper = self._getTargetClass()
         helper.set_property(foo, worker, name='x')
-
-        def doit():
-            foo.x = 1
-
-        self.assertRaises(AttributeError, doit)
+        self.assertIsNone(foo.x)
+        foo.x = 1
+        self.assertEqual(foo.x, 1)
+        del foo.x
+        self.assertIsNone(foo.x)
 
     def test_override_reify(self):
-        def worker(obj):  # pragma: no cover
+        def worker(obj):
             pass
 
         foo = Dummy()
         helper = self._getTargetClass()
         helper.set_property(foo, worker, name='x', reify=True)
+        self.assertIsNone(foo.x)
         foo.x = 1
         self.assertEqual(1, foo.x)
         foo.x = 2
@@ -301,23 +302,24 @@ class Test_InstancePropertyMixin(unittest.TestCase):
         )
 
     def test_override_property(self):
-        def worker(obj):  # pragma: no cover
+        def worker(obj):
             pass
 
         foo = self._makeOne()
         foo.set_property(worker, name='x')
-
-        def doit():
-            foo.x = 1
-
-        self.assertRaises(AttributeError, doit)
+        self.assertIsNone(foo.x)
+        foo.x = 1
+        self.assertEqual(foo.x, 1)
+        del foo.x
+        self.assertIsNone(foo.x)
 
     def test_override_reify(self):
-        def worker(obj):  # pragma: no cover
+        def worker(obj):
             pass
 
         foo = self._makeOne()
         foo.set_property(worker, name='x', reify=True)
+        self.assertIsNone(foo.x)
         foo.x = 1
         self.assertEqual(1, foo.x)
         foo.x = 2


### PR DESCRIPTION
I found it pretty annoying that if I do something like `config.add_request_method(lambda r: r.authenticated_identity, 'user', property=True)` that later I could not do `request.user = ...` in a test case or for whatever reason. This isn't a very intentional behavior in Pyramid as-is - it's just the way the `property()` descriptor works. So I made my own `SettableProperty` descriptor that we use by default.