### PR TITLE
Add warning to docs about venusian's limitation of only scanning for *.py files

### DIFF
--- a/src/pyramid/view.py
+++ b/src/pyramid/view.py
@@ -196,21 +196,26 @@ class view_config:
         See also :ref:`mapping_views_using_a_decorator_section` for
         details about using :class:`pyramid.view.view_config`.
 
-    .. warning::
+    .. note::
 
-        ``view_config`` will work ONLY on module top level members
-        because of the limitation of ``venusian.Scanner.scan``.
+        Because of the limitation of ``venusian.Scanner.scan``, note that
+        ``view_config`` will work only for the following conditions.
 
-        Also it will ONLY work on views present as plaintext python
-        files (*.py), ignoring all non-*.py ones which also includes
-        *.pyc and *.pyo (python precompiled byte code / optimized) files.
+        -   In Python packages that have an ``__init__.py`` file in their
+            directory.
 
-        Another venusian specific precondition to take into account is that
-        python packages to be found by venusian need to have a __init__.py
-        file in their root directory.
+            .. seealso::
 
-        This is a limitation in venusian documented in:
-        https://docs.pylonsproject.org/projects/venusian/en/latest/#using-venusian
+                See also https://github.com/Pylons/venusian/issues/68
+
+        -   On module top level members.
+        -   On Python source (``.py``) files.
+            Compiled Python files (``.pyc``, ``.pyo``) without a corresponding
+            source file are ignored.
+        .. seealso::
+
+            See also the `Venusian documentation
+            <https://docs.pylonsproject.org/projects/venusian/en/latest/#using-venusian>`_.
     """
 
     venusian = venusian  # for testing injection

--- a/src/pyramid/view.py
+++ b/src/pyramid/view.py
@@ -212,6 +212,7 @@ class view_config:
         -   On Python source (``.py``) files.
             Compiled Python files (``.pyc``, ``.pyo``) without a corresponding
             source file are ignored.
+
         .. seealso::
 
             See also the `Venusian documentation

--- a/src/pyramid/view.py
+++ b/src/pyramid/view.py
@@ -201,6 +201,16 @@ class view_config:
         ``view_config`` will work ONLY on module top level members
         because of the limitation of ``venusian.Scanner.scan``.
 
+        Also it will ONLY work on views present as plaintext python
+        files (*.py), ignoring all non-*.py ones which also includes
+        *.pyc and *.pyo (python precompiled byte code / optimized) files.
+
+        Another venusian specific precondition to take into account is that
+        python packages to be found by venusian need to have a __init__.py
+        file in their root directory.
+
+        This is a limitation in venusian documented in:
+        https://docs.pylonsproject.org/projects/venusian/en/latest/#using-venusian
     """
 
     venusian = venusian  # for testing injection

--- a/src/pyramid/view.py
+++ b/src/pyramid/view.py
@@ -198,7 +198,7 @@ class view_config:
 
     .. note::
 
-        Because of the limitation of ``venusian.Scanner.scan``, note that
+        Because of a limitation of ``venusian.Scanner.scan``, note that
         ``view_config`` will work only for the following conditions.
 
         -   In Python packages that have an ``__init__.py`` file in their


### PR DESCRIPTION
It appears to be common sense that pre-compiling python files into byte code does not have any non-obvious disadvantages[1].
During my effort of porting pyramid and its dependencies to OpenWrt I also pre-compiled all python packages into byte-code, as the final to-be-flashed OpenWrt images are focused on size and memory footprint.
I however had to realise, that pyramid "just doesn't work" - without throwing any error, exception or alike - only returning 404 for every HTTP request.
Turns out, pyramid uses venusian to scan for its views (and potentially other components), where venusian skips all non-*.py files - including *.pyc/*.pyo files. Hence, no views in my case.
This is documented here[2].

WARNING: This PR is *untested*, as in, I only added text without (re-)rendering the docs.

[1]https://stackoverflow.com/questions/35618159/should-i-generate-pyc-files-when-deploying/35619259
[2]https://docs.pylonsproject.org/projects/venusian/en/latest/#using-venusian