### PR TITLE
py3 features

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -350,3 +350,5 @@ Contributors
 - Jan Likar, 2019/11/07
 
 - Andrea Borghi, 2019/11/11
+
+- Sergey Maranchuk, 2020/04/18

--- a/docs/quick_tour/sqla_demo/tests/test_it.py
+++ b/docs/quick_tour/sqla_demo/tests/test_it.py
@@ -43,7 +43,7 @@ class BaseTest(unittest.TestCase):
 class TestMyViewSuccessCondition(BaseTest):
 
     def setUp(self):
-        super(TestMyViewSuccessCondition, self).setUp()
+        super().setUp()
         self.init_database()
 
         from sqla_demo.models import MyModel

--- a/docs/quick_tutorial/authorization/tutorial/resources.py
+++ b/docs/quick_tutorial/authorization/tutorial/resources.py
@@ -1,7 +1,7 @@
 from pyramid.authorization import Allow, Everyone
 
 
-class Root(object):
+class Root:
     __acl__ = [(Allow, Everyone, 'view'),
                (Allow, 'group:editors', 'edit')]
 

--- a/docs/quick_tutorial/databases/tutorial/models.py
+++ b/docs/quick_tutorial/databases/tutorial/models.py
@@ -27,7 +27,7 @@ class Page(Base):
     body = Column(Text)
 
 
-class Root(object):
+class Root:
     __acl__ = [(Allow, Everyone, 'view'),
                (Allow, 'group:editors', 'edit')]
 

--- a/docs/quick_tutorial/databases/tutorial/views.py
+++ b/docs/quick_tutorial/databases/tutorial/views.py
@@ -15,7 +15,7 @@ class WikiPage(colander.MappingSchema):
     )
 
 
-class WikiViews(object):
+class WikiViews:
     def __init__(self, request):
         self.request = request
 

--- a/docs/quick_tutorial/forms/tutorial/views.py
+++ b/docs/quick_tutorial/forms/tutorial/views.py
@@ -18,7 +18,7 @@ class WikiPage(colander.MappingSchema):
     )
 
 
-class WikiViews(object):
+class WikiViews:
     def __init__(self, request):
         self.request = request
 

--- a/docs/quick_tutorial/more_view_classes/tutorial/views.py
+++ b/docs/quick_tutorial/more_view_classes/tutorial/views.py
@@ -5,7 +5,7 @@ from pyramid.view import (
 
 
 @view_defaults(route_name='hello')
-class TutorialViews(object):
+class TutorialViews:
     def __init__(self, request):
         self.request = request
         self.view_name = 'TutorialViews'

--- a/docs/quick_tutorial/retail_forms/tutorial/views.py
+++ b/docs/quick_tutorial/retail_forms/tutorial/views.py
@@ -18,7 +18,7 @@ class WikiPage(colander.MappingSchema):
     )
 
 
-class WikiViews(object):
+class WikiViews:
     def __init__(self, request):
         self.request = request
 

--- a/docs/tutorials/wiki2/src/authorization/tutorial/routes.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/routes.py
@@ -28,7 +28,7 @@ def new_page_factory(request):
         raise HTTPSeeOther(location=next_url)
     return NewPage(pagename)
 
-class NewPage(object):
+class NewPage:
     def __init__(self, pagename):
         self.pagename = pagename
 
@@ -45,7 +45,7 @@ def page_factory(request):
         raise HTTPNotFound
     return PageResource(page)
 
-class PageResource(object):
+class PageResource:
     def __init__(self, page):
         self.page = page
 

--- a/docs/tutorials/wiki2/src/tests/tutorial/routes.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/routes.py
@@ -28,7 +28,7 @@ def new_page_factory(request):
         raise HTTPSeeOther(location=next_url)
     return NewPage(pagename)
 
-class NewPage(object):
+class NewPage:
     def __init__(self, pagename):
         self.pagename = pagename
 
@@ -45,7 +45,7 @@ def page_factory(request):
         raise HTTPNotFound
     return PageResource(page)
 
-class PageResource(object):
+class PageResource:
     def __init__(self, page):
         self.page = page
 

--- a/src/pyramid/authentication.py
+++ b/src/pyramid/authentication.py
@@ -23,7 +23,7 @@ from pyramid.util import (
 VALID_TOKEN = re.compile(r"^[A-Za-z][A-Za-z0-9+_-]*$")
 
 
-class CallbackAuthenticationPolicy(object):
+class CallbackAuthenticationPolicy:
     """ Abstract class """
 
     debug = False
@@ -660,7 +660,7 @@ def b64decode(v):
 
 
 # this class licensed under the MIT license (stolen from Paste)
-class AuthTicket(object):
+class AuthTicket:
     """
     This class represents an authentication token.  You must pass in
     the shared secret, the userid, and the IP address.  Optionally you
@@ -821,7 +821,7 @@ def encode_ip_timestamp(ip, timestamp):
     return bytes_(ip_chars + ts_chars)
 
 
-class AuthTktCookieHelper(object):
+class AuthTktCookieHelper:
     """
     A helper class for security policies that obtains data from an "auth
     ticket" cookie.

--- a/src/pyramid/authorization.py
+++ b/src/pyramid/authorization.py
@@ -47,7 +47,7 @@ DENY_ALL = (Deny, Everyone, ALL_PERMISSIONS)  # api
 
 
 @implementer(IAuthorizationPolicy)
-class ACLAuthorizationPolicy(object):
+class ACLAuthorizationPolicy:
     """ An :term:`authorization policy` which consults an :term:`ACL`
     object attached to a :term:`context` to determine authorization
     information about a :term:`principal` or multiple principals.

--- a/src/pyramid/config/actions.py
+++ b/src/pyramid/config/actions.py
@@ -15,7 +15,7 @@ from pyramid.registry import undefer
 from pyramid.util import is_nonstr_iter, reraise
 
 
-class ActionConfiguratorMixin(object):
+class ActionConfiguratorMixin:
     @property
     def action_info(self):
         info = self.info  # usually a ZCML action (ParserInfo) if self.info
@@ -155,7 +155,7 @@ class ActionConfiguratorMixin(object):
 
 
 # this class is licensed under the ZPL (stolen from Zope)
-class ActionState(object):
+class ActionState:
     def __init__(self):
         # NB "actions" is an API, dep'd upon by pyramid_zcml's load_zcml func
         self.actions = []
@@ -330,7 +330,7 @@ class ActionState(object):
                 self.actions = []
 
 
-class ConflictResolverState(object):
+class ConflictResolverState:
     def __init__(self):
         # keep a set of resolved discriminators to test against to ensure
         # that a new action does not conflict with something already executed
@@ -527,7 +527,7 @@ def expand_action_tuple(
 
 
 @implementer(IActionInfo)
-class ActionInfo(object):
+class ActionInfo:
     def __init__(self, file, line, function, src):
         self.file = file
         self.line = line

--- a/src/pyramid/config/adapters.py
+++ b/src/pyramid/config/adapters.py
@@ -7,7 +7,7 @@ from pyramid.interfaces import IResourceURL, IResponse, ITraverser
 from pyramid.util import takes_one_arg
 
 
-class AdaptersConfiguratorMixin(object):
+class AdaptersConfiguratorMixin:
     @action_method
     def add_subscriber(self, subscriber, iface=None, **predicates):
         """Add an event :term:`subscriber` for the event stream

--- a/src/pyramid/config/assets.py
+++ b/src/pyramid/config/assets.py
@@ -85,7 +85,7 @@ class OverrideProvider(pkg_resources.DefaultProvider):
 
 
 @implementer(IPackageOverrides)
-class PackageOverrides(object):
+class PackageOverrides:
     # pkg_resources arg in kw args below for testing
     def __init__(self, package, pkg_resources=pkg_resources):
         loader = self._real_loader = getattr(package, '__loader__', None)
@@ -206,7 +206,7 @@ class FileOverride:
             return self.source, ''
 
 
-class PackageAssetSource(object):
+class PackageAssetSource:
     """
     An asset source relative to a package.
 
@@ -258,7 +258,7 @@ class PackageAssetSource(object):
             return pkg_resources.resource_listdir(self.pkg_name, path)
 
 
-class FSAssetSource(object):
+class FSAssetSource:
     """
     An asset source relative to a path in the filesystem.
 
@@ -306,7 +306,7 @@ class FSAssetSource(object):
             return os.listdir(path)
 
 
-class AssetsConfiguratorMixin(object):
+class AssetsConfiguratorMixin:
     def _override(
         self, package, path, override_source, PackageOverrides=PackageOverrides
     ):

--- a/src/pyramid/config/factories.py
+++ b/src/pyramid/config/factories.py
@@ -15,7 +15,7 @@ from pyramid.traversal import DefaultRootFactory
 from pyramid.util import InstancePropertyHelper, get_callable_name
 
 
-class FactoriesConfiguratorMixin(object):
+class FactoriesConfiguratorMixin:
     @action_method
     def set_root_factory(self, factory):
         """ Add a :term:`root factory` to the current configuration
@@ -257,7 +257,7 @@ class FactoriesConfiguratorMixin(object):
 
 
 @implementer(IRequestExtensions)
-class _RequestExtensions(object):
+class _RequestExtensions:
     def __init__(self):
         self.descriptors = {}
         self.methods = {}

--- a/src/pyramid/config/i18n.py
+++ b/src/pyramid/config/i18n.py
@@ -4,7 +4,7 @@ from pyramid.interfaces import ILocaleNegotiator, ITranslationDirectories
 from pyramid.path import AssetResolver
 
 
-class I18NConfiguratorMixin(object):
+class I18NConfiguratorMixin:
     @action_method
     def set_locale_negotiator(self, negotiator):
         """

--- a/src/pyramid/config/predicates.py
+++ b/src/pyramid/config/predicates.py
@@ -11,7 +11,7 @@ MAX_ORDER = 1 << 30
 DEFAULT_PHASH = md5().hexdigest()
 
 
-class PredicateConfiguratorMixin(object):
+class PredicateConfiguratorMixin:
     def get_predlist(self, name):
         predlist = self.registry.queryUtility(IPredicateList, name=name)
         if predlist is None:
@@ -52,7 +52,7 @@ class PredicateConfiguratorMixin(object):
         )  # must be registered early
 
 
-class not_(object):
+class not_:
     """
 
     You can invert the meaning of any predicate value by wrapping it in a call
@@ -96,7 +96,7 @@ class not_(object):
 # over = before
 
 
-class PredicateInfo(object):
+class PredicateInfo:
     def __init__(self, package, registry, settings, maybe_dotted):
         self.package = package
         self.registry = registry
@@ -104,7 +104,7 @@ class PredicateInfo(object):
         self.maybe_dotted = maybe_dotted
 
 
-class PredicateList(object):
+class PredicateList:
     def __init__(self):
         self.sorter = TopologicalSorter()
         self.last_added = None

--- a/src/pyramid/config/predicates.py
+++ b/src/pyramid/config/predicates.py
@@ -205,7 +205,8 @@ class PredicateList:
         score = 0
         for bit in weights:
             score = score | bit
-        order = (MAX_ORDER - score) / (len(preds) + 1)
+        order = (MAX_ORDER - score) // (len(preds) + 1)
+
         return order, preds, phash.hexdigest()
 
 

--- a/src/pyramid/config/rendering.py
+++ b/src/pyramid/config/rendering.py
@@ -8,7 +8,7 @@ DEFAULT_RENDERERS = (
 )
 
 
-class RenderingConfiguratorMixin(object):
+class RenderingConfiguratorMixin:
     def add_default_renderers(self):
         for name, renderer in DEFAULT_RENDERERS:
             self.add_renderer(name, renderer)

--- a/src/pyramid/config/routes.py
+++ b/src/pyramid/config/routes.py
@@ -17,7 +17,7 @@ from pyramid.urldispatch import RoutesMapper
 from pyramid.util import as_sorted_tuple, is_nonstr_iter
 
 
-class RoutesConfiguratorMixin(object):
+class RoutesConfiguratorMixin:
     @action_method
     def add_route(
         self,

--- a/src/pyramid/config/security.py
+++ b/src/pyramid/config/security.py
@@ -18,7 +18,7 @@ from pyramid.security import LegacySecurityPolicy
 from pyramid.util import as_sorted_tuple
 
 
-class SecurityConfiguratorMixin(object):
+class SecurityConfiguratorMixin:
     def add_default_security(self):
         self.set_csrf_storage_policy(LegacySessionCSRFStoragePolicy())
 
@@ -371,7 +371,7 @@ class SecurityConfiguratorMixin(object):
 
 
 @implementer(IDefaultCSRFOptions)
-class DefaultCSRFOptions(object):
+class DefaultCSRFOptions:
     def __init__(
         self,
         require_csrf,

--- a/src/pyramid/config/settings.py
+++ b/src/pyramid/config/settings.py
@@ -3,7 +3,7 @@ import os
 from pyramid.settings import asbool, aslist
 
 
-class SettingsConfiguratorMixin(object):
+class SettingsConfiguratorMixin:
     def _set_settings(self, mapping):
         if mapping is None:
             mapping = {}

--- a/src/pyramid/config/testing.py
+++ b/src/pyramid/config/testing.py
@@ -6,7 +6,7 @@ from pyramid.renderers import RendererHelper
 from pyramid.traversal import split_path_info
 
 
-class TestingConfiguratorMixin(object):
+class TestingConfiguratorMixin:
     # testing API
     def testing_securitypolicy(
         self,

--- a/src/pyramid/config/tweens.py
+++ b/src/pyramid/config/tweens.py
@@ -11,7 +11,7 @@ from pyramid.util import (
 )
 
 
-class TweensConfiguratorMixin(object):
+class TweensConfiguratorMixin:
     def add_tween(self, tween_factory, under=None, over=None):
         """
         .. versionadded:: 1.2
@@ -162,7 +162,7 @@ class TweensConfiguratorMixin(object):
 
 
 @implementer(ITweens)
-class Tweens(object):
+class Tweens:
     def __init__(self):
         self.sorter = TopologicalSorter(
             default_before=None,

--- a/src/pyramid/config/views.py
+++ b/src/pyramid/config/views.py
@@ -75,7 +75,7 @@ view_description = view_description  # bw-compat
 
 
 @implementer(IMultiView)
-class MultiView(object):
+class MultiView:
     def __init__(self, name):
         self.name = name
         self.media_views = {}
@@ -235,7 +235,7 @@ def combine_decorators(*decorators):
     return decorated
 
 
-class ViewsConfiguratorMixin(object):
+class ViewsConfiguratorMixin:
     @viewdefaults
     @action_method
     def add_view(
@@ -2125,7 +2125,7 @@ def runtime_exc_view(view, excview):
 
 
 @implementer(IViewDeriverInfo)
-class ViewDeriverInfo(object):
+class ViewDeriverInfo:
     def __init__(
         self, view, registry, package, predicates, exception_only, options
     ):
@@ -2142,7 +2142,7 @@ class ViewDeriverInfo(object):
 
 
 @implementer(IStaticURLInfo)
-class StaticURLInfo(object):
+class StaticURLInfo:
     def __init__(self):
         self.registrations = []
         self.cache_busters = []

--- a/src/pyramid/config/zca.py
+++ b/src/pyramid/config/zca.py
@@ -1,7 +1,7 @@
 from pyramid.threadlocal import get_current_registry
 
 
-class ZCAConfiguratorMixin(object):
+class ZCAConfiguratorMixin:
     def hook_zca(self):
         """ Call :func:`zope.component.getSiteManager.sethook` with the
         argument :data:`pyramid.threadlocal.get_current_registry`, causing

--- a/src/pyramid/csrf.py
+++ b/src/pyramid/csrf.py
@@ -16,7 +16,7 @@ from pyramid.util import (
 
 
 @implementer(ICSRFStoragePolicy)
-class LegacySessionCSRFStoragePolicy(object):
+class LegacySessionCSRFStoragePolicy:
     """ A CSRF storage policy that defers control of CSRF storage to the
     session.
 
@@ -49,7 +49,7 @@ class LegacySessionCSRFStoragePolicy(object):
 
 
 @implementer(ICSRFStoragePolicy)
-class SessionCSRFStoragePolicy(object):
+class SessionCSRFStoragePolicy:
     """ A CSRF storage policy that persists the CSRF token in the session.
 
     Note that using this CSRF implementation requires that
@@ -92,7 +92,7 @@ class SessionCSRFStoragePolicy(object):
 
 
 @implementer(ICSRFStoragePolicy)
-class CookieCSRFStoragePolicy(object):
+class CookieCSRFStoragePolicy:
     """ An alternative CSRF implementation that stores its information in
     unauthenticated cookies, known as the 'Double Submit Cookie' method in the
     `OWASP CSRF guidelines

--- a/src/pyramid/decorator.py
+++ b/src/pyramid/decorator.py
@@ -1,7 +1,7 @@
 from functools import update_wrapper
 
 
-class reify(object):
+class reify:
     """ Use as a class method decorator.  It operates almost exactly like the
     Python ``@property`` decorator, but it puts the result of the method it
     decorates into the instance dict after the first call, effectively
@@ -13,7 +13,7 @@ class reify(object):
 
         >>> from pyramid.decorator import reify
 
-        >>> class Foo(object):
+        >>> class Foo:
         ...     @reify
         ...     def jammy(self):
         ...         print('jammy called')

--- a/src/pyramid/events.py
+++ b/src/pyramid/events.py
@@ -11,7 +11,7 @@ from pyramid.interfaces import (
 )
 
 
-class subscriber(object):
+class subscriber:
     """ Decorator activated via a :term:`scan` which treats the function
     being decorated as an event subscriber for the set of interfaces passed
     as ``*ifaces`` and the set of predicate terms passed as ``**predicates``
@@ -111,7 +111,7 @@ class subscriber(object):
 
 
 @implementer(INewRequest)
-class NewRequest(object):
+class NewRequest:
     """ An instance of this class is emitted as an :term:`event`
     whenever :app:`Pyramid` begins to process a new request.  The
     event instance has an attribute, ``request``, which is a
@@ -123,7 +123,7 @@ class NewRequest(object):
 
 
 @implementer(INewResponse)
-class NewResponse(object):
+class NewResponse:
     """ An instance of this class is emitted as an :term:`event`
     whenever any :app:`Pyramid` :term:`view` or :term:`exception
     view` returns a :term:`response`.
@@ -161,7 +161,7 @@ class NewResponse(object):
 
 
 @implementer(IBeforeTraversal)
-class BeforeTraversal(object):
+class BeforeTraversal:
     """
     An instance of this class is emitted as an :term:`event` after the
     :app:`Pyramid` :term:`router` has attempted to find a :term:`route` object
@@ -182,7 +182,7 @@ class BeforeTraversal(object):
 
 
 @implementer(IContextFound)
-class ContextFound(object):
+class ContextFound:
     """ An instance of this class is emitted as an :term:`event` after
     the :app:`Pyramid` :term:`router` finds a :term:`context`
     object (after it performs traversal) but before any view code is
@@ -211,7 +211,7 @@ AfterTraversal = ContextFound  # b/c as of 1.0
 
 
 @implementer(IApplicationCreated)
-class ApplicationCreated(object):
+class ApplicationCreated:
     """ An instance of this class is emitted as an :term:`event` when
     the :meth:`pyramid.config.Configurator.make_wsgi_app` is
     called.  The instance has an attribute, ``app``, which is an

--- a/src/pyramid/httpexceptions.py
+++ b/src/pyramid/httpexceptions.py
@@ -143,8 +143,6 @@ def _no_escape(value):
     if value is None:
         return ''
     if not isinstance(value, str):
-        if hasattr(value, '__unicode__'):
-            value = value.__unicode__()
         if isinstance(value, bytes):
             value = text_(value, 'utf-8')
         else:

--- a/src/pyramid/httpexceptions.py
+++ b/src/pyramid/httpexceptions.py
@@ -534,7 +534,7 @@ ${html_comment}'''
     ):
         if location is None:
             raise ValueError("HTTP redirects need a location to redirect to.")
-        super(_HTTPMove, self).__init__(
+        super().__init__(
             detail=detail,
             headers=headers,
             comment=comment,

--- a/src/pyramid/httpexceptions.py
+++ b/src/pyramid/httpexceptions.py
@@ -280,7 +280,7 @@ ${body}'''
                 if comment:
                     html_comment = escape(comment)
 
-                class JsonPageTemplate(object):
+                class JsonPageTemplate:
                     def __init__(self, excobj):
                         self.excobj = excobj
 

--- a/src/pyramid/i18n.py
+++ b/src/pyramid/i18n.py
@@ -18,7 +18,7 @@ TranslationStringFactory = TranslationStringFactory  # PyFlakes
 DEFAULT_PLURAL = lambda n: int(n != 1)
 
 
-class Localizer(object):
+class Localizer:
     """
     An object providing translation and pluralizations related to
     the current request's locale name.  A
@@ -366,7 +366,7 @@ class Translations(gettext.GNUTranslations, object):
         return self._domains.get(domain, self).ngettext(singular, plural, num)
 
 
-class LocalizerRequestMixin(object):
+class LocalizerRequestMixin:
     @reify
     def localizer(self):
         """ Convenience property to return a localizer """

--- a/src/pyramid/path.py
+++ b/src/pyramid/path.py
@@ -80,7 +80,7 @@ def package_path(package):
     return prefix
 
 
-class _CALLER_PACKAGE(object):
+class _CALLER_PACKAGE:
     def __repr__(self):  # pragma: no cover (for docs)
         return 'pyramid.path.CALLER_PACKAGE'
 
@@ -88,7 +88,7 @@ class _CALLER_PACKAGE(object):
 CALLER_PACKAGE = _CALLER_PACKAGE()
 
 
-class Resolver(object):
+class Resolver:
     def __init__(self, package=CALLER_PACKAGE):
         if package in (None, CALLER_PACKAGE):
             self.package = package
@@ -393,7 +393,7 @@ class DottedNameResolver(Resolver):
 
 
 @implementer(IAssetDescriptor)
-class PkgResourcesAssetDescriptor(object):
+class PkgResourcesAssetDescriptor:
     pkg_resources = pkg_resources
 
     def __init__(self, pkg_name, path):
@@ -422,7 +422,7 @@ class PkgResourcesAssetDescriptor(object):
 
 
 @implementer(IAssetDescriptor)
-class FSAssetDescriptor(object):
+class FSAssetDescriptor:
     def __init__(self, path):
         self.path = os.path.abspath(path)
 

--- a/src/pyramid/predicates.py
+++ b/src/pyramid/predicates.py
@@ -12,7 +12,7 @@ from pyramid.util import as_sorted_tuple, is_nonstr_iter, object_description
 _marker = object()
 
 
-class XHRPredicate(object):
+class XHRPredicate:
     def __init__(self, val, config):
         self.val = bool(val)
 
@@ -25,7 +25,7 @@ class XHRPredicate(object):
         return bool(request.is_xhr) is self.val
 
 
-class RequestMethodPredicate(object):
+class RequestMethodPredicate:
     def __init__(self, val, config):
         request_method = as_sorted_tuple(val)
         if 'GET' in request_method and 'HEAD' not in request_method:
@@ -42,7 +42,7 @@ class RequestMethodPredicate(object):
         return request.method in self.val
 
 
-class PathInfoPredicate(object):
+class PathInfoPredicate:
     def __init__(self, val, config):
         self.orig = val
         try:
@@ -60,7 +60,7 @@ class PathInfoPredicate(object):
         return self.val.match(request.upath_info) is not None
 
 
-class RequestParamPredicate(object):
+class RequestParamPredicate:
     def __init__(self, val, config):
         val = as_sorted_tuple(val)
         reqs = []
@@ -96,7 +96,7 @@ class RequestParamPredicate(object):
         return True
 
 
-class HeaderPredicate(object):
+class HeaderPredicate:
     def __init__(self, val, config):
         name = val
         v = None
@@ -127,7 +127,7 @@ class HeaderPredicate(object):
         return self.val.match(val) is not None
 
 
-class AcceptPredicate(object):
+class AcceptPredicate:
     def __init__(self, values, config):
         if not is_nonstr_iter(values):
             values = (values,)
@@ -142,7 +142,7 @@ class AcceptPredicate(object):
         return bool(request.accept.acceptable_offers(self.values))
 
 
-class ContainmentPredicate(object):
+class ContainmentPredicate:
     def __init__(self, val, config):
         self.val = config.maybe_dotted(val)
 
@@ -156,7 +156,7 @@ class ContainmentPredicate(object):
         return find_interface(ctx, self.val) is not None
 
 
-class RequestTypePredicate(object):
+class RequestTypePredicate:
     def __init__(self, val, config):
         self.val = val
 
@@ -169,7 +169,7 @@ class RequestTypePredicate(object):
         return self.val.providedBy(request)
 
 
-class MatchParamPredicate(object):
+class MatchParamPredicate:
     def __init__(self, val, config):
         val = as_sorted_tuple(val)
         self.val = val
@@ -193,7 +193,7 @@ class MatchParamPredicate(object):
         return True
 
 
-class CustomPredicate(object):
+class CustomPredicate:
     def __init__(self, func, config):
         self.func = func
 
@@ -217,7 +217,7 @@ class CustomPredicate(object):
         return self.func(context, request)
 
 
-class TraversePredicate(object):
+class TraversePredicate:
     # Can only be used as a *route* "predicate"; it adds 'traverse' to the
     # matchdict if it's specified in the routing args.  This causes the
     # ResourceTreeTraverser to use the resolved traverse pattern as the
@@ -247,7 +247,7 @@ class TraversePredicate(object):
         return True
 
 
-class PhysicalPathPredicate(object):
+class PhysicalPathPredicate:
     def __init__(self, val, config):
         if is_nonstr_iter(val):
             self.val = tuple(val)
@@ -266,7 +266,7 @@ class PhysicalPathPredicate(object):
         return False
 
 
-class EffectivePrincipalsPredicate(object):
+class EffectivePrincipalsPredicate:
     def __init__(self, val, config):
         if is_nonstr_iter(val):
             self.val = set(val)
@@ -287,7 +287,7 @@ class EffectivePrincipalsPredicate(object):
         return False
 
 
-class Notted(object):
+class Notted:
     def __init__(self, predicate):
         self.predicate = predicate
 

--- a/src/pyramid/registry.py
+++ b/src/pyramid/registry.py
@@ -57,7 +57,7 @@ class Registry(Components, dict):
     def _clear_view_lookup_cache(self):
         self._view_lookup_cache = {}
 
-    def __nonzero__(self):
+    def __bool__(self):
         # defeat bool determination via dict.__len__
         return True
 
@@ -245,10 +245,8 @@ class Introspectable(dict):
             self.discriminator,
         )
 
-    def __nonzero__(self):
+    def __bool__(self):
         return True
-
-    __bool__ = __nonzero__  # py3
 
     def register(self, introspector, action_info):
         self.discriminator = undefer(self.discriminator)

--- a/src/pyramid/registry.py
+++ b/src/pyramid/registry.py
@@ -115,7 +115,7 @@ class Registry(Components, dict):
 
 
 @implementer(IIntrospector)
-class Introspector(object):
+class Introspector:
     def __init__(self):
         self._refs = {}
         self._categories = {}
@@ -266,7 +266,7 @@ class Introspectable(dict):
             )
 
 
-class Deferred(object):
+class Deferred:
     """ Can be used by a third-party configuration extender to wrap a
     :term:`discriminator` during configuration if an immediately hashable
     discriminator cannot be computed because it relies on unresolved values.

--- a/src/pyramid/renderers.py
+++ b/src/pyramid/renderers.py
@@ -177,7 +177,7 @@ def string_renderer_factory(info):
 _marker = object()
 
 
-class JSON(object):
+class JSON:
     """ Renderer that returns a JSON-encoded string.
 
     Configure a custom JSON renderer using the
@@ -243,7 +243,7 @@ class JSON(object):
 
         .. code-block:: python
 
-           class Foo(object):
+           class Foo:
                x = 5
 
            def foo_adapter(obj, request):
@@ -397,7 +397,7 @@ class JSONP(JSON):
 
 
 @implementer(IRendererInfo)
-class RendererHelper(object):
+class RendererHelper:
     def __init__(self, name=None, package=None, registry=None):
         if name and '.' in name:
             rtype = os.path.splitext(name)[1]

--- a/src/pyramid/request.py
+++ b/src/pyramid/request.py
@@ -26,11 +26,11 @@ from pyramid.util import (
 from pyramid.view import ViewMethodsMixin
 
 
-class TemplateContext(object):
+class TemplateContext:
     pass
 
 
-class CallbackMethodsMixin(object):
+class CallbackMethodsMixin:
     @reify
     def finished_callbacks(self):
         return deque()

--- a/src/pyramid/response.py
+++ b/src/pyramid/response.py
@@ -47,7 +47,7 @@ class FileResponse(Response):
     ):
         if content_type is None:
             content_type, content_encoding = _guess_type(path)
-        super(FileResponse, self).__init__(
+        super().__init__(
             conditional_response=True,
             content_type=content_type,
             content_encoding=content_encoding,

--- a/src/pyramid/response.py
+++ b/src/pyramid/response.py
@@ -69,7 +69,7 @@ class FileResponse(Response):
             self.cache_expires = cache_max_age
 
 
-class FileIter(object):
+class FileIter:
     """ A fixed-block-size iterator for use as a WSGI app_iter.
 
     ``file`` is a Python file pointer (or at least an object with a ``read``
@@ -95,7 +95,7 @@ class FileIter(object):
         self.file.close()
 
 
-class response_adapter(object):
+class response_adapter:
     """ Decorator activated via a :term:`scan` which treats the function
     being decorated as a :term:`response adapter` for the set of types or
     interfaces passed as ``*types_or_ifaces`` to the decorator constructor.

--- a/src/pyramid/router.py
+++ b/src/pyramid/router.py
@@ -27,7 +27,7 @@ from pyramid.view import _call_view
 
 
 @implementer(IRouter)
-class Router(object):
+class Router:
 
     debug_notfound = False
     debug_routematch = False

--- a/src/pyramid/scripts/prequest.py
+++ b/src/pyramid/scripts/prequest.py
@@ -13,7 +13,7 @@ def main(argv=sys.argv, quiet=False):
     return command.run()
 
 
-class PRequestCommand(object):
+class PRequestCommand:
     description = """\
     Submit a HTTP request to a web application.
 

--- a/src/pyramid/scripts/proutes.py
+++ b/src/pyramid/scripts/proutes.py
@@ -211,7 +211,7 @@ def get_route_data(route, registry):
     return final_routes
 
 
-class PRoutesCommand(object):
+class PRoutesCommand:
     description = """\
     Print all URL dispatch routes used by a Pyramid application in the
     order in which they are evaluated.  Each route includes the name of the

--- a/src/pyramid/scripts/pserve.py
+++ b/src/pyramid/scripts/pserve.py
@@ -30,7 +30,7 @@ def main(argv=sys.argv, quiet=False, original_ignore_files=None):
     return command.run()
 
 
-class PServeCommand(object):
+class PServeCommand:
 
     description = """\
     This command serves a web application that uses a PasteDeploy

--- a/src/pyramid/scripts/pshell.py
+++ b/src/pyramid/scripts/pshell.py
@@ -24,7 +24,7 @@ def python_shell_runner(env, help, interact=interact):
     interact(banner, local=env)
 
 
-class PShellCommand(object):
+class PShellCommand:
     description = """\
     Open an interactive shell with a Pyramid app loaded.  This command
     accepts one positional argument named "config_uri" which specifies the

--- a/src/pyramid/scripts/ptweens.py
+++ b/src/pyramid/scripts/ptweens.py
@@ -13,7 +13,7 @@ def main(argv=sys.argv, quiet=False):
     return command.run()
 
 
-class PTweensCommand(object):
+class PTweensCommand:
     description = """\
     Print all implicit and explicit tween objects used by a Pyramid
     application.  The handler output includes whether the system is using an

--- a/src/pyramid/scripts/pviews.py
+++ b/src/pyramid/scripts/pviews.py
@@ -14,7 +14,7 @@ def main(argv=sys.argv, quiet=False):
     return command.run()
 
 
-class PViewsCommand(object):
+class PViewsCommand:
     description = """\
     Print, for a given URL, the views that might match. Underneath each
     potentially matching route, list the predicates required. Underneath
@@ -102,7 +102,7 @@ class PViewsCommand(object):
         adapters = registry.adapters
 
         @implementer(IMultiView)
-        class RoutesMultiView(object):
+        class RoutesMultiView:
             def __init__(self, infos, context_iface, root_factory, request):
                 self.views = []
                 for info in infos:

--- a/src/pyramid/security.py
+++ b/src/pyramid/security.py
@@ -272,7 +272,7 @@ class SecurityAPIMixin:
         return policy.permits(self, context, permission)
 
 
-class AuthenticationAPIMixin(object):
+class AuthenticationAPIMixin:
     """ Mixin for Request class providing compatibility properties. """
 
     @property
@@ -390,7 +390,7 @@ Allow = 'Allow'
 Deny = 'Deny'
 
 
-class AllPermissionsList(object):
+class AllPermissionsList:
     """ Stand in 'permission list' to represent all permissions """
 
     def __iter__(self):

--- a/src/pyramid/session.py
+++ b/src/pyramid/session.py
@@ -39,7 +39,7 @@ def manage_changed(wrapped):
     return changed
 
 
-class PickleSerializer(object):
+class PickleSerializer:
     """
     .. deprecated:: 2.0
 

--- a/src/pyramid/static.py
+++ b/src/pyramid/static.py
@@ -327,7 +327,7 @@ class QueryStringConstantCacheBuster(QueryStringCacheBuster):
     """
 
     def __init__(self, token, param='x'):
-        super(QueryStringConstantCacheBuster, self).__init__(param=param)
+        super().__init__(param=param)
         self._token = token
 
     def tokenize(self, request, subpath, kw):

--- a/src/pyramid/static.py
+++ b/src/pyramid/static.py
@@ -13,7 +13,7 @@ from pyramid.response import FileResponse, _guess_type
 from pyramid.traversal import traversal_path_info
 
 
-class static_view(object):
+class static_view:
     """ An instance of this class is a callable which can act as a
     :app:`Pyramid` :term:`view callable`; this view will serve
     static files from a directory on disk based on the ``root_dir``
@@ -285,7 +285,7 @@ def _secure_path(path_tuple):
     return encoded
 
 
-class QueryStringCacheBuster(object):
+class QueryStringCacheBuster:
     """
     An implementation of :class:`~pyramid.interfaces.ICacheBuster` which adds
     a token for cache busting in the query string of an asset URL.
@@ -334,7 +334,7 @@ class QueryStringConstantCacheBuster(QueryStringCacheBuster):
         return self._token
 
 
-class ManifestCacheBuster(object):
+class ManifestCacheBuster:
     """
     An implementation of :class:`~pyramid.interfaces.ICacheBuster` which
     uses a supplied manifest file to map an asset path to a cache-busted

--- a/src/pyramid/testing.py
+++ b/src/pyramid/testing.py
@@ -203,10 +203,8 @@ class DummyResource:
 
     __iter__ = keys
 
-    def __nonzero__(self):
+    def __bool__(self):
         return True
-
-    __bool__ = __nonzero__
 
     def __len__(self):
         return len(self.subs)

--- a/src/pyramid/testing.py
+++ b/src/pyramid/testing.py
@@ -21,7 +21,7 @@ from pyramid.view import ViewMethodsMixin
 _marker = object()
 
 
-class DummyRootFactory(object):
+class DummyRootFactory:
     __parent__ = None
     __name__ = None
 
@@ -30,7 +30,7 @@ class DummyRootFactory(object):
             self.__dict__.update(request['bfg.routes.matchdict'])
 
 
-class DummySecurityPolicy(object):
+class DummySecurityPolicy:
     """ A standin for a :term:`security policy`."""
 
     def __init__(
@@ -69,7 +69,7 @@ class DummySecurityPolicy(object):
         return self.forget_result
 
 
-class DummyTemplateRenderer(object):
+class DummyTemplateRenderer:
     """
     An instance of this class is returned from
     :meth:`pyramid.config.Configurator.testing_add_renderer`.  It has a
@@ -555,7 +555,7 @@ def cleanUp(*arg, **kw):
     return setUp(*arg, **kw)
 
 
-class DummyRendererFactory(object):
+class DummyRendererFactory:
     """ Registered by
     :meth:`pyramid.config.Configurator.testing_add_renderer` as
     a dummy renderer factory.  The indecision about what to use as a
@@ -592,7 +592,7 @@ class DummyRendererFactory(object):
         return renderer
 
 
-class MockTemplate(object):
+class MockTemplate:
     def __init__(self, response):
         self._received = {}
         self.response = response

--- a/src/pyramid/threadlocal.py
+++ b/src/pyramid/threadlocal.py
@@ -71,7 +71,7 @@ def get_current_registry(
     return manager.get()['registry']
 
 
-class RequestContext(object):
+class RequestContext:
     def __init__(self, request):
         self.request = request
 

--- a/src/pyramid/traversal.py
+++ b/src/pyramid/traversal.py
@@ -580,7 +580,7 @@ def quote_path_segment(segment, safe=PATH_SEGMENT_SAFE):
 
 
 @implementer(ITraverser)
-class ResourceTreeTraverser(object):
+class ResourceTreeTraverser:
     """ A resource tree traverser that should be used (for speed) when
     every resource in the tree supplies a ``__name__`` and
     ``__parent__`` attribute (ie. every resource in the tree is
@@ -711,7 +711,7 @@ ModelGraphTraverser = (
 
 
 @implementer(IResourceURL)
-class ResourceURL(object):
+class ResourceURL:
     VH_ROOT_KEY = VH_ROOT_KEY
 
     def __init__(self, resource, request):

--- a/src/pyramid/url.py
+++ b/src/pyramid/url.py
@@ -56,7 +56,7 @@ def parse_url_overrides(request, kw):
     return app_url, qs, frag
 
 
-class URLMethodsMixin(object):
+class URLMethodsMixin:
     """ Request methods mixin for BaseRequest having to do with URL
     generation """
 

--- a/src/pyramid/urldispatch.py
+++ b/src/pyramid/urldispatch.py
@@ -10,7 +10,7 @@ _marker = object()
 
 
 @implementer(IRoute)
-class Route(object):
+class Route:
     def __init__(
         self, name, pattern, factory=None, predicates=(), pregenerator=None
     ):
@@ -24,7 +24,7 @@ class Route(object):
 
 
 @implementer(IRoutesMapper)
-class RoutesMapper(object):
+class RoutesMapper:
     def __init__(self):
         self.routelist = []
         self.static_routes = []

--- a/src/pyramid/util.py
+++ b/src/pyramid/util.py
@@ -73,7 +73,7 @@ def as_sorted_tuple(val):
     return val
 
 
-class SettableProperty(object):
+class SettableProperty:
     # this is just like reify but does not store the computed result on
     # the class such that subsequent invocations invoke the callable again
     def __init__(self, wrapped):
@@ -86,7 +86,7 @@ class SettableProperty(object):
         return self.wrapped(obj)
 
 
-class InstancePropertyHelper(object):
+class InstancePropertyHelper:
     """A helper object for assigning properties and descriptors to instances.
     It is not normally possible to do this because descriptors must be
     defined on the class itself.
@@ -187,7 +187,7 @@ class InstancePropertyHelper(object):
             self.apply_properties(target, self.properties)
 
 
-class InstancePropertyMixin(object):
+class InstancePropertyMixin:
     """ Mixin that will allow an instance to add properties at
     run-time as if they had been defined via @property or @reify
     on the class itself.
@@ -250,7 +250,7 @@ class InstancePropertyMixin(object):
         )
 
 
-class WeakOrderedSet(object):
+class WeakOrderedSet:
     """ Maintain a set of items.
 
     Each item is stored as a weakref to avoid extending their lifetime.
@@ -410,7 +410,7 @@ def shortrepr(object, closer):
     return r
 
 
-class Sentinel(object):
+class Sentinel:
     def __init__(self, repr):
         self.repr = repr
 
@@ -422,7 +422,7 @@ FIRST = Sentinel('FIRST')
 LAST = Sentinel('LAST')
 
 
-class TopologicalSorter(object):
+class TopologicalSorter:
     """ A utility class which can be used to perform topological sorts against
     tuple-like data."""
 
@@ -695,7 +695,7 @@ def takes_one_arg(callee, attr=None, argname=None):
     return False
 
 
-class SimpleSerializer(object):
+class SimpleSerializer:
     def loads(self, bstruct):
         return text_(bstruct)
 

--- a/src/pyramid/view.py
+++ b/src/pyramid/view.py
@@ -135,7 +135,7 @@ def render_view(context, request, name='', secure=True):
     return b''.join(iterable)
 
 
-class view_config(object):
+class view_config:
     """ A function, class or method :term:`decorator` which allows a
     developer to create view registrations nearer to a :term:`view
     callable` definition than use :term:`imperative
@@ -261,7 +261,7 @@ def view_defaults(**settings):
     return wrap
 
 
-class AppendSlashNotFoundViewFactory(object):
+class AppendSlashNotFoundViewFactory:
     """ There can only be one :term:`Not Found view` in any
     :app:`Pyramid` application.  Even if you use
     :func:`pyramid.view.append_slash_notfound_view` as the Not
@@ -348,7 +348,7 @@ view as the Not Found view::
 """
 
 
-class notfound_view_config(object):
+class notfound_view_config:
     """
     .. versionadded:: 1.3
 
@@ -444,7 +444,7 @@ class notfound_view_config(object):
         return wrapped
 
 
-class forbidden_view_config(object):
+class forbidden_view_config:
     """
     .. versionadded:: 1.3
 
@@ -508,7 +508,7 @@ class forbidden_view_config(object):
         return wrapped
 
 
-class exception_view_config(object):
+class exception_view_config:
     """
     .. versionadded:: 1.8
 
@@ -666,7 +666,7 @@ def _call_view(
     return response
 
 
-class ViewMethodsMixin(object):
+class ViewMethodsMixin:
     """ Request methods mixin for BaseRequest having to do with executing
     views """
 

--- a/src/pyramid/viewderivers.py
+++ b/src/pyramid/viewderivers.py
@@ -39,7 +39,7 @@ def requestonly(view, attr=None):
 
 @implementer(IViewMapper)
 @provider(IViewMapperFactory)
-class DefaultViewMapper(object):
+class DefaultViewMapper:
     def __init__(self, **kw):
         self.attr = kw.get('attr')
 

--- a/tests/pkgs/eventonly/__init__.py
+++ b/tests/pkgs/eventonly/__init__.py
@@ -2,7 +2,7 @@ from pyramid.events import subscriber
 from pyramid.view import view_config
 
 
-class Yup(object):
+class Yup:
     def __init__(self, val, config):
         self.val = val
 
@@ -15,12 +15,12 @@ class Yup(object):
         return getattr(event.response, 'yup', False)
 
 
-class Foo(object):
+class Foo:
     def __init__(self, response):
         self.response = response
 
 
-class Bar(object):
+class Bar:
     pass
 
 

--- a/tests/pkgs/exceptionviewapp/models.py
+++ b/tests/pkgs/exceptionviewapp/models.py
@@ -1,4 +1,4 @@
-class NotAnException(object):
+class NotAnException:
     pass
 
 
@@ -6,11 +6,11 @@ class AnException(Exception):
     pass
 
 
-class RouteContext(object):
+class RouteContext:
     pass
 
 
-class RouteContext2(object):
+class RouteContext2:
     pass
 
 

--- a/tests/pkgs/restbugapp/views.py
+++ b/tests/pkgs/restbugapp/views.py
@@ -11,7 +11,7 @@ class PetRESTView(BaseRESTView):
     """ REST Controller to control action of an avatar """
 
     def __init__(self, context, request):
-        super(PetRESTView, self).__init__(context, request)
+        super().__init__(context, request)
 
     def GET(self):
         return Response('gotten')

--- a/tests/pkgs/restbugapp/views.py
+++ b/tests/pkgs/restbugapp/views.py
@@ -1,7 +1,7 @@
 from pyramid.response import Response
 
 
-class BaseRESTView(object):
+class BaseRESTView:
     def __init__(self, context, request):
         self.context = context
         self.request = request

--- a/tests/pkgs/staticpermapp/__init__.py
+++ b/tests/pkgs/staticpermapp/__init__.py
@@ -1,11 +1,11 @@
-class RootFactory(object):
+class RootFactory:
     __acl__ = [('Allow', 'fred', 'view')]
 
     def __init__(self, request):
         pass
 
 
-class LocalRootFactory(object):
+class LocalRootFactory:
     __acl__ = [('Allow', 'bob', 'view')]
 
     def __init__(self, request):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1962,7 +1962,7 @@ class DummyContext:
     pass
 
 
-class DummyCookies(object):
+class DummyCookies:
     def __init__(self, cookie):
         self.cookie = cookie
 
@@ -2007,7 +2007,7 @@ class DummyCookieHelper:
         return []
 
 
-class DummyAuthTktModule(object):
+class DummyAuthTktModule:
     def __init__(
         self,
         timestamp=0,
@@ -2034,7 +2034,7 @@ class DummyAuthTktModule(object):
 
         self.parse_ticket = parse_ticket
 
-        class AuthTicket(object):
+        class AuthTicket:
             def __init__(self, secret, userid, remote_addr, **kw):
                 self.secret = secret
                 self.userid = userid

--- a/tests/test_config/__init__.py
+++ b/tests/test_config/__init__.py
@@ -33,7 +33,7 @@ class DummyContext:
 
 
 @implementer(IFactory)
-class DummyFactory(object):
+class DummyFactory:
     def __call__(self):
         """ """
 
@@ -61,7 +61,7 @@ def dummy_extend2(config, discrim):
 dummy_partial = partial(dummy_extend, discrim='partial')
 
 
-class DummyCallable(object):
+class DummyCallable:
     def __call__(self, config, discrim):
         config.action(discrim, None, config.package)
 

--- a/tests/test_config/pkgs/scannable/__init__.py
+++ b/tests/test_config/pkgs/scannable/__init__.py
@@ -18,7 +18,7 @@ def stacked(context, request):
     return 'stacked'
 
 
-class stacked_class(object):
+class stacked_class:
     def __init__(self, context, request):
         self.context = context
         self.request = request
@@ -49,7 +49,7 @@ oldstyle_grokked_class = view_config(
 )(oldstyle_grokked_class)
 
 
-class grokked_class(object):
+class grokked_class:
     def __init__(self, context, request):
         self.context = context
         self.request = request
@@ -63,7 +63,7 @@ grokked_class = view_config(name='grokked_class', renderer=null_renderer)(
 )
 
 
-class Foo(object):
+class Foo:
     def __call__(self, context, request):
         return 'grokked_instance'
 
@@ -74,7 +74,7 @@ grokked_instance = view_config(
 )(grokked_instance)
 
 
-class Base(object):
+class Base:
     @view_config(name='basemethod', renderer=null_renderer)
     def basemethod(self):
         """ """
@@ -109,7 +109,7 @@ def stuff():
     """ """
 
 
-class Whatever(object):
+class Whatever:
     pass
 
 

--- a/tests/test_config/pkgs/scannable/another.py
+++ b/tests/test_config/pkgs/scannable/another.py
@@ -18,7 +18,7 @@ def stacked(context, request):
     return 'another_stacked'
 
 
-class stacked_class(object):
+class stacked_class:
     def __init__(self, context, request):
         self.context = context
         self.request = request
@@ -49,7 +49,7 @@ oldstyle_grokked_class = view_config(
 )(oldstyle_grokked_class)
 
 
-class grokked_class(object):
+class grokked_class:
     def __init__(self, context, request):
         self.context = context
         self.request = request
@@ -63,7 +63,7 @@ grokked_class = view_config(
 )(grokked_class)
 
 
-class Foo(object):
+class Foo:
     def __call__(self, context, request):
         return 'another_grokked_instance'
 

--- a/tests/test_config/test_actions.py
+++ b/tests/test_config/test_actions.py
@@ -1072,7 +1072,7 @@ def _conflictFunctions(e):
             yield confinst.function
 
 
-class DummyActionState(object):
+class DummyActionState:
     autocommit = False
     info = ''
 
@@ -1083,7 +1083,7 @@ class DummyActionState(object):
         self.actions.append((arg, kw))
 
 
-class DummyIntrospectable(object):
+class DummyIntrospectable:
     def __init__(self):
         self.registered = []
 

--- a/tests/test_config/test_adapters.py
+++ b/tests/test_config/test_adapters.py
@@ -244,7 +244,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
 
         config = self._makeOne(autocommit=True)
 
-        class Adapter(object):
+        class Adapter:
             def __init__(self, other):
                 self.other = other
 
@@ -257,7 +257,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
 
         config = self._makeOne(autocommit=True)
 
-        class Adapter(object):
+        class Adapter:
             pass
 
         config.add_response_adapter(None, Adapter)
@@ -396,23 +396,23 @@ class Test_eventonly(unittest.TestCase):
         self.assertTrue(self._callFUT(acallable))
 
 
-class DummyTraverser(object):
+class DummyTraverser:
     def __init__(self, root):
         self.root = root
 
 
-class DummyIface(object):
+class DummyIface:
     pass
 
 
-class DummyResourceURL(object):
+class DummyResourceURL:
     def __init__(self, resource, request):
         self.resource = resource
         self.request = request
 
 
 def predicate_maker(name):
-    class Predicate(object):
+    class Predicate:
         def __init__(self, val, config):
             self.val = val
 

--- a/tests/test_config/test_assets.py
+++ b/tests/test_config/test_assets.py
@@ -820,7 +820,7 @@ class TestPackageOverrides(unittest.TestCase):
         self.assertEqual(loader._got_source, 'whatever')
 
 
-class AssetSourceIntegrationTests(object):
+class AssetSourceIntegrationTests:
     def test_get_filename(self):
         source = self._makeOne('')
         self.assertEqual(

--- a/tests/test_config/test_init.py
+++ b/tests/test_config/test_init.py
@@ -435,10 +435,10 @@ class ConfiguratorTests(unittest.TestCase):
             pass
 
         @implementer(IFoo)
-        class Foo(object):
+        class Foo:
             pass
 
-        class Bar(object):
+        class Bar:
             pass
 
         adaptation = ()
@@ -925,7 +925,7 @@ test_config.dummy_include2"""
 
         config = self._makeOne()
 
-        class DummyInspect(object):
+        class DummyInspect:
             def getmodule(self, c):
                 return inspect.getmodule(c)
 
@@ -1419,7 +1419,7 @@ class DummyRequest:
         self.cookies = {}
 
 
-class DummyThreadLocalManager(object):
+class DummyThreadLocalManager:
     def __init__(self):
         self.pushed = {'registry': None, 'request': None}
         self.popped = False
@@ -1434,7 +1434,7 @@ class DummyThreadLocalManager(object):
         self.popped = True
 
 
-class DummyRegistry(object):
+class DummyRegistry:
     def __init__(self, adaptation=None, util=None):
         self.utilities = []
         self.adapters = []
@@ -1458,5 +1458,5 @@ class DummyRegistry(object):
         return self.util
 
 
-class DummyPredicate(object):
+class DummyPredicate:
     pass

--- a/tests/test_config/test_predicates.py
+++ b/tests/test_config/test_predicates.py
@@ -200,7 +200,7 @@ class TestPredicateList(unittest.TestCase):
     def test_different_custom_predicates_with_same_hash(self):
         from pyramid.config.predicates import predvalseq
 
-        class PredicateWithHash(object):
+        class PredicateWithHash:
             def __hash__(self):
                 return 1
 
@@ -443,7 +443,7 @@ class Test_sort_accept_offers(unittest.TestCase):
         )
 
 
-class DummyCustomPredicate(object):
+class DummyCustomPredicate:
     def __init__(self):
         self.__text__ = 'custom predicate'
 
@@ -458,7 +458,7 @@ class DummyCustomPredicate(object):
         pass  # pragma: no cover
 
 
-class Dummy(object):
+class Dummy:
     def __init__(self, **kw):
         self.__dict__.update(**kw)
 
@@ -475,7 +475,7 @@ class DummyRequest:
         self.cookies = {}
 
 
-class DummyConfigurator(object):
+class DummyConfigurator:
     package = 'dummy package'
     registry = 'dummy registry'
 

--- a/tests/test_config/test_routes.py
+++ b/tests/test_config/test_routes.py
@@ -332,7 +332,7 @@ class DummyRequest:
         self.cookies = {}
 
 
-class DummyAccept(object):
+class DummyAccept:
     def __init__(self, *matches, **kw):
         self.matches = list(matches)
         self.contains = kw.pop('contains', False)

--- a/tests/test_config/test_tweens.py
+++ b/tests/test_config/test_tweens.py
@@ -117,7 +117,7 @@ class TestTweensConfiguratorMixin(unittest.TestCase):
     def test_add_tween_instance(self):
         from pyramid.exceptions import ConfigurationError
 
-        class ATween(object):
+        class ATween:
             pass
 
         atween = ATween()

--- a/tests/test_config/test_views.py
+++ b/tests/test_config/test_views.py
@@ -1322,13 +1322,13 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from pyramid.renderers import null_renderer as nr
         from pyramid.router import Router
 
-        class OtherBase(object):
+        class OtherBase:
             pass
 
-        class Int1(object):
+        class Int1:
             pass
 
-        class Int2(object):
+        class Int2:
             pass
 
         class Resource(OtherBase, Int1, Int2):
@@ -1370,13 +1370,13 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from pyramid.renderers import null_renderer as nr
         from pyramid.router import Router
 
-        class OtherBase(object):
+        class OtherBase:
             pass
 
-        class Int1(object):
+        class Int1:
             pass
 
-        class Int2(object):
+        class Int2:
             pass
 
         class Resource(OtherBase, Int1, Int2):
@@ -1433,11 +1433,11 @@ class TestViewsConfigurationMixin(unittest.TestCase):
             pass
 
         @implementer(IFoo)
-        class Foo(object):
+        class Foo:
             pass
 
         @implementer(IBar)
-        class Bar(object):
+        class Bar:
             pass
 
         foo = Foo()
@@ -1468,7 +1468,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from tests import test_config
         from pyramid.interfaces import ISettings
 
-        class view(object):
+        class view:
             def __init__(self, context, request):
                 self.request = request
                 self.context = context
@@ -1494,7 +1494,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(result.settings, settings)
 
     def test_add_view_with_default_renderer(self):
-        class view(object):
+        class view:
             def __init__(self, context, request):
                 self.request = request
                 self.context = context
@@ -1504,7 +1504,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
         config = self._makeOne(autocommit=True)
 
-        class moo(object):
+        class moo:
             def __init__(self, *arg, **kw):
                 pass
 
@@ -2042,7 +2042,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         view1 = lambda *arg: 'OK'
         outerself = self
 
-        class DummyPolicy(object):
+        class DummyPolicy:
             def permits(self, r, context, permission):
                 outerself.assertEqual(r, request)
                 outerself.assertEqual(context, None)
@@ -2062,7 +2062,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         view1 = lambda *arg: 'OK'
         outerself = self
 
-        class DummyPolicy(object):
+        class DummyPolicy:
             def permits(self, r, context, permission):
                 outerself.assertEqual(r, request)
                 outerself.assertEqual(context, None)
@@ -2083,7 +2083,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
         view1 = lambda *arg: 'OK'
 
-        class DummyPolicy(object):
+        class DummyPolicy:
             pass  # wont be called
 
         policy = DummyPolicy()
@@ -2100,7 +2100,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
     def test_add_view_with_mapper(self):
         from pyramid.renderers import null_renderer
 
-        class Mapper(object):
+        class Mapper:
             def __init__(self, **kw):
                 self.__class__.kw = kw
 
@@ -2122,7 +2122,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from pyramid.exceptions import PredicateMismatch
         from zope.interface import directlyProvides
 
-        class view(object):
+        class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
 
             def __init__(self, request):
@@ -2183,10 +2183,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
     def test_add_view_with_view_config_and_view_defaults_doesnt_conflict(self):
         from pyramid.renderers import null_renderer
 
-        class view(object):
+        class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
 
-        class view2(object):
+        class view2:
             __view_defaults__ = {'containment': 'tests.test_config.IFactory'}
 
         config = self._makeOne(autocommit=False)
@@ -2197,10 +2197,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
     def test_add_view_with_view_config_and_view_defaults_conflicts(self):
         from pyramid.renderers import null_renderer
 
-        class view(object):
+        class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
 
-        class view2(object):
+        class view2:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
 
         config = self._makeOne(autocommit=False)
@@ -2214,7 +2214,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
         config = self._makeOne(autocommit=True)
 
-        class DummyViewClass(object):
+        class DummyViewClass:
             def run(self):  # pragma: no cover
                 pass
 
@@ -2261,7 +2261,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         view = lambda *arg: 'OK'
         config = self._makeOne(autocommit=True)
 
-        class NotAnException(object):
+        class NotAnException:
             pass
 
         self.assertRaises(
@@ -2353,7 +2353,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from zope.interface import directlyProvides
         from zope.interface import implementedBy
 
-        class view(object):
+        class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
 
             def __init__(self, request):
@@ -2401,7 +2401,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
     def test_derive_view_with_default_renderer_no_explicit_renderer(self):
         config = self._makeOne()
 
-        class moo(object):
+        class moo:
             def __init__(self, view):
                 pass
 
@@ -2419,10 +2419,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(result(None, None).body, b'moo')
 
     def test_derive_view_with_default_renderer_with_explicit_renderer(self):
-        class moo(object):
+        class moo:
             pass
 
-        class foo(object):
+        class foo:
             def __init__(self, view):
                 pass
 
@@ -2578,7 +2578,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from zope.interface import directlyProvides
         from zope.interface import implementedBy
 
-        class view(object):
+        class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
 
             def __init__(self, request):
@@ -2742,7 +2742,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         from zope.interface import directlyProvides
         from zope.interface import implementedBy
 
-        class view(object):
+        class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
 
             def __init__(self, request):
@@ -3020,7 +3020,7 @@ class Test_requestonly(unittest.TestCase):
         self.assertTrue(self._callFUT(aview))
 
     def test_otherattr(self):
-        class AView(object):
+        class AView:
             def __init__(self, request, a=1, b=2):  # pragma: no cover
                 pass
 
@@ -3465,7 +3465,7 @@ class TestDefaultViewMapper(unittest.TestCase):
         self.assertRaises(TypeError, result, None, request)
 
     def test_view_as_newstyle_class_context_and_request(self):
-        class view(object):
+        class view:
             def __init__(self, context, request):
                 pass
 
@@ -3479,7 +3479,7 @@ class TestDefaultViewMapper(unittest.TestCase):
         self.assertEqual(result(None, request), 'OK')
 
     def test_view_as_newstyle_class_context_and_request_with_attr(self):
-        class view(object):
+        class view:
             def __init__(self, context, request):
                 pass
 
@@ -3493,7 +3493,7 @@ class TestDefaultViewMapper(unittest.TestCase):
         self.assertEqual(result(None, request), 'OK')
 
     def test_view_as_newstyle_class_requestonly(self):
-        class view(object):
+        class view:
             def __init__(self, request):
                 pass
 
@@ -3507,7 +3507,7 @@ class TestDefaultViewMapper(unittest.TestCase):
         self.assertEqual(result(None, request), 'OK')
 
     def test_view_as_newstyle_class_requestonly_with_attr(self):
-        class view(object):
+        class view:
             def __init__(self, request):
                 pass
 
@@ -4185,7 +4185,7 @@ class DummyRegistry:
 
 
 @implementer(IResponse)
-class DummyResponse(object):
+class DummyResponse:
     content_type = None
     default_content_type = None
     body = None
@@ -4210,7 +4210,7 @@ class DummyContext:
     pass
 
 
-class DummyAccept(object):
+class DummyAccept:
     def __init__(self, *matches, **kw):
         self.matches = list(matches)
         self.contains = kw.pop('contains', False)
@@ -4260,7 +4260,7 @@ class DummyMultiView:
         """ """
 
 
-class DummyCacheBuster(object):
+class DummyCacheBuster:
     def __init__(self, token):
         self.token = token
 
@@ -4293,7 +4293,7 @@ class DummyStaticURLInfo:
         self.added.append((config, name, spec, kw))
 
 
-class DummyViewDefaultsClass(object):
+class DummyViewDefaultsClass:
     __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
 
     def __init__(self, request):
@@ -4303,7 +4303,7 @@ class DummyViewDefaultsClass(object):
         return 'OK'
 
 
-class DummyPredicate(object):
+class DummyPredicate:
     def __init__(self, val, config):
         self.val = val
 
@@ -4313,7 +4313,7 @@ class DummyPredicate(object):
     phash = text
 
 
-class DummyIntrospector(object):
+class DummyIntrospector:
     def __init__(self, getval=None):
         self.related = []
         self.introspectables = []

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -5,7 +5,7 @@ from pyramid.config import Configurator
 
 
 class TestLegacySessionCSRFStoragePolicy(unittest.TestCase):
-    class MockSession(object):
+    class MockSession:
         def __init__(self, current_token='02821185e4c94269bdc38e6eeae0a2f8'):
             self.current_token = current_token
 
@@ -455,7 +455,7 @@ class Test_check_csrf_origin(unittest.TestCase):
         self.assertFalse(self._callFUT(request, raises=False))
 
 
-class DummyRequest(object):
+class DummyRequest:
     registry = None
     session = None
     response_callback = None
@@ -469,12 +469,12 @@ class DummyRequest(object):
         self.response_callback = callback
 
 
-class MockResponse(object):
+class MockResponse:
     def __init__(self):
         self.headerlist = []
 
 
-class DummyCSRF(object):
+class DummyCSRF:
     def new_csrf_token(self, request):
         return 'e5e9e30a08b34ff9842ff7d2b958c14b'
 

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -215,7 +215,7 @@ class Test_get_csrf_token(unittest.TestCase):
 
         csrf_token = self._callFUT(request)
 
-        self.assertEquals(csrf_token, '02821185e4c94269bdc38e6eeae0a2f8')
+        self.assertEqual(csrf_token, '02821185e4c94269bdc38e6eeae0a2f8')
 
 
 class Test_new_csrf_token(unittest.TestCase):
@@ -237,7 +237,7 @@ class Test_new_csrf_token(unittest.TestCase):
 
         csrf_token = self._callFUT(request)
 
-        self.assertEquals(csrf_token, 'e5e9e30a08b34ff9842ff7d2b958c14b')
+        self.assertEqual(csrf_token, 'e5e9e30a08b34ff9842ff7d2b958c14b')
 
 
 class Test_check_csrf_token(unittest.TestCase):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -26,5 +26,5 @@ class TestReify(unittest.TestCase):
         self.assertEqual(result, decorator)
 
 
-class Dummy(object):
+class Dummy:
     pass

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -377,7 +377,7 @@ class TestBeforeRender(unittest.TestCase):
         self.assertTrue(event.rendering_val is val)
 
 
-class DummyConfigurator(object):
+class DummyConfigurator:
     def __init__(self):
         self.subscribed = []
 
@@ -388,11 +388,11 @@ class DummyConfigurator(object):
             self.subscribed.append((wrapped, ifaces, predicates))
 
 
-class DummyRegistry(object):
+class DummyRegistry:
     pass
 
 
-class DummyVenusian(object):
+class DummyVenusian:
     def __init__(self):
         self.attached = []
 

--- a/tests/test_httpexceptions.py
+++ b/tests/test_httpexceptions.py
@@ -74,7 +74,7 @@ class Test__no_escape(unittest.TestCase):
         )
 
     def test_unicode(self):
-        class DummyUnicodeObject(object):
+        class DummyUnicodeObject:
             def __unicode__(self):
                 return text_('42')
 
@@ -392,7 +392,7 @@ class TestHTTPException(unittest.TestCase):
         exc = cls(body_template='${REQUEST_METHOD}')
         environ = _makeEnviron()
 
-        class Choke(object):
+        class Choke:
             def __str__(self):  # pragma no cover
                 raise ValueError
 
@@ -514,11 +514,11 @@ class TestHTTPMethodNotAllowed(unittest.TestCase):
         )
 
 
-class DummyRequest(object):
+class DummyRequest:
     exception = None
 
 
-class DummyStartResponse(object):
+class DummyStartResponse:
     def __call__(self, status, headerlist):
         self.status = status
         self.headerlist = headerlist

--- a/tests/test_httpexceptions.py
+++ b/tests/test_httpexceptions.py
@@ -75,7 +75,7 @@ class Test__no_escape(unittest.TestCase):
 
     def test_unicode(self):
         class DummyUnicodeObject:
-            def __unicode__(self):
+            def __str__(self):
                 return text_('42')
 
         duo = DummyUnicodeObject()

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -532,7 +532,7 @@ class TestLocalizerRequestMixin(unittest.TestCase):
         self.assertEqual(result.translate('Approve', 'deformsite'), 'Approve')
 
 
-class DummyRequest(object):
+class DummyRequest:
     def __init__(self):
         self.params = {}
         self.cookies = {}
@@ -542,7 +542,7 @@ def dummy_negotiator(request):
     return 'bogus'
 
 
-class DummyTranslations(object):
+class DummyTranslations:
     def ugettext(self, text):
         return text
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -62,7 +62,7 @@ class WGSIAppPlusViewConfigTests(unittest.TestCase):
         self.assertEqual(view.__original_view__, wsgiapptest)
 
 
-class IntegrationBase(object):
+class IntegrationBase:
     root_factory = None
     package = None
 
@@ -966,7 +966,7 @@ class AcceptContentTypeTest(unittest.TestCase):
         self.assertEqual(res.content_type, 'text/x-fallback')
 
 
-class DummyContext(object):
+class DummyContext:
     pass
 
 

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -48,5 +48,5 @@ class TestLineage(unittest.TestCase):
 
 
 @implementer(ILocation)
-class Location(object):
+class Location:
     __name__ = __parent__ = None

--- a/tests/test_paster.py
+++ b/tests/test_paster.py
@@ -131,7 +131,7 @@ class Test_bootstrap(unittest.TestCase):
         self.app = app = DummyApp()
         self.root = root = Dummy()
 
-        class DummyGetApp(object):
+        class DummyGetApp:
             def __call__(self, *a, **kw):
                 self.a = a
                 self.kw = kw
@@ -139,7 +139,7 @@ class Test_bootstrap(unittest.TestCase):
 
         self.get_app = pyramid.paster.get_app = DummyGetApp()
 
-        class DummyPrepare(object):
+        class DummyPrepare:
             def __call__(self, *a, **kw):
                 self.a = a
                 self.kw = kw
@@ -166,7 +166,7 @@ class Dummy:
     pass
 
 
-class DummyRegistry(object):
+class DummyRegistry:
     settings = {}
 
 

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -68,10 +68,10 @@ class TestCallerModule(unittest.TestCase):
         self.assertNotEqual(result, test_path)
 
     def test_it_no___name__(self):
-        class DummyFrame(object):
+        class DummyFrame:
             f_globals = {}
 
-        class DummySys(object):
+        class DummySys:
             def _getframe(self, level):
                 return DummyFrame()
 
@@ -627,7 +627,7 @@ class TestDottedNameResolver(unittest.TestCase):
         self.assertEqual(typ.package, None)
 
 
-class DummyPkgResource(object):
+class DummyPkgResource:
     pass
 
 

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -537,7 +537,7 @@ class TestNotted(unittest.TestCase):
         self.assertEqual(inst(None, None), True)
 
 
-class predicate(object):
+class predicate:
     def __repr__(self):
         return 'predicate'
 
@@ -545,11 +545,11 @@ class predicate(object):
         return 1
 
 
-class Dummy(object):
+class Dummy:
     pass
 
 
-class DummyPredicate(object):
+class DummyPredicate:
     def __init__(self, result):
         self.result = result
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -11,9 +11,9 @@ class TestRegistry(unittest.TestCase):
     def _makeOne(self, *args, **kw):
         return self._getTargetClass()(*args, **kw)
 
-    def test___nonzero__(self):
+    def test___bool__(self):
         registry = self._makeOne()
-        self.assertEqual(registry.__nonzero__(), True)
+        self.assertEqual(registry.__bool__(), True)
 
     def test__lock(self):
         registry = self._makeOne()
@@ -379,10 +379,6 @@ class TestIntrospectable(unittest.TestCase):
             repr(inst),
             "<Introspectable category 'category', discriminator 'discrim'>",
         )
-
-    def test___nonzero__(self):
-        inst = self._makeOnePopulated()
-        self.assertEqual(inst.__nonzero__(), True)
 
     def test___bool__(self):
         inst = self._makeOnePopulated()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -407,7 +407,7 @@ class TestIntrospectable(unittest.TestCase):
         )
 
 
-class DummyIntrospector(object):
+class DummyIntrospector:
     def __init__(self):
         self.intrs = []
         self.relations = []
@@ -429,7 +429,7 @@ class DummyModule:
     __file__ = ''
 
 
-class DummyIntrospectable(object):
+class DummyIntrospectable:
     category_name = 'category'
     discriminator = 'discriminator'
     title = 'title'
@@ -447,5 +447,5 @@ class IDummyEvent(Interface):
 
 
 @implementer(IDummyEvent)
-class DummyEvent(object):
+class DummyEvent:
     pass

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -63,7 +63,7 @@ class TestJSON(unittest.TestCase):
         self.assertEqual(result, '{"a": "%s"}' % now.isoformat())
 
     def test_with_custom_serializer(self):
-        class Serializer(object):
+        class Serializer:
             def __call__(self, obj, **kw):
                 self.obj = obj
                 self.kw = kw
@@ -82,7 +82,7 @@ class TestJSON(unittest.TestCase):
         request = testing.DummyRequest()
         outerself = self
 
-        class MyObject(object):
+        class MyObject:
             def __init__(self, x):
                 self.x = x
 
@@ -96,7 +96,7 @@ class TestJSON(unittest.TestCase):
         self.assertEqual(result, '[{"x": 1}, {"x": 2}]')
 
     def test_with_object_adapter_no___json__(self):
-        class MyObject(object):
+        class MyObject:
             def __init__(self, x):
                 self.x = x
 
@@ -163,14 +163,14 @@ class TestRendererHelper(unittest.TestCase):
         verifyObject(IRendererInfo, helper)
 
     def test_settings_registry_settings_is_None(self):
-        class Dummy(object):
+        class Dummy:
             settings = None
 
         helper = self._makeOne(registry=Dummy)
         self.assertEqual(helper.settings, {})
 
     def test_settings_registry_name_is_None(self):
-        class Dummy(object):
+        class Dummy:
             settings = None
 
         helper = self._makeOne(registry=Dummy)
@@ -178,7 +178,7 @@ class TestRendererHelper(unittest.TestCase):
         self.assertEqual(helper.type, '')
 
     def test_settings_registry_settings_is_not_None(self):
-        class Dummy(object):
+        class Dummy:
             settings = {'a': 1}
 
         helper = self._makeOne(registry=Dummy)
@@ -202,7 +202,7 @@ class TestRendererHelper(unittest.TestCase):
     def _registerResponseFactory(self):
         from pyramid.interfaces import IResponseFactory
 
-        class ResponseFactory(object):
+        class ResponseFactory:
             pass
 
         self.config.registry.registerUtility(
@@ -254,7 +254,7 @@ class TestRendererHelper(unittest.TestCase):
     def test_render_explicit_registry(self):
         factory = self._registerRendererFactory()
 
-        class DummyRegistry(object):
+        class DummyRegistry:
             def __init__(self):
                 self.responses = [factory, lambda *arg: {}, None]
 
@@ -372,7 +372,7 @@ class TestRendererHelper(unittest.TestCase):
     def test_with_alternate_response_factory(self):
         from pyramid.interfaces import IResponseFactory
 
-        class ResponseFactory(object):
+        class ResponseFactory:
             def __init__(self):
                 pass
 
@@ -560,7 +560,7 @@ class Test_render(unittest.TestCase):
     def test_no_response_to_preserve(self):
         from pyramid.decorator import reify
 
-        class DummyRequestWithClassResponse(object):
+        class DummyRequestWithClassResponse:
             _response = DummyResponse()
             _response.content_type = None
             _response.default_content_type = None
@@ -639,7 +639,7 @@ class Test_render_to_response(unittest.TestCase):
     def test_no_response_to_preserve(self):
         from pyramid.decorator import reify
 
-        class DummyRequestWithClassResponse(object):
+        class DummyRequestWithClassResponse:
             _response = DummyResponse()
             _response.content_type = None
             _response.default_content_type = None
@@ -655,7 +655,7 @@ class Test_render_to_response(unittest.TestCase):
         self.assertFalse('response' in request.__dict__)
 
     def test_custom_response_object(self):
-        class DummyRequestWithClassResponse(object):
+        class DummyRequestWithClassResponse:
             pass
 
         request = DummyRequestWithClassResponse()

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -26,7 +26,7 @@ class TestRequest(unittest.TestCase):
         from pyramid.interfaces import IResourceURL
         from zope.interface import Interface
 
-        class DummyResourceURL(object):
+        class DummyResourceURL:
             def __init__(self, context, request):
                 self.physical_path = '/context/'
                 self.virtual_path = '/context/'
@@ -311,7 +311,7 @@ class TestRequest(unittest.TestCase):
         def adapter(ob):
             return object()
 
-        class Foo(object):
+        class Foo:
             pass
 
         foo = Foo()
@@ -324,7 +324,7 @@ class TestRequest(unittest.TestCase):
         request = self._makeOne()
         request.registry = self.config.registry
 
-        class Foo(object):
+        class Foo:
             pass
 
         foo = Foo()
@@ -695,11 +695,11 @@ class TestRequestLocalCache(unittest.TestCase):
         self.assertRaises(ValueError, cache.get_or_create, req)
 
 
-class Dummy(object):
+class Dummy:
     pass
 
 
-class DummyRequest(object):
+class DummyRequest:
     def __init__(self, environ=None):
         if environ is None:
             environ = {}

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -78,7 +78,7 @@ class TestFileResponse(unittest.TestCase):
         from pyramid import response
         from pyramid.util import text_
 
-        class FakeMimetypesModule(object):
+        class FakeMimetypesModule:
             def guess_type(self, *arg, **kw):
                 return text_('foo/bar'), None
 
@@ -218,11 +218,11 @@ class TestGetResponseFactory(unittest.TestCase):
         self.assertTrue(isinstance(response, Response))
 
 
-class Dummy(object):
+class Dummy:
     pass
 
 
-class DummyConfigurator(object):
+class DummyConfigurator:
     def __init__(self):
         self.adapters = []
 
@@ -230,7 +230,7 @@ class DummyConfigurator(object):
         self.adapters.append((wrapped, type_or_iface))
 
 
-class DummyVenusian(object):
+class DummyVenusian:
     def __init__(self):
         self.attached = []
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -153,7 +153,7 @@ class TestRouter(unittest.TestCase):
     def test_request_factory(self):
         from pyramid.interfaces import IRequestFactory
 
-        class DummyRequestFactory(object):
+        class DummyRequestFactory:
             pass
 
         self.registry.registerUtility(DummyRequestFactory, IRequestFactory)
@@ -378,7 +378,7 @@ class TestRouter(unittest.TestCase):
         context = DummyContext()
         self._registerTraverserFactory(context)
 
-        class Extensions(object):
+        class Extensions:
             def __init__(self):
                 self.methods = {}
                 self.descriptors = {}
@@ -1642,7 +1642,7 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result[1], None)
 
 
-class DummyPredicate(object):
+class DummyPredicate:
     def __call__(self, info, request):
         return True
 
@@ -1685,7 +1685,7 @@ class DummyStartResponse:
 
 
 @implementer(IResponse)
-class DummyResponse(object):
+class DummyResponse:
     headerlist = ()
     app_iter = ()
     environ = None

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -213,7 +213,7 @@ class Dummy:
 dummy_root = Dummy()
 
 
-class DummyFactory(object):
+class DummyFactory:
     @classmethod
     def blank(cls, path):
         req = DummyRequest({'path': path})
@@ -224,7 +224,7 @@ class DummyFactory(object):
         self.kw = kw
 
 
-class DummyRegistry(object):
+class DummyRegistry:
     def __init__(self, utilities):
         self.utilities = utilities
 
@@ -243,7 +243,7 @@ class DummyApp:
         return dummy_root
 
 
-class DummyRequest(object):
+class DummyRequest:
     matchdict = None
     matched_route = None
 

--- a/tests/test_scripts/dummy.py
+++ b/tests/test_scripts/dummy.py
@@ -3,7 +3,7 @@ from zope.interface import implementer
 from pyramid.interfaces import IMultiView
 
 
-class DummyTweens(object):
+class DummyTweens:
     def __init__(self, implicit, explicit):
         self._implicit = implicit
         self.explicit = explicit
@@ -20,7 +20,7 @@ class Dummy:
 dummy_root = Dummy()
 
 
-class DummyRegistry(object):
+class DummyRegistry:
     settings = {}
 
     def queryUtility(self, iface, default=None, name=''):
@@ -30,7 +30,7 @@ class DummyRegistry(object):
 dummy_registry = DummyRegistry()
 
 
-class DummyShell(object):
+class DummyShell:
     env = {}
     help = ''
     called = False
@@ -54,7 +54,7 @@ class DummyApp:
         self.registry = dummy_registry
 
 
-class DummyMapper(object):
+class DummyMapper:
     def __init__(self, *routes):
         self.routes = routes
 
@@ -62,7 +62,7 @@ class DummyMapper(object):
         return self.routes
 
 
-class DummyRoute(object):
+class DummyRoute:
     def __init__(
         self, name, pattern, factory=None, matchdict=None, predicate=None
     ):
@@ -91,7 +91,7 @@ class DummyRequest:
         self.matchdict = {}
 
 
-class DummyView(object):
+class DummyView:
     def __init__(self, **attrs):
         self.__request_attrs__ = attrs
 
@@ -100,18 +100,18 @@ class DummyView(object):
 
 
 @implementer(IMultiView)
-class DummyMultiView(object):
+class DummyMultiView:
     def __init__(self, *views, **attrs):
         self.views = [(None, view, None) for view in views]
         self.__request_attrs__ = attrs
 
 
-class DummyCloser(object):
+class DummyCloser:
     def __call__(self):
         self.called = True
 
 
-class DummyBootstrap(object):
+class DummyBootstrap:
     def __init__(
         self,
         app=None,
@@ -154,7 +154,7 @@ class DummyBootstrap(object):
         }
 
 
-class DummyEntryPoint(object):
+class DummyEntryPoint:
     def __init__(self, name, module):
         self.name = name
         self.module = module
@@ -163,7 +163,7 @@ class DummyEntryPoint(object):
         return self.module
 
 
-class DummyPkgResources(object):
+class DummyPkgResources:
     def __init__(self, entry_point_values):
         self.entry_points = []
 
@@ -174,13 +174,13 @@ class DummyPkgResources(object):
         return self.entry_points
 
 
-class dummy_setup_logging(object):
+class dummy_setup_logging:
     def __call__(self, config_uri, global_conf):
         self.config_uri = config_uri
         self.defaults = global_conf
 
 
-class DummyLoader(object):
+class DummyLoader:
     def __init__(
         self, settings=None, app_settings=None, app=None, server=None
     ):

--- a/tests/test_scripts/test_pdistreport.py
+++ b/tests/test_scripts/test_pdistreport.py
@@ -64,7 +64,7 @@ class TestPDistReportCommand(unittest.TestCase):
         )
 
 
-class DummyPkgResources(object):
+class DummyPkgResources:
     def __init__(self, working_set=()):
         self.working_set = working_set
 
@@ -72,12 +72,12 @@ class DummyPkgResources(object):
         return Version('1')
 
 
-class Version(object):
+class Version:
     def __init__(self, version):
         self.version = version
 
 
-class DummyDistribution(object):
+class DummyDistribution:
     def __init__(self, name):
         self.project_name = name
         self.version = '1'

--- a/tests/test_scripts/test_proutes.py
+++ b/tests/test_scripts/test_proutes.py
@@ -4,7 +4,7 @@ import unittest
 from . import dummy
 
 
-class DummyIntrospector(object):
+class DummyIntrospector:
     def __init__(self):
         self.relations = {}
         self.introspectables = {}

--- a/tests/test_scripts/test_pserve.py
+++ b/tests/test_scripts/test_pserve.py
@@ -137,10 +137,10 @@ class TestPServeCommand(unittest.TestCase):
         finally:
             pserve.hupper = orig_hupper
 
-        self.assertEquals(
+        self.assertEqual(
             dummy_start_reloader.args, ('pyramid.scripts.pserve.main',)
         )
-        self.assertEquals(
+        self.assertEqual(
             dummy_start_reloader.kwargs,
             {
                 'reload_interval': 1,

--- a/tests/test_scripts/test_pserve.py
+++ b/tests/test_scripts/test_pserve.py
@@ -119,7 +119,7 @@ class TestPServeCommand(unittest.TestCase):
 
         class AttrDict(dict):
             def __init__(self, *args, **kwargs):
-                super(AttrDict, self).__init__(*args, **kwargs)
+                super().__init__(*args, **kwargs)
                 self.__dict__ = self
 
         def dummy_start_reloader(*args, **kwargs):

--- a/tests/test_scripts/test_pshell.py
+++ b/tests/test_scripts/test_pshell.py
@@ -27,7 +27,7 @@ class TestPShellCommand(unittest.TestCase):
             cmd.get_config_loader = self.loader
         if patch_args:
 
-            class Args(object):
+            class Args:
                 pass
 
             self.args = Args()
@@ -35,7 +35,7 @@ class TestPShellCommand(unittest.TestCase):
             cmd.args.config_uri = self.args.config_uri
         if patch_options:
 
-            class Options(object):
+            class Options:
                 pass
 
             self.options = Options()

--- a/tests/test_scripts/test_pviews.py
+++ b/tests/test_scripts/test_pviews.py
@@ -51,7 +51,7 @@ class TestPViewsCommand(unittest.TestCase):
         registry = Registry()
 
         @implementer(IMultiView)
-        class View1(object):
+        class View1:
             pass
 
         request = dummy.DummyRequest()
@@ -105,7 +105,7 @@ class TestPViewsCommand(unittest.TestCase):
         registry = Registry()
 
         @implementer(IMultiView)
-        class View1(object):
+        class View1:
             pass
 
         request = dummy.DummyRequest()
@@ -147,7 +147,7 @@ class TestPViewsCommand(unittest.TestCase):
         registry.registerUtility(IMyRoute, IRouteRequest, name='a')
 
         @implementer(IMyRoot)
-        class Factory(object):
+        class Factory:
             def __init__(self, request):
                 pass
 
@@ -190,7 +190,7 @@ class TestPViewsCommand(unittest.TestCase):
         registry.registerUtility(IMyRoute2, IRouteRequest, name='b')
 
         @implementer(IMyRoot)
-        class Factory(object):
+        class Factory:
             def __init__(self, request):
                 pass
 
@@ -242,7 +242,7 @@ class TestPViewsCommand(unittest.TestCase):
         registry.registerUtility(IMyRoute2, IRouteRequest, name='b')
 
         @implementer(IMyRoot)
-        class Factory(object):
+        class Factory:
             def __init__(self, request):
                 pass
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -327,7 +327,7 @@ class TestAuthenticatedIdentity(unittest.TestCase):
 
     def test_identity_no_security_policy(self):
         request = _makeRequest()
-        self.assertEquals(request.authenticated_identity, None)
+        self.assertEqual(request.authenticated_identity, None)
 
     def test_identity(self):
         request = _makeRequest()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -248,7 +248,7 @@ class TestViewExecutionPermitted(unittest.TestCase):
         from pyramid.interfaces import ISecuredView
         from pyramid.interfaces import IViewClassifier
 
-        class Checker(object):
+        class Checker:
             def __permitted__(self, context, request):
                 self.context = context
                 self.request = request
@@ -277,7 +277,7 @@ class TestViewExecutionPermitted(unittest.TestCase):
         context = DummyContext()
         request = testing.DummyRequest({})
 
-        class DummyView(object):
+        class DummyView:
             pass
 
         view = DummyView()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,7 +6,7 @@ import unittest
 from pyramid import testing
 
 
-class SharedCookieSessionTests(object):
+class SharedCookieSessionTests:
     def test_ctor_no_cookie(self):
         request = testing.DummyRequest()
         session = self._makeOne(request)
@@ -603,11 +603,11 @@ class TestPickleSerializer(unittest.TestCase):
         self.assertIsInstance(result, bytes)
 
 
-class Dummy(object):
+class Dummy:
     pass
 
 
-class DummySerializer(object):
+class DummySerializer:
     def dumps(self, value):
         return base64.b64encode(json.dumps(value).encode('utf-8'))
 
@@ -634,6 +634,6 @@ class DummySessionFactory(dict):
         self._dirty = True
 
 
-class DummyResponse(object):
+class DummyResponse:
     def __init__(self):
         self.headerlist = []

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -132,7 +132,7 @@ class Test_static_view_use_subpath_False(unittest.TestCase):
         inst = self._makeOne('tests:fixtures/static')
         request = self._makeRequest({'PATH_INFO': '/index.html'})
 
-        class _Wrapper(object):
+        class _Wrapper:
             def __init__(self, file, block_size=None):
                 self.file = file
                 self.block_size = block_size

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -258,7 +258,7 @@ class TestDummyRequest(unittest.TestCase):
 
         registry = Registry('this_test')
 
-        class ResponseFactory(object):
+        class ResponseFactory:
             pass
 
         registry.registerUtility(lambda r: ResponseFactory(), IResponseFactory)
@@ -695,7 +695,7 @@ class DummyFactory:
         """ """
 
 
-class DummyRegistry(object):
+class DummyRegistry:
     inited = 0
     __name__ = 'name'
 
@@ -703,7 +703,7 @@ class DummyRegistry(object):
         self.inited = self.inited + 1
 
 
-class DummyRendererInfo(object):
+class DummyRendererInfo:
     def __init__(self, kw):
         self.__dict__.update(kw)
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -103,10 +103,6 @@ class TestDummyResource(unittest.TestCase):
         self.assertEqual(L(resource.keys()), L(resource.subs.keys()))
         self.assertEqual(len(resource), 2)
 
-    def test_nonzero(self):
-        resource = self._makeOne()
-        self.assertEqual(resource.__nonzero__(), True)
-
     def test_bool(self):
         resource = self._makeOne()
         self.assertEqual(resource.__bool__(), True)

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -506,7 +506,7 @@ class FindInterfaceTests(unittest.TestCase):
         self.assertEqual(result.__name__, 'root')
 
     def test_it_class(self):
-        class DummyRoot(object):
+        class DummyRoot:
             def __init__(self, child):
                 self.child = child
 
@@ -870,7 +870,7 @@ class QuotePathSegmentTests(unittest.TestCase):
         self.assertEqual(result, '12345')
 
     def test_other(self):
-        class Foo(object):
+        class Foo:
             def __str__(self):
                 return 'abc'
 
@@ -1188,7 +1188,7 @@ class TestDefaultRootFactory(unittest.TestCase):
         return self._getTargetClass()(environ)
 
     def test_it(self):
-        class DummyRequest(object):
+        class DummyRequest:
             pass
 
         root = self._makeOne(DummyRequest())
@@ -1235,7 +1235,7 @@ class Test__join_path_tuple(unittest.TestCase):
 
 
 def make_traverser(result):
-    class DummyTraverser(object):
+    class DummyTraverser:
         def __init__(self, context):
             self.context = context
             context.wascontext = True
@@ -1247,7 +1247,7 @@ def make_traverser(result):
     return DummyTraverser
 
 
-class DummyContext(object):
+class DummyContext:
     __parent__ = None
 
     def __init__(self, next=None, name=None):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -34,7 +34,7 @@ class TestURLMethodsMixin(unittest.TestCase):
         from pyramid.interfaces import IResourceURL
         from zope.interface import Interface
 
-        class DummyResourceURL(object):
+        class DummyResourceURL:
             physical_path = '/context/'
             virtual_path = '/context/'
 
@@ -1081,7 +1081,7 @@ class Test_route_url(unittest.TestCase):
         return route_url(route_name, request, *elements, **kw)
 
     def _makeRequest(self):
-        class Request(object):
+        class Request:
             def route_url(self, route_name, *elements, **kw):
                 self.route_name = route_name
                 self.elements = elements
@@ -1106,7 +1106,7 @@ class Test_route_path(unittest.TestCase):
         return route_path(route_name, request, *elements, **kw)
 
     def _makeRequest(self):
-        class Request(object):
+        class Request:
             def route_path(self, route_name, *elements, **kw):
                 self.route_name = route_name
                 self.elements = elements
@@ -1131,7 +1131,7 @@ class Test_resource_url(unittest.TestCase):
         return resource_url(resource, request, *elements, **kw)
 
     def _makeRequest(self):
-        class Request(object):
+        class Request:
             def resource_url(self, resource, *elements, **kw):
                 self.resource = resource
                 self.elements = elements
@@ -1156,7 +1156,7 @@ class Test_static_url(unittest.TestCase):
         return static_url(path, request, **kw)
 
     def _makeRequest(self):
-        class Request(object):
+        class Request:
             def static_url(self, path, **kw):
                 self.path = path
                 self.kw = kw
@@ -1193,7 +1193,7 @@ class Test_static_path(unittest.TestCase):
         return static_path(path, request, **kw)
 
     def _makeRequest(self):
-        class Request(object):
+        class Request:
             def static_path(self, path, **kw):
                 self.path = path
                 self.kw = kw
@@ -1230,7 +1230,7 @@ class Test_current_route_url(unittest.TestCase):
         return current_route_url(request, *elements, **kw)
 
     def _makeRequest(self):
-        class Request(object):
+        class Request:
             def current_route_url(self, *elements, **kw):
                 self.elements = elements
                 self.kw = kw
@@ -1253,7 +1253,7 @@ class Test_current_route_path(unittest.TestCase):
         return current_route_path(request, *elements, **kw)
 
     def _makeRequest(self):
-        class Request(object):
+        class Request:
             def current_route_path(self, *elements, **kw):
                 self.elements = elements
                 self.kw = kw
@@ -1410,7 +1410,7 @@ class Test_with_route_prefix(unittest.TestCase):
         assert self.config.route_prefix == 'old_prefix'
 
 
-class DummyContext(object):
+class DummyContext:
     def __init__(self, next=None):
         self.next = next
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -660,17 +660,17 @@ class TestCompileRouteFunctional(unittest.TestCase):
         self.generates('/foo/:abc_def', {'abc_def': '20'}, '/foo/20')
 
 
-class DummyContext(object):
+class DummyContext:
     """ """
 
 
-class DummyRequest(object):
+class DummyRequest:
     scheme = 'http'
 
     def __init__(self, **kw):
         self.__dict__.update(kw)
 
 
-class DummyRoute(object):
+class DummyRoute:
     def __init__(self, generator):
         self.generate = generator

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -841,7 +841,7 @@ class Test_hide_attrs(unittest.TestCase):
     def _makeDummy(self):
         from pyramid.decorator import reify
 
-        class Dummy(object):
+        class Dummy:
             x = 1
 
             @reify
@@ -896,7 +896,7 @@ def dummyfunc():  # pragma: no cover
     pass
 
 
-class Dummy(object):
+class Dummy:
     pass
 
 
@@ -971,55 +971,55 @@ class Test_takes_one_arg(unittest.TestCase):
         return takes_one_arg(view, attr=attr, argname=argname)
 
     def test_requestonly_newstyle_class_no_init(self):
-        class foo(object):
+        class foo:
             """ """
 
         self.assertFalse(self._callFUT(foo))
 
     def test_requestonly_newstyle_class_init_toomanyargs(self):
-        class foo(object):
+        class foo:
             def __init__(self, context, request):
                 """ """
 
         self.assertFalse(self._callFUT(foo))
 
     def test_requestonly_newstyle_class_init_onearg_named_request(self):
-        class foo(object):
+        class foo:
             def __init__(self, request):
                 """ """
 
         self.assertTrue(self._callFUT(foo))
 
     def test_newstyle_class_init_onearg_named_somethingelse(self):
-        class foo(object):
+        class foo:
             def __init__(self, req):
                 """ """
 
         self.assertTrue(self._callFUT(foo))
 
     def test_newstyle_class_init_defaultargs_firstname_not_request(self):
-        class foo(object):
+        class foo:
             def __init__(self, context, request=None):
                 """ """
 
         self.assertFalse(self._callFUT(foo))
 
     def test_newstyle_class_init_defaultargs_firstname_request(self):
-        class foo(object):
+        class foo:
             def __init__(self, request, foo=1, bar=2):
                 """ """
 
         self.assertTrue(self._callFUT(foo, argname='request'))
 
     def test_newstyle_class_init_firstname_request_with_secondname(self):
-        class foo(object):
+        class foo:
             def __init__(self, request, two):
                 """ """
 
         self.assertFalse(self._callFUT(foo))
 
     def test_newstyle_class_init_noargs(self):
-        class foo(object):
+        class foo:
             def __init__():
                 """ """
 
@@ -1209,7 +1209,7 @@ class TestSimpleSerializer(unittest.TestCase):
 
 
 class TestUnboundMethods(unittest.TestCase):
-    class Dummy(object):
+    class Dummy:
         def run(self):  # pragma: no cover
             return 'OK'
 

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -6,7 +6,7 @@ from pyramid import testing
 from pyramid.interfaces import IRequest, IResponse
 
 
-class BaseTest(object):
+class BaseTest:
     def setUp(self):
         self.config = testing.setUp()
 
@@ -98,7 +98,7 @@ class Test_notfound_view_config(BaseTest, unittest.TestCase):
         decorator.venusian = venusian
         decorator.venusian.info.scope = 'class'
 
-        class view(object):
+        class view:
             pass
 
         wrapped = decorator(view)
@@ -170,7 +170,7 @@ class Test_forbidden_view_config(BaseTest, unittest.TestCase):
         decorator.venusian = venusian
         decorator.venusian.info.scope = 'class'
 
-        class view(object):
+        class view:
             pass
 
         wrapped = decorator(view)
@@ -255,7 +255,7 @@ class Test_exception_view_config(BaseTest, unittest.TestCase):
         decorator.venusian = venusian
         decorator.venusian.info.scope = 'class'
 
-        class view(object):
+        class view:
             pass
 
         wrapped = decorator(view)
@@ -583,7 +583,7 @@ class TestViewConfigDecorator(unittest.TestCase):
         decorator.venusian = venusian
         decorator.venusian.info.scope = 'class'
 
-        class foo(object):
+        class foo:
             pass
 
         wrapped = decorator(foo)
@@ -602,7 +602,7 @@ class TestViewConfigDecorator(unittest.TestCase):
         decorator.venusian = venusian
         decorator.venusian.info.scope = 'class'
 
-        class foo(object):
+        class foo:
             pass
 
         wrapped = decorator(foo)
@@ -649,7 +649,7 @@ class TestViewConfigDecorator(unittest.TestCase):
         def bar(self):  # pragma: no cover
             pass
 
-        class foo(object):
+        class foo:
             foomethod = decorator(foo)
             barmethod = decorator(bar)
 
@@ -715,7 +715,7 @@ class TestViewConfigDecorator(unittest.TestCase):
         from pyramid.interfaces import IRendererInfo
 
         @implementer(IRendererInfo)
-        class DummyRendererHelper(object):
+        class DummyRendererHelper:
             pass
 
         renderer_helper = DummyRendererHelper()
@@ -785,14 +785,14 @@ class Test_append_slash_notfound_view(BaseTest, unittest.TestCase):
     def _registerMapper(self, reg, match=True):
         from pyramid.interfaces import IRoutesMapper
 
-        class DummyRoute(object):
+        class DummyRoute:
             def __init__(self, val):
                 self.val = val
 
             def match(self, path):
                 return self.val
 
-        class DummyMapper(object):
+        class DummyMapper:
             def __init__(self):
                 self.routelist = [DummyRoute(match)]
 
@@ -919,7 +919,7 @@ class Test_view_defaults(unittest.TestCase):
         from pyramid.view import view_defaults
 
         @view_defaults(route_name='abc', renderer='def')
-        class Foo(object):
+        class Foo:
             pass
 
         self.assertEqual(Foo.__view_defaults__['route_name'], 'abc')
@@ -929,7 +929,7 @@ class Test_view_defaults(unittest.TestCase):
         from pyramid.view import view_defaults
 
         @view_defaults(route_name='abc', renderer='def')
-        class Foo(object):
+        class Foo:
             pass
 
         class Bar(Foo):
@@ -942,7 +942,7 @@ class Test_view_defaults(unittest.TestCase):
         from pyramid.view import view_defaults
 
         @view_defaults(route_name='abc', renderer='def')
-        class Foo(object):
+        class Foo:
             pass
 
         @view_defaults(route_name='ghi')
@@ -956,7 +956,7 @@ class Test_view_defaults(unittest.TestCase):
         from pyramid.view import view_defaults
 
         @view_defaults(route_name='abc', renderer='def')
-        class Foo(object):
+        class Foo:
             pass
 
         @view_defaults()
@@ -1224,7 +1224,7 @@ class DummyRequest:
 
 
 @implementer(IResponse)
-class DummyResponse(object):
+class DummyResponse:
     headerlist = ()
     app_iter = ()
     status = '200 OK'
@@ -1241,13 +1241,13 @@ class IContext(Interface):
     pass
 
 
-class DummyVenusianInfo(object):
+class DummyVenusianInfo:
     scope = 'notaclass'
     module = sys.modules['tests']
     codeinfo = 'codeinfo'
 
 
-class DummyVenusian(object):
+class DummyVenusian:
     def __init__(self, info=None):
         if info is None:
             info = DummyVenusianInfo()
@@ -1259,11 +1259,11 @@ class DummyVenusian(object):
         return self.info
 
 
-class DummyRegistry(object):
+class DummyRegistry:
     pass
 
 
-class DummyConfig(object):
+class DummyConfig:
     def __init__(self):
         self.settings = []
         self.registry = DummyRegistry()
@@ -1278,7 +1278,7 @@ class DummyConfig(object):
         return self
 
 
-class DummyVenusianContext(object):
+class DummyVenusianContext:
     def __init__(self):
         self.config = DummyConfig()
 

--- a/tests/test_viewderivers.py
+++ b/tests/test_viewderivers.py
@@ -73,7 +73,7 @@ class TestDeriveView(unittest.TestCase):
             raise AssertionError
 
     def test_instance_returns_non_adaptable(self):
-        class AView(object):
+        class AView:
             def __call__(self, request):
                 return None
 
@@ -129,7 +129,7 @@ class TestDeriveView(unittest.TestCase):
     def test_requestonly_default_method_returns_non_adaptable(self):
         request = DummyRequest()
 
-        class AView(object):
+        class AView:
             def __init__(self, request):
                 pass
 
@@ -155,7 +155,7 @@ class TestDeriveView(unittest.TestCase):
     def test_requestonly_nondefault_method_returns_non_adaptable(self):
         request = DummyRequest()
 
-        class AView(object):
+        class AView:
             def __init__(self, request):
                 pass
 
@@ -191,7 +191,7 @@ class TestDeriveView(unittest.TestCase):
     def test_requestonly_function_with_renderer(self):
         response = DummyResponse()
 
-        class moo(object):
+        class moo:
             def render_view(inself, req, resp, view_inst, ctx):
                 self.assertEqual(req, request)
                 self.assertEqual(resp, 'OK')
@@ -235,7 +235,7 @@ class TestDeriveView(unittest.TestCase):
     def test_requestonly_function_with_renderer_request_has_view(self):
         response = DummyResponse()
 
-        class moo(object):
+        class moo:
             def render_view(inself, req, resp, view_inst, ctx):
                 self.assertEqual(req, request)
                 self.assertEqual(resp, 'OK')
@@ -261,7 +261,7 @@ class TestDeriveView(unittest.TestCase):
     def test_class_without_attr(self):
         response = DummyResponse()
 
-        class View(object):
+        class View:
             def __init__(self, request):
                 pass
 
@@ -276,7 +276,7 @@ class TestDeriveView(unittest.TestCase):
     def test_class_with_attr(self):
         response = DummyResponse()
 
-        class View(object):
+        class View:
             def __init__(self, request):
                 pass
 
@@ -314,7 +314,7 @@ class TestDeriveView(unittest.TestCase):
     def test_as_newstyle_class_context_and_request(self):
         response = DummyResponse()
 
-        class view(object):
+        class view:
             def __init__(self, context, request):
                 pass
 
@@ -334,7 +334,7 @@ class TestDeriveView(unittest.TestCase):
     def test_as_newstyle_class_requestonly(self):
         response = DummyResponse()
 
-        class view(object):
+        class view:
             def __init__(self, context, request):
                 pass
 
@@ -924,7 +924,7 @@ class TestDeriveView(unittest.TestCase):
     def test_as_newstyle_class_context_and_request_attr_and_renderer(self):
         response = DummyResponse()
 
-        class renderer(object):
+        class renderer:
             def render_view(inself, req, resp, view_inst, ctx):
                 self.assertEqual(req, request)
                 self.assertEqual(resp, {'a': '1'})
@@ -935,7 +935,7 @@ class TestDeriveView(unittest.TestCase):
             def clone(self):
                 return self
 
-        class View(object):
+        class View:
             def __init__(self, context, request):
                 pass
 
@@ -956,7 +956,7 @@ class TestDeriveView(unittest.TestCase):
     def test_as_newstyle_class_requestonly_attr_and_renderer(self):
         response = DummyResponse()
 
-        class renderer(object):
+        class renderer:
             def render_view(inself, req, resp, view_inst, ctx):
                 self.assertEqual(req, request)
                 self.assertEqual(resp, {'a': '1'})
@@ -967,7 +967,7 @@ class TestDeriveView(unittest.TestCase):
             def clone(self):
                 return self
 
-        class View(object):
+        class View:
             def __init__(self, request):
                 pass
 
@@ -988,7 +988,7 @@ class TestDeriveView(unittest.TestCase):
     def test_as_oldstyle_cls_context_request_attr_and_renderer(self):
         response = DummyResponse()
 
-        class renderer(object):
+        class renderer:
             def render_view(inself, req, resp, view_inst, ctx):
                 self.assertEqual(req, request)
                 self.assertEqual(resp, {'a': '1'})
@@ -1020,7 +1020,7 @@ class TestDeriveView(unittest.TestCase):
     def test_as_oldstyle_cls_requestonly_attr_and_renderer(self):
         response = DummyResponse()
 
-        class renderer(object):
+        class renderer:
             def render_view(inself, req, resp, view_inst, ctx):
                 self.assertEqual(req, request)
                 self.assertEqual(resp, {'a': '1'})
@@ -1052,7 +1052,7 @@ class TestDeriveView(unittest.TestCase):
     def test_as_instance_context_and_request_attr_and_renderer(self):
         response = DummyResponse()
 
-        class renderer(object):
+        class renderer:
             def render_view(inself, req, resp, view_inst, ctx):
                 self.assertEqual(req, request)
                 self.assertEqual(resp, {'a': '1'})
@@ -1081,7 +1081,7 @@ class TestDeriveView(unittest.TestCase):
     def test_as_instance_requestonly_attr_and_renderer(self):
         response = DummyResponse()
 
-        class renderer(object):
+        class renderer:
             def render_view(inself, req, resp, view_inst, ctx):
                 self.assertEqual(req, request)
                 self.assertEqual(resp, {'a': '1'})
@@ -1110,7 +1110,7 @@ class TestDeriveView(unittest.TestCase):
     def test_with_view_mapper_config_specified(self):
         response = DummyResponse()
 
-        class mapper(object):
+        class mapper:
             def __init__(self, **kw):
                 self.kw = kw
 
@@ -2046,7 +2046,7 @@ class TestDeriverIntegration(unittest.TestCase):
 
 
 @implementer(IResponse)
-class DummyResponse(object):
+class DummyResponse:
     content_type = None
     default_content_type = None
     body = None

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -121,7 +121,7 @@ def dummyapp(environ, start_response):
     """ """
 
 
-class DummyApp(object):
+class DummyApp:
     def __call__(self, environ, start_response):
         """ """
 


### PR DESCRIPTION
some addition to https://github.com/Pylons/pyramid/pull/3421

- `class Foo(object):` replaced with `class Foo:`, `(object)` make no sense in py3
- `__nonzero__()`  -> `__bool__()`, first method was removed from py3
- use new py3 `super()` syntax without `(class, self)`
- `/` replaced with `//`
https://github.com/Pylons/pyramid/blob/48cf45b0a1ac04e701101fa18778164825edd429/src/pyramid/config/predicates.py#L208
in py2 it returned `int` type, now in py3 - `float`, that looks not correct (but not critical :])
- `__unicode__` method was removed in py3, so we don't need any extra checks
- unittest.AssertEqual**s** [was deprecated](https://docs.python.org/3/library/unittest.html#deprecated-aliases)

