### PR TITLE
correct configuration.rst add missing route_name

### DIFF
--- a/docs/narr/configuration.rst
+++ b/docs/narr/configuration.rst
@@ -49,7 +49,7 @@ configured imperatively:
     if __name__ == '__main__':
         with Configurator() as config:
             config.add_route('hello', '/')
-            config.add_view(hello_world)
+            config.add_view(hello_world, route_name='hello')
             app = config.make_wsgi_app()
         server = make_server('0.0.0.0', 6543, app)
         server.serve_forever()


### PR DESCRIPTION
Add missing route_name argument to the call of config.add_view in the imperative configuration example.

according to #3566