### PR TITLE
move acl helper apis from pyramid.security to pyramid.authorization

### DIFF
--- a/docs/api/request.rst
+++ b/docs/api/request.rst
@@ -202,7 +202,7 @@
       currently authenticated, but this depends on the
       :term:`authentication policy` in effect.  If no :term:`authentication
       policy` is in effect, this will return a sequence containing only the
-      :attr:`pyramid.security.Everyone` principal.
+      :attr:`pyramid.authorization.Everyone` principal.
 
    .. method:: invoke_subrequest(request, use_tweens=False)
 

--- a/docs/narr/advanced-features.rst
+++ b/docs/narr/advanced-features.rst
@@ -34,7 +34,7 @@ For our example above, you can do this instead:
 .. code-block:: python
     :linenos:
 
-    @view_config(route_name="items", effective_principals=pyramid.security.Authenticated)
+    @view_config(route_name="items", effective_principals=pyramid.authorization.Authenticated)
     def auth_view(request):
         # do one thing
 

--- a/docs/narr/security.rst
+++ b/docs/narr/security.rst
@@ -330,14 +330,13 @@ Pyramid provides :class:`pyramid.authorization.ACLHelper` to assist with an
 ACL-based implementation of ``permits``.  Application-specific code should
 construct a list of principals for the user and call
 :meth:`pyramid.authorization.ACLHelper.permits`, which will return an
-:class:`pyramid.security.ACLAllowed` or :class:`pyramid.security.ACLDenied`
+:class:`pyramid.authorization.ACLAllowed` or :class:`pyramid.authorization.ACLDenied`
 object.  An implementation might look like this:
 
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Everyone, Authenticated
-    from pyramid.authorization import ACLHelper
+    from pyramid.authorization import ACLHelper, Everyone, Authenticated
 
     class SecurityPolicy:
         def permits(self, request, context, permission):
@@ -358,8 +357,8 @@ For example, an ACL might be attached to the resource for a blog via its class:
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Allow
-    from pyramid.security import Everyone
+    from pyramid.authorization import Allow
+    from pyramid.authorization import Everyone
 
     class Blog(object):
         __acl__ = [
@@ -374,8 +373,8 @@ Or, if your resources are persistent, an ACL might be specified via the
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Allow
-    from pyramid.security import Everyone
+    from pyramid.authorization import Allow
+    from pyramid.authorization import Everyone
 
     class Blog(object):
         pass
@@ -401,8 +400,8 @@ properties of the instance.
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Allow
-    from pyramid.security import Everyone
+    from pyramid.authorization import Allow
+    from pyramid.authorization import Everyone
 
     class Blog(object):
         def __acl__(self):
@@ -435,8 +434,8 @@ Here's an example ACL:
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Allow
-    from pyramid.security import Everyone
+    from pyramid.authorization import Allow
+    from pyramid.authorization import Everyone
 
     __acl__ = [
         (Allow, Everyone, 'view'),
@@ -444,7 +443,7 @@ Here's an example ACL:
         (Allow, 'group:editors', 'edit'),
     ]
 
-The example ACL indicates that the :data:`pyramid.security.Everyone`
+The example ACL indicates that the :data:`pyramid.authorization.Everyone`
 principal—a special system-defined principal indicating, literally, everyone—is
 allowed to view the blog, and the ``group:editors`` principal is allowed to add
 to and edit the blog.
@@ -453,8 +452,8 @@ Each element of an ACL is an :term:`ACE`, or access control entry. For example,
 in the above code block, there are three ACEs: ``(Allow, Everyone, 'view')``,
 ``(Allow, 'group:editors', 'add')``, and ``(Allow, 'group:editors', 'edit')``.
 
-The first element of any ACE is either :data:`pyramid.security.Allow`, or
-:data:`pyramid.security.Deny`, representing the action to take when the ACE
+The first element of any ACE is either :data:`pyramid.authorization.Allow`, or
+:data:`pyramid.authorization.Deny`, representing the action to take when the ACE
 matches.  The second element is a :term:`principal`.  The third argument is a
 permission or sequence of permission names.
 
@@ -467,9 +466,9 @@ dictated by the ACL*.  So if you have an ACL like this:
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Allow
-    from pyramid.security import Deny
-    from pyramid.security import Everyone
+    from pyramid.authorization import Allow
+    from pyramid.authorization import Deny
+    from pyramid.authorization import Everyone
 
     __acl__ = [
         (Allow, Everyone, 'view'),
@@ -483,9 +482,9 @@ hand, if you have an ACL like this:
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Everyone
-    from pyramid.security import Allow
-    from pyramid.security import Deny
+    from pyramid.authorization import Everyone
+    from pyramid.authorization import Allow
+    from pyramid.authorization import Deny
 
     __acl__ = [
         (Deny, Everyone, 'view'),
@@ -503,8 +502,8 @@ can collapse this into a single ACE, as below.
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Allow
-    from pyramid.security import Everyone
+    from pyramid.authorization import Allow
+    from pyramid.authorization import Everyone
 
     __acl__ = [
         (Allow, Everyone, 'view'),
@@ -520,17 +519,17 @@ can collapse this into a single ACE, as below.
 Special Principal Names
 -----------------------
 
-Special principal names exist in the :mod:`pyramid.security` module.  They can
+Special principal names exist in the :mod:`pyramid.authorization` module.  They can
 be imported for use in your own code to populate ACLs, e.g.,
-:data:`pyramid.security.Everyone`.
+:data:`pyramid.authorization.Everyone`.
 
-:data:`pyramid.security.Everyone`
+:data:`pyramid.authorization.Everyone`
 
   Literally, everyone, no matter what.  This object is actually a string under
   the hood (``system.Everyone``).  Every user *is* the principal named
   "Everyone" during every request, even if a security policy is not in use.
 
-:data:`pyramid.security.Authenticated`
+:data:`pyramid.authorization.Authenticated`
 
   Any user with credentials as determined by the current security policy.  You
   might think of it as any user that is "logged in".  This object is actually a
@@ -543,12 +542,12 @@ be imported for use in your own code to populate ACLs, e.g.,
 Special Permissions
 -------------------
 
-Special permission names exist in the :mod:`pyramid.security` module.  These
+Special permission names exist in the :mod:`pyramid.authorization` module.  These
 can be imported for use in ACLs.
 
 .. _all_permissions:
 
-:data:`pyramid.security.ALL_PERMISSIONS`
+:data:`pyramid.authorization.ALL_PERMISSIONS`
 
   An object representing, literally, *all* permissions.  Useful in an ACL like
   so: ``(Allow, 'fred', ALL_PERMISSIONS)``.  The ``ALL_PERMISSIONS`` object is
@@ -565,7 +564,7 @@ Special ACEs
 ------------
 
 A convenience :term:`ACE` is defined representing a deny to everyone of all
-permissions in :data:`pyramid.security.DENY_ALL`.  This ACE is often used as
+permissions in :data:`pyramid.authorization.DENY_ALL`.  This ACE is often used as
 the *last* ACE of an ACL to explicitly cause inheriting authorization policies
 to "stop looking up the traversal tree" (effectively breaking any inheritance).
 For example, an ACL which allows *only* ``fred`` the view permission for a
@@ -574,18 +573,18 @@ particular resource, despite what inherited ACLs may say, might look like so:
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import Allow
-    from pyramid.security import DENY_ALL
+    from pyramid.authorization import Allow
+    from pyramid.authorization import DENY_ALL
 
     __acl__ = [ (Allow, 'fred', 'view'), DENY_ALL ]
 
-Under the hood, the :data:`pyramid.security.DENY_ALL` ACE equals the
+Under the hood, the :data:`pyramid.authorization.DENY_ALL` ACE equals the
 following:
 
 .. code-block:: python
     :linenos:
 
-    from pyramid.security import ALL_PERMISSIONS
+    from pyramid.authorization import ALL_PERMISSIONS
     __acl__ = [ (Deny, Everyone, ALL_PERMISSIONS) ]
 
 .. index::
@@ -681,7 +680,7 @@ security within view functions imperatively.  It returns instances of objects
 that are effectively booleans.  But these objects are not raw ``True`` or
 ``False`` objects, and have information attached to them about why the
 permission was allowed or denied.  The object will be one of
-:data:`pyramid.security.ACLAllowed`, :data:`pyramid.security.ACLDenied`,
+:data:`pyramid.authorization.ACLAllowed`, :data:`pyramid.authorization.ACLDenied`,
 :data:`pyramid.security.Allowed`, or :data:`pyramid.security.Denied`, as
 documented in :ref:`security_module`.  At the very minimum, these objects will
 have a ``msg`` attribute, which is a string indicating why the permission was

--- a/docs/narr/viewconfig.rst
+++ b/docs/narr/viewconfig.rst
@@ -499,7 +499,7 @@ configured view.
   :meth:`pyramid.request.Request.effective_principals` method indicates that
   every principal named in the argument list is present in the current request,
   this predicate will return True; otherwise it will return False.  For
-  example: ``effective_principals=pyramid.security.Authenticated`` or
+  example: ``effective_principals=pyramid.authorization.Authenticated`` or
   ``effective_principals=('fred', 'group:admins')``.
 
   .. versionadded:: 1.4a4

--- a/src/pyramid/authentication.py
+++ b/src/pyramid/authentication.py
@@ -10,8 +10,8 @@ import warnings
 from webob.cookies import CookieProfile
 from zope.interface import implementer
 
-from pyramid.interfaces import IAuthenticationPolicy, IDebugLogger
 from pyramid.authorization import Authenticated, Everyone
+from pyramid.interfaces import IAuthenticationPolicy, IDebugLogger
 from pyramid.util import (
     SimpleSerializer,
     ascii_,

--- a/src/pyramid/authentication.py
+++ b/src/pyramid/authentication.py
@@ -11,7 +11,7 @@ from webob.cookies import CookieProfile
 from zope.interface import implementer
 
 from pyramid.interfaces import IAuthenticationPolicy, IDebugLogger
-from pyramid.security import Authenticated, Everyone
+from pyramid.authorization import Authenticated, Everyone
 from pyramid.util import (
     SimpleSerializer,
     ascii_,
@@ -98,7 +98,7 @@ class CallbackAuthenticationPolicy(object):
         """ A list of effective principals derived from request.
 
         This will return a list of principals including, at least,
-        :data:`pyramid.security.Everyone`. If there is no authenticated
+        :data:`pyramid.authorization.Everyone`. If there is no authenticated
         userid, or the ``callback`` returns ``None``, this will be the
         only principal:
 
@@ -108,8 +108,9 @@ class CallbackAuthenticationPolicy(object):
 
         If the ``callback`` does not return ``None`` and an authenticated
         userid is found, then the principals will include
-        :data:`pyramid.security.Authenticated`, the ``authenticated_userid``
-        and the list of principals returned by the ``callback``:
+        :data:`pyramid.authorization.Authenticated`, the
+        ``authenticated_userid`` and the list of principals returned by the
+        ``callback``:
 
         .. code-block:: python
 
@@ -274,13 +275,14 @@ class RepozeWho1AuthenticationPolicy(CallbackAuthenticationPolicy):
         """ A list of effective principals derived from the identity.
 
         This will return a list of principals including, at least,
-        :data:`pyramid.security.Everyone`. If there is no identity, or
+        :data:`pyramid.authorization.Everyone`. If there is no identity, or
         the ``callback`` returns ``None``, this will be the only principal.
 
         If the ``callback`` does not return ``None`` and an identity is
         found, then the principals will include
-        :data:`pyramid.security.Authenticated`, the ``authenticated_userid``
-        and the list of principals returned by the ``callback``.
+        :data:`pyramid.authorization.Authenticated`, the
+        ``authenticated_userid`` and the list of principals returned by the
+        ``callback``.
 
         """
         effective_principals = [Everyone]

--- a/src/pyramid/authorization.py
+++ b/src/pyramid/authorization.py
@@ -1,9 +1,49 @@
+import warnings
 from zope.interface import implementer
 
 from pyramid.interfaces import IAuthorizationPolicy
 from pyramid.location import lineage
-from pyramid.security import ACLAllowed, ACLDenied, Allow, Deny, Everyone
 from pyramid.util import is_nonstr_iter
+
+# the simplest way to deprecate the attributes in security.py is to
+# leave them defined there and then import/re-export them here because
+# otherwise there is a difficult-to-resolve circular import between
+# the two modules - in the future when we remove the deprecated code and
+# move it to live here, we will be able to remove this
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    from pyramid.security import (
+        ACLAllowed as _ACLAllowed,
+        ACLDenied as _ACLDenied,
+        AllPermissionsList as _AllPermissionsList,
+        Allow,
+        Authenticated,
+        Deny,
+        Everyone,
+    )
+
+
+Everyone = Everyone  # api
+Authenticated = Authenticated  # api
+Allow = Allow  # api
+Deny = Deny  # api
+
+
+class AllPermissionsList(_AllPermissionsList):
+    pass
+
+
+ALL_PERMISSIONS = AllPermissionsList()  # api
+DENY_ALL = (Deny, Everyone, ALL_PERMISSIONS)  # api
+
+# subclass to fix __qualname__
+class ACLAllowed(_ACLAllowed):
+    pass
+
+
+# subclass to fix __qualname__
+class ACLDenied(_ACLDenied):
+    pass
 
 
 @implementer(IAuthorizationPolicy)

--- a/src/pyramid/authorization.py
+++ b/src/pyramid/authorization.py
@@ -69,9 +69,9 @@ class ACLAuthorizationPolicy(object):
 
     def permits(self, context, principals, permission):
         """ Return an instance of
-        :class:`pyramid.security.ACLAllowed` instance if the policy
+        :class:`pyramid.authorization.ACLAllowed` instance if the policy
         permits access, return an instance of
-        :class:`pyramid.security.ACLDenied` if not."""
+        :class:`pyramid.authorization.ACLDenied` if not."""
         return self.helper.permits(context, principals, permission)
 
     def principals_allowed_by_permission(self, context, permission):
@@ -94,9 +94,9 @@ class ACLHelper:
     """
 
     def permits(self, context, principals, permission):
-        """ Return an instance of :class:`pyramid.security.ACLAllowed` if the
-        ACL allows access a user with the given principals, return an instance
-        of :class:`pyramid.security.ACLDenied` if not.
+        """ Return an instance of :class:`pyramid.authorization.ACLAllowed` if
+        the ACL allows access a user with the given principals, return an
+        instance of :class:`pyramid.authorization.ACLDenied` if not.
 
         When checking if principals are allowed, the security policy consults
         the ``context`` for an ACL first.  If no ACL exists on the context, or
@@ -105,18 +105,18 @@ class ACLHelper:
         so on, until the lineage is exhausted or we determine that the policy
         permits or denies.
 
-        During this processing, if any :data:`pyramid.security.Deny`
+        During this processing, if any :data:`pyramid.authorization.Deny`
         ACE is found matching any principal in ``principals``, stop
         processing by returning an
-        :class:`pyramid.security.ACLDenied` instance (equals
+        :class:`pyramid.authorization.ACLDenied` instance (equals
         ``False``) immediately.  If any
-        :data:`pyramid.security.Allow` ACE is found matching any
+        :data:`pyramid.authorization.Allow` ACE is found matching any
         principal, stop processing by returning an
-        :class:`pyramid.security.ACLAllowed` instance (equals
+        :class:`pyramid.authorization.ACLAllowed` instance (equals
         ``True``) immediately.  If we exhaust the context's
         :term:`lineage`, and no ACE has explicitly permitted or denied
         access, return an instance of
-        :class:`pyramid.security.ACLDenied` (equals ``False``).
+        :class:`pyramid.authorization.ACLDenied` (equals ``False``).
 
         """
         acl = '<No ACL found on any object in resource lineage>'
@@ -160,13 +160,13 @@ class ACLHelper:
         of principals that are explicitly granted the ``permission`` in the
         provided ``context``.  We do this by walking 'up' the object graph
         *from the root* to the context.  During this walking process, if we
-        find an explicit :data:`pyramid.security.Allow` ACE for a principal
+        find an explicit :data:`pyramid.authorization.Allow` ACE for a principal
         that matches the ``permission``, the principal is included in the allow
         list.  However, if later in the walking process that principal is
-        mentioned in any :data:`pyramid.security.Deny` ACE for the permission,
-        the principal is removed from the allow list.  If a
-        :data:`pyramid.security.Deny` to the principal
-        :data:`pyramid.security.Everyone` is encountered during the walking
+        mentioned in any :data:`pyramid.authorization.Deny` ACE for the
+        permission, the principal is removed from the allow list.  If a
+        :data:`pyramid.authorization.Deny` to the principal
+        :data:`pyramid.authorization.Everyone` is encountered during the walking
         process that matches the ``permission``, the allow list is cleared for
         all principals encountered in previous ACLs.  The walking process ends
         after we've processed the any ACL directly attached to ``context``; a

--- a/src/pyramid/config/routes.py
+++ b/src/pyramid/config/routes.py
@@ -278,7 +278,7 @@ class RoutesConfiguratorMixin(object):
           indicates that every principal named in the argument list is present
           in the current request, this predicate will return True; otherwise it
           will return False.  For example:
-          ``effective_principals=pyramid.security.Authenticated`` or
+          ``effective_principals=pyramid.authorization.Authenticated`` or
           ``effective_principals=('fred', 'group:admins')``.
 
           .. versionadded:: 1.4a4

--- a/src/pyramid/config/views.py
+++ b/src/pyramid/config/views.py
@@ -718,7 +718,7 @@ class ViewsConfiguratorMixin(object):
           indicates that every principal named in the argument list is present
           in the current request, this predicate will return True; otherwise it
           will return False.  For example:
-          ``effective_principals=pyramid.security.Authenticated`` or
+          ``effective_principals=pyramid.authorization.Authenticated`` or
           ``effective_principals=('fred', 'group:admins')``.
 
           .. versionadded:: 1.4a4

--- a/src/pyramid/httpexceptions.py
+++ b/src/pyramid/httpexceptions.py
@@ -755,7 +755,7 @@ class HTTPForbidden(HTTPClientError):
     argument, ``detail``, should be a string.  The value of this string will
     be used as the ``message`` attribute of the exception object.  The second
     special keyword argument, ``result`` is usually an instance of
-    :class:`pyramid.security.Denied` or :class:`pyramid.security.ACLDenied`
+    :class:`pyramid.security.Denied` or :class:`pyramid.authorization.ACLDenied`
     each of which indicates a reason for the forbidden error.  However,
     ``result`` is also permitted to be just a plain boolean ``False`` object
     or ``None``.  The ``result`` value will be used as the ``result``

--- a/src/pyramid/interfaces.py
+++ b/src/pyramid/interfaces.py
@@ -554,8 +554,8 @@ class IAuthenticationPolicy(Interface):
         """ Return a sequence representing the effective principals
         typically including the :term:`userid` and any groups belonged
         to by the current user, always including 'system' groups such
-        as ``pyramid.security.Everyone`` and
-        ``pyramid.security.Authenticated``.
+        as ``pyramid.authorization.Everyone`` and
+        ``pyramid.authorization.Authenticated``.
 
         """
 

--- a/src/pyramid/security.py
+++ b/src/pyramid/security.py
@@ -92,7 +92,7 @@ def principals_allowed_by_permission(context, permission):
     in effect, return a sequence of :term:`principal` ids that possess
     the permission in the ``context``.  If no authorization policy is
     in effect, this will return a sequence with the single value
-    :mod:`pyramid.security.Everyone` (the special principal
+    :mod:`pyramid.authorization.Everyone` (the special principal
     identifier representing all principals).
 
     .. note::

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -321,15 +321,15 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.authenticated_userid(request), None)
 
     def test_effective_principals_None(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest({})
         policy = self._makeOne()
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals_userid_only(self):
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
+        from pyramid.authorization import Everyone
+        from pyramid.authorization import Authenticated
 
         request = DummyRequest(
             {'repoze.who.identity': {'repoze.who.userid': 'fred'}}
@@ -341,8 +341,8 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         )
 
     def test_effective_principals_userid_and_groups(self):
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
+        from pyramid.authorization import Everyone
+        from pyramid.authorization import Authenticated
 
         request = DummyRequest(
             {
@@ -363,7 +363,7 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         )
 
     def test_effective_principals_userid_callback_returns_None(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest(
             {
@@ -381,7 +381,7 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals_repoze_who_userid_is_None(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest(
             {'repoze.who.identity': {'repoze.who.userid': None}}
@@ -390,7 +390,7 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals_repoze_who_userid_is_unclean_Everyone(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest(
             {'repoze.who.identity': {'repoze.who.userid': 'system.Everyone'}}
@@ -401,7 +401,7 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
     def test_effective_principals_repoze_who_userid_is_unclean_Authenticated(
         self,
     ):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest(
             {
@@ -498,15 +498,15 @@ class TestRemoteUserAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.authenticated_userid(request), 'fred')
 
     def test_effective_principals_None(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest({})
         policy = self._makeOne()
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals(self):
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
+        from pyramid.authorization import Everyone
+        from pyramid.authorization import Authenticated
 
         request = DummyRequest({'REMOTE_USER': 'fred'})
         policy = self._makeOne()
@@ -601,14 +601,14 @@ class TestAuthTktAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.authenticated_userid(request), 'fred')
 
     def test_effective_principals_no_cookie_identity(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest({})
         policy = self._makeOne(None, None)
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals_callback_returns_None(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest({})
 
@@ -619,8 +619,8 @@ class TestAuthTktAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals(self):
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
+        from pyramid.authorization import Everyone
+        from pyramid.authorization import Authenticated
 
         request = DummyRequest({})
 
@@ -1640,14 +1640,14 @@ class TestSessionAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.authenticated_userid(request), 'fred')
 
     def test_effective_principals_no_identity(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest()
         policy = self._makeOne()
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals_callback_returns_None(self):
-        from pyramid.security import Everyone
+        from pyramid.authorization import Everyone
 
         request = DummyRequest(session={'userid': 'fred'})
 
@@ -1658,8 +1658,8 @@ class TestSessionAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals(self):
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
+        from pyramid.authorization import Everyone
+        from pyramid.authorization import Authenticated
 
         request = DummyRequest(session={'userid': 'fred'})
 

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -36,12 +36,12 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(policy.permits(context, [], 'view'), False)
 
     def test_permits(self):
-        from pyramid.security import Deny
-        from pyramid.security import Allow
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
-        from pyramid.security import ALL_PERMISSIONS
-        from pyramid.security import DENY_ALL
+        from pyramid.authorization import Deny
+        from pyramid.authorization import Allow
+        from pyramid.authorization import Everyone
+        from pyramid.authorization import Authenticated
+        from pyramid.authorization import ALL_PERMISSIONS
+        from pyramid.authorization import DENY_ALL
 
         root = DummyContext()
         community = DummyContext(__name__='community', __parent__=root)
@@ -132,7 +132,7 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         )
 
     def test_permits_string_permissions_in_acl(self):
-        from pyramid.security import Allow
+        from pyramid.authorization import Allow
 
         root = DummyContext()
         root.__acl__ = [(Allow, 'wilma', 'view_stuff')]
@@ -145,8 +145,8 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, False)
 
     def test_principals_allowed_by_permission_direct(self):
-        from pyramid.security import Allow
-        from pyramid.security import DENY_ALL
+        from pyramid.authorization import Allow
+        from pyramid.authorization import DENY_ALL
 
         context = DummyContext()
         acl = [
@@ -162,8 +162,8 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, ['chrism'])
 
     def test_principals_allowed_by_permission_callable_acl(self):
-        from pyramid.security import Allow
-        from pyramid.security import DENY_ALL
+        from pyramid.authorization import Allow
+        from pyramid.authorization import DENY_ALL
 
         context = DummyContext()
         acl = lambda: [
@@ -179,7 +179,7 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, ['chrism'])
 
     def test_principals_allowed_by_permission_string_permission(self):
-        from pyramid.security import Allow
+        from pyramid.authorization import Allow
 
         context = DummyContext()
         acl = [(Allow, 'chrism', 'read_it')]
@@ -191,10 +191,10 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(list(result), [])
 
     def test_principals_allowed_by_permission(self):
-        from pyramid.security import Allow
-        from pyramid.security import Deny
-        from pyramid.security import DENY_ALL
-        from pyramid.security import ALL_PERMISSIONS
+        from pyramid.authorization import Allow
+        from pyramid.authorization import Deny
+        from pyramid.authorization import DENY_ALL
+        from pyramid.authorization import ALL_PERMISSIONS
 
         root = DummyContext(__name__='', __parent__=None)
         community = DummyContext(__name__='community', __parent__=root)
@@ -236,8 +236,8 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_principals_allowed_by_permission_deny_not_permission_in_acl(self):
-        from pyramid.security import Deny
-        from pyramid.security import Everyone
+        from pyramid.authorization import Deny
+        from pyramid.authorization import Everyone
 
         context = DummyContext()
         acl = [(Deny, Everyone, 'write')]
@@ -249,8 +249,8 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_principals_allowed_by_permission_deny_permission_in_acl(self):
-        from pyramid.security import Deny
-        from pyramid.security import Everyone
+        from pyramid.authorization import Deny
+        from pyramid.authorization import Everyone
 
         context = DummyContext()
         acl = [(Deny, Everyone, 'read')]
@@ -262,7 +262,7 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_callable_acl(self):
-        from pyramid.security import Allow
+        from pyramid.authorization import Allow
 
         context = DummyContext()
         fn = lambda self: [(Allow, 'bob', 'read')]
@@ -290,12 +290,12 @@ class TestACLHelper(unittest.TestCase):
 
     def test_acl(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Deny
-        from pyramid.security import Allow
-        from pyramid.security import Everyone
-        from pyramid.security import Authenticated
-        from pyramid.security import ALL_PERMISSIONS
-        from pyramid.security import DENY_ALL
+        from pyramid.authorization import Deny
+        from pyramid.authorization import Allow
+        from pyramid.authorization import Everyone
+        from pyramid.authorization import Authenticated
+        from pyramid.authorization import ALL_PERMISSIONS
+        from pyramid.authorization import DENY_ALL
 
         helper = ACLHelper()
         root = DummyContext()
@@ -386,7 +386,7 @@ class TestACLHelper(unittest.TestCase):
 
     def test_string_permissions_in_acl(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Allow
+        from pyramid.authorization import Allow
 
         helper = ACLHelper()
         root = DummyContext()
@@ -399,7 +399,7 @@ class TestACLHelper(unittest.TestCase):
 
     def test_callable_acl(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Allow
+        from pyramid.authorization import Allow
 
         helper = ACLHelper()
         context = DummyContext()
@@ -410,8 +410,8 @@ class TestACLHelper(unittest.TestCase):
 
     def test_principals_allowed_by_permission_direct(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Allow
-        from pyramid.security import DENY_ALL
+        from pyramid.authorization import Allow
+        from pyramid.authorization import DENY_ALL
 
         helper = ACLHelper()
         context = DummyContext()
@@ -428,8 +428,8 @@ class TestACLHelper(unittest.TestCase):
 
     def test_principals_allowed_by_permission_callable_acl(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Allow
-        from pyramid.security import DENY_ALL
+        from pyramid.authorization import Allow
+        from pyramid.authorization import DENY_ALL
 
         helper = ACLHelper()
         context = DummyContext()
@@ -446,7 +446,7 @@ class TestACLHelper(unittest.TestCase):
 
     def test_principals_allowed_by_permission_string_permission(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Allow
+        from pyramid.authorization import Allow
 
         helper = ACLHelper()
         context = DummyContext()
@@ -459,10 +459,10 @@ class TestACLHelper(unittest.TestCase):
 
     def test_principals_allowed_by_permission(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Allow
-        from pyramid.security import Deny
-        from pyramid.security import DENY_ALL
-        from pyramid.security import ALL_PERMISSIONS
+        from pyramid.authorization import Allow
+        from pyramid.authorization import Deny
+        from pyramid.authorization import DENY_ALL
+        from pyramid.authorization import ALL_PERMISSIONS
 
         helper = ACLHelper()
         root = DummyContext(__name__='', __parent__=None)
@@ -506,8 +506,8 @@ class TestACLHelper(unittest.TestCase):
 
     def test_principals_allowed_by_permission_deny_not_permission_in_acl(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Deny
-        from pyramid.security import Everyone
+        from pyramid.authorization import Deny
+        from pyramid.authorization import Everyone
 
         helper = ACLHelper()
         context = DummyContext()
@@ -520,8 +520,8 @@ class TestACLHelper(unittest.TestCase):
 
     def test_principals_allowed_by_permission_deny_permission_in_acl(self):
         from pyramid.authorization import ACLHelper
-        from pyramid.security import Deny
-        from pyramid.security import Everyone
+        from pyramid.authorization import Deny
+        from pyramid.authorization import Everyone
 
         helper = ACLHelper()
         context = DummyContext()

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -454,7 +454,7 @@ class Test_EffectivePrincipalsPredicate(unittest.TestCase):
 
     def _testing_authn_policy(self, userid, groupids=tuple()):
         from pyramid.interfaces import IAuthenticationPolicy, ISecurityPolicy
-        from pyramid.security import Everyone, Authenticated
+        from pyramid.authorization import Everyone, Authenticated
         from pyramid.security import LegacySecurityPolicy
 
         class DummyPolicy:
@@ -500,7 +500,7 @@ class Test_EffectivePrincipalsPredicate(unittest.TestCase):
         self.assertTrue(inst(context, request))
 
     def test_it_call_authentication_policy_provides_superset_implicit(self):
-        from pyramid.security import Authenticated
+        from pyramid.authorization import Authenticated
 
         request = testing.DummyRequest()
         self._testing_authn_policy('fred', groupids=('verna', 'bambi'))


### PR DESCRIPTION
This deprecates the ACL-specific parts of `pyramid.security` and moves them into `pyramid.authorization` since ACL features are not specifically top-level in the security API any longer.

Here are the options:

1) merge this, and isolate anything ACL-related in `pyramid.authorization`
2) come up with a way to un-deprecate effective_principals so that it can be used by the framework as makes sense.

I'm having a little bit of a reckoning on how smart it is to deprecate `request.effective_principals` and the `effective_principals` predicate. I think most apps benefit from these abstractions and having them baked into Pyramid and if people don't use them then no harm done. I'm thinking about how to expose that - likely via an optional method on the security policy.

cc @luhn 