### PR TITLE
Fix docs build on Sphinx 3.0+

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -379,9 +379,9 @@ def app_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
 
 def setup(app):
     app.add_role('app', app_role)
-    app.add_directive('frontmatter', FrontMatter, 1, (0, 0, 0))
-    app.add_directive('mainmatter', MainMatter, 1, (0, 0, 0))
-    app.add_directive('backmatter', BackMatter, 1, (0, 0, 0))
+    app.add_directive('frontmatter', FrontMatter)
+    app.add_directive('mainmatter', MainMatter)
+    app.add_directive('backmatter', BackMatter)
     app.connect('autodoc-process-signature', resig)
 
 


### PR DESCRIPTION
`add_directive` arguments was changed in latest sphinx
https://github.com/sphinx-doc/sphinx/blob/v3.0.1/sphinx/application.py#L593