### PR TITLE
Backport #3577

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,6 @@ extensions = [
 intersphinx_mapping = {
     'colander': ('https://docs.pylonsproject.org/projects/colander/en/latest', None),
     'cookbook': ('https://docs.pylonsproject.org/projects/pyramid-cookbook/en/latest/', None),
-    'cookiecutter': ('https://cookiecutter.readthedocs.io/en/latest/', None),
     'deform': ('https://docs.pylonsproject.org/projects/deform/en/latest', None),
     'jinja2': ('https://docs.pylonsproject.org/projects/pyramid-jinja2/en/latest/', None),
     'plaster': ('https://docs.pylonsproject.org/projects/plaster/en/latest/', None),

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1153,7 +1153,7 @@ Glossary
       packaging.
 
    cookiecutter
-      A command-line utility that creates projects from :ref:`cookiecutters <cookiecutter:readme>` (project templates), e.g., creating a Python package project from a Python package project template.
+      A command-line utility that creates projects from `cookiecutters <https://cookiecutter.readthedocs.io/en/latest/>`_ (project templates), e.g., creating a Python package project from a Python package project template.
 
       Pyramid cookiecutters include:
 

--- a/docs/narr/cookiecutters.rst
+++ b/docs/narr/cookiecutters.rst
@@ -5,7 +5,7 @@ Pyramid cookiecutters
 
 .. versionadded:: 1.8
 
-A :term:`cookiecutter` is a command-line utility that creates projects from :ref:`cookiecutters <cookiecutter:readme>` (project templates), e.g., creating a Python package project from a Python package project template.
+A :term:`cookiecutter` is a command-line utility that creates projects from `cookiecutters <https://cookiecutter.readthedocs.io/en/latest/>`__ (project templates), e.g., creating a Python package project from a Python package project template.
 
 Pyramid cookiecutters have replaced the now deprecated Pyramid scaffolds, and should be used going forward. Pyramid cookiecutters released under the Pylons Project include:
 

--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -75,7 +75,7 @@ In :ref:`installing_chapter`, you created a virtual Python environment via the
 ``venv`` command. We called the virtual environment directory
 ``env`` and set an environment variable ``VENV`` to its path.
 
-We assume that you :ref:`previously installed cookiecutter <cookiecutters>`, following its installation instructions.
+We assume that you `previously installed cookiecutter <https://cookiecutter.readthedocs.io/en/latest/>`_, following its installation instructions.
 
 We'll choose ``pyramid-cookiecutter-starter`` to start the project.  When we invoke ``cookiecutter``, it will create a directory that represents our project.
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ tests_require = [
 
 
 docs_extras = [
-    'Sphinx >= 1.8.1',
+    'Sphinx < 3.0.0',
     'docutils',
     'repoze.sphinx.autointerface',
     'pylons_sphinx_latesturl',


### PR DESCRIPTION
Sort of. In Sphinx 3.0.x, lots of things blow up on this branch, so I pinned it to `Sphinx < 3.0.0`. I think it is not worth the effort to fix everything in this branch for the sake of Sphinx 3.0.x, given that Pyramid 2.0 will soon be released and we won't be doing further updates.

Use links to cookiecutter instead of intersphinx.