### PR TITLE
Fix Sphinx 3.0.x build

### DIFF
--- a/docs/api/request.rst
+++ b/docs/api/request.rst
@@ -14,7 +14,7 @@
                      model_url, resource_url, resource_path, set_property, 
                      effective_principals, authenticated_userid,
                      unauthenticated_userid, has_permission,
-                     invoke_exception_view, localizer
+                     invoke_exception_view, localizer, response, session
 
    .. attribute:: context
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -379,9 +379,9 @@ def app_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
 
 def setup(app):
     app.add_role('app', app_role)
-    app.add_directive('frontmatter', FrontMatter, 1, (0, 0, 0))
-    app.add_directive('mainmatter', MainMatter, 1, (0, 0, 0))
-    app.add_directive('backmatter', BackMatter, 1, (0, 0, 0))
+    app.add_directive('frontmatter', FrontMatter)
+    app.add_directive('mainmatter', MainMatter)
+    app.add_directive('backmatter', BackMatter)
     app.connect('autodoc-process-signature', resig)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,14 +33,14 @@ deps =
 [testenv:docs]
 whitelist_externals = make
 commands =
-    make -C docs {posargs:doctest html epub} BUILDDIR={envdir} "SPHINXOPTS=-W -E"
+    make -C docs {posargs:doctest html epub} BUILDDIR={envdir} "SPHINXOPTS=-W -E -D suppress_warnings=ref.term"
 extras =
     docs
 
 [testenv:pdf]
 whitelist_externals = make
 commands =
-    make -C docs latexpdf BUILDDIR={envdir} "SPHINXOPTS=-W -E"
+    make -C docs latexpdf BUILDDIR={envdir} "SPHINXOPTS=-W -E -D suppress_warnings=ref.term"
 extras =
     docs
 


### PR DESCRIPTION
WIP

Regarding these two warnings:

```
src/pyramid/request.py:docstring of pyramid.request.Request.response:1: WARNING: duplicate object description of pyramid.request.Request.response, other instance in api/request, use :noindex: for one of them
src/pyramid/request.py:docstring of pyramid.request.Request.session:1: WARNING: duplicate object description of pyramid.request.Request.session, other instance in api/request, use :noindex: for one of them
```

If I follow the advice do this:

```rst
   .. attribute:: response
     :noindex:
```

...then it does not have an index entry and cannot be linked to, like so:
https://docs.pylonsproject.org/projects/pyramid/en/latest/api/request.html#pyramid.request.Request.response

I see that further down the rendered page, another `response` and `session` appear, which are from the `request` docstrings.

I went ahead and tried a "fix" in commit , but I want to make sure that this doesn't mess up anything.

Alternatively, we could move all that rst into the docstrings, but I assume y'all put it at the top of the .rst file for a good reason.