### PR TITLE
Update isort to 5.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,13 @@ exclude = '''
  # This next section only exists for people that have their editors
 # automatically call isort, black already sorts entries on its own when run.
 [tool.isort]
+profile = "black"
 multi_line_output = 3
+src_paths = ["src", "tests"]
+skip_glob = ["docs/*"]
 include_trailing_comma = true
 force_grid_wrap = false
 combine_as_imports = true
-use_parenthesis = true
 line_length = 79
 force_sort_within_sections = true
 no_lines_before = "THIRDPARTY"

--- a/src/pyramid/authorization.py
+++ b/src/pyramid/authorization.py
@@ -15,8 +15,8 @@ with warnings.catch_warnings():
     from pyramid.security import (
         ACLAllowed as _ACLAllowed,
         ACLDenied as _ACLDenied,
-        AllPermissionsList as _AllPermissionsList,
         Allow,
+        AllPermissionsList as _AllPermissionsList,
         Authenticated,
         Deny,
         Everyone,

--- a/src/pyramid/scripts/pviews.py
+++ b/src/pyramid/scripts/pviews.py
@@ -84,15 +84,16 @@ class PViewsCommand:
         find a :app:`Pyramid` view based on introspection of :term:`view
         configuration` within the application registry; return the view.
         """
-        from zope.interface import providedBy
-        from zope.interface import implementer
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IRootFactory
-        from pyramid.interfaces import IRouteRequest
-        from pyramid.interfaces import IRoutesMapper
-        from pyramid.interfaces import ITraverser
-        from pyramid.traversal import DefaultRootFactory
-        from pyramid.traversal import ResourceTreeTraverser
+        from zope.interface import implementer, providedBy
+
+        from pyramid.interfaces import (
+            IRequest,
+            IRootFactory,
+            IRouteRequest,
+            IRoutesMapper,
+            ITraverser,
+        )
+        from pyramid.traversal import DefaultRootFactory, ResourceTreeTraverser
 
         registry = request.registry
         q = registry.queryUtility

--- a/tests/pkgs/defpermbugapp/__init__.py
+++ b/tests/pkgs/defpermbugapp/__init__.py
@@ -20,8 +20,8 @@ def z_view(request):
 
 
 def includeme(config):
-    from pyramid.authorization import ACLAuthorizationPolicy
     from pyramid.authentication import AuthTktAuthenticationPolicy
+    from pyramid.authorization import ACLAuthorizationPolicy
 
     authn_policy = AuthTktAuthenticationPolicy('seekt1t', hashalg='sha512')
     authz_policy = ACLAuthorizationPolicy()

--- a/tests/pkgs/fixtureapp/__init__.py
+++ b/tests/pkgs/fixtureapp/__init__.py
@@ -8,7 +8,7 @@ def includeme(config):
         name='dummyskin.html',
         request_type='.views.IDummy',
     )
-    from .models import fixture, IFixture
+    from .models import IFixture, fixture
 
     config.registry.registerUtility(fixture, IFixture)
     config.add_view('.views.fixture_view', name='another.html')

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -239,12 +239,14 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
 
     def test_class_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyClass(IAuthenticationPolicy, self._getTargetClass())
 
     def test_instance_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyObject(IAuthenticationPolicy, self._makeOne())
@@ -328,8 +330,7 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals_userid_only(self):
-        from pyramid.authorization import Everyone
-        from pyramid.authorization import Authenticated
+        from pyramid.authorization import Authenticated, Everyone
 
         request = DummyRequest(
             {'repoze.who.identity': {'repoze.who.userid': 'fred'}}
@@ -341,8 +342,7 @@ class TestRepozeWho1AuthenticationPolicy(unittest.TestCase):
         )
 
     def test_effective_principals_userid_and_groups(self):
-        from pyramid.authorization import Everyone
-        from pyramid.authorization import Authenticated
+        from pyramid.authorization import Authenticated, Everyone
 
         request = DummyRequest(
             {
@@ -467,12 +467,14 @@ class TestRemoteUserAuthenticationPolicy(unittest.TestCase):
 
     def test_class_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyClass(IAuthenticationPolicy, self._getTargetClass())
 
     def test_instance_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyObject(IAuthenticationPolicy, self._makeOne())
@@ -505,8 +507,7 @@ class TestRemoteUserAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals(self):
-        from pyramid.authorization import Everyone
-        from pyramid.authorization import Authenticated
+        from pyramid.authorization import Authenticated, Everyone
 
         request = DummyRequest({'REMOTE_USER': 'fred'})
         policy = self._makeOne()
@@ -619,8 +620,7 @@ class TestAuthTktAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals(self):
-        from pyramid.authorization import Everyone
-        from pyramid.authorization import Authenticated
+        from pyramid.authorization import Authenticated, Everyone
 
         request = DummyRequest({})
 
@@ -654,12 +654,14 @@ class TestAuthTktAuthenticationPolicy(unittest.TestCase):
 
     def test_class_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyClass(IAuthenticationPolicy, self._getTargetClass())
 
     def test_instance_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyObject(IAuthenticationPolicy, self._makeOne(None, None))
@@ -1596,12 +1598,14 @@ class TestSessionAuthenticationPolicy(unittest.TestCase):
 
     def test_class_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyClass(IAuthenticationPolicy, self._getTargetClass())
 
     def test_instance_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyObject(IAuthenticationPolicy, self._makeOne())
@@ -1658,8 +1662,7 @@ class TestSessionAuthenticationPolicy(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_effective_principals(self):
-        from pyramid.authorization import Everyone
-        from pyramid.authorization import Authenticated
+        from pyramid.authorization import Authenticated, Everyone
 
         request = DummyRequest(session={'userid': 'fred'})
 
@@ -1755,6 +1758,7 @@ class TestBasicAuthAuthenticationPolicy(unittest.TestCase):
 
     def test_class_implements_IAuthenticationPolicy(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IAuthenticationPolicy
 
         verifyClass(IAuthenticationPolicy, self._getTargetClass())

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -20,12 +20,14 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
 
     def test_class_implements_IAuthorizationPolicy(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IAuthorizationPolicy
 
         verifyClass(IAuthorizationPolicy, self._getTargetClass())
 
     def test_instance_implements_IAuthorizationPolicy(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IAuthorizationPolicy
 
         verifyObject(IAuthorizationPolicy, self._makeOne())
@@ -36,12 +38,14 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(policy.permits(context, [], 'view'), False)
 
     def test_permits(self):
-        from pyramid.authorization import Deny
-        from pyramid.authorization import Allow
-        from pyramid.authorization import Everyone
-        from pyramid.authorization import Authenticated
-        from pyramid.authorization import ALL_PERMISSIONS
-        from pyramid.authorization import DENY_ALL
+        from pyramid.authorization import (
+            ALL_PERMISSIONS,
+            DENY_ALL,
+            Allow,
+            Authenticated,
+            Deny,
+            Everyone,
+        )
 
         root = DummyContext()
         community = DummyContext(__name__='community', __parent__=root)
@@ -145,8 +149,7 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, False)
 
     def test_principals_allowed_by_permission_direct(self):
-        from pyramid.authorization import Allow
-        from pyramid.authorization import DENY_ALL
+        from pyramid.authorization import DENY_ALL, Allow
 
         context = DummyContext()
         acl = [
@@ -162,8 +165,7 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, ['chrism'])
 
     def test_principals_allowed_by_permission_callable_acl(self):
-        from pyramid.authorization import Allow
-        from pyramid.authorization import DENY_ALL
+        from pyramid.authorization import DENY_ALL, Allow
 
         context = DummyContext()
         acl = lambda: [
@@ -191,10 +193,12 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(list(result), [])
 
     def test_principals_allowed_by_permission(self):
-        from pyramid.authorization import Allow
-        from pyramid.authorization import Deny
-        from pyramid.authorization import DENY_ALL
-        from pyramid.authorization import ALL_PERMISSIONS
+        from pyramid.authorization import (
+            ALL_PERMISSIONS,
+            DENY_ALL,
+            Allow,
+            Deny,
+        )
 
         root = DummyContext(__name__='', __parent__=None)
         community = DummyContext(__name__='community', __parent__=root)
@@ -236,8 +240,7 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_principals_allowed_by_permission_deny_not_permission_in_acl(self):
-        from pyramid.authorization import Deny
-        from pyramid.authorization import Everyone
+        from pyramid.authorization import Deny, Everyone
 
         context = DummyContext()
         acl = [(Deny, Everyone, 'write')]
@@ -249,8 +252,7 @@ class TestACLAuthorizationPolicy(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_principals_allowed_by_permission_deny_permission_in_acl(self):
-        from pyramid.authorization import Deny
-        from pyramid.authorization import Everyone
+        from pyramid.authorization import Deny, Everyone
 
         context = DummyContext()
         acl = [(Deny, Everyone, 'read')]
@@ -289,13 +291,15 @@ class TestACLHelper(unittest.TestCase):
         self.assertEqual(result.context, context)
 
     def test_acl(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Deny
-        from pyramid.authorization import Allow
-        from pyramid.authorization import Everyone
-        from pyramid.authorization import Authenticated
-        from pyramid.authorization import ALL_PERMISSIONS
-        from pyramid.authorization import DENY_ALL
+        from pyramid.authorization import (
+            ALL_PERMISSIONS,
+            DENY_ALL,
+            ACLHelper,
+            Allow,
+            Authenticated,
+            Deny,
+            Everyone,
+        )
 
         helper = ACLHelper()
         root = DummyContext()
@@ -385,8 +389,7 @@ class TestACLHelper(unittest.TestCase):
         )
 
     def test_string_permissions_in_acl(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Allow
+        from pyramid.authorization import ACLHelper, Allow
 
         helper = ACLHelper()
         root = DummyContext()
@@ -398,8 +401,7 @@ class TestACLHelper(unittest.TestCase):
         self.assertEqual(result, False)
 
     def test_callable_acl(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Allow
+        from pyramid.authorization import ACLHelper, Allow
 
         helper = ACLHelper()
         context = DummyContext()
@@ -409,9 +411,7 @@ class TestACLHelper(unittest.TestCase):
         self.assertTrue(result)
 
     def test_principals_allowed_by_permission_direct(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Allow
-        from pyramid.authorization import DENY_ALL
+        from pyramid.authorization import DENY_ALL, ACLHelper, Allow
 
         helper = ACLHelper()
         context = DummyContext()
@@ -427,9 +427,7 @@ class TestACLHelper(unittest.TestCase):
         self.assertEqual(result, ['chrism'])
 
     def test_principals_allowed_by_permission_callable_acl(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Allow
-        from pyramid.authorization import DENY_ALL
+        from pyramid.authorization import DENY_ALL, ACLHelper, Allow
 
         helper = ACLHelper()
         context = DummyContext()
@@ -445,8 +443,7 @@ class TestACLHelper(unittest.TestCase):
         self.assertEqual(result, ['chrism'])
 
     def test_principals_allowed_by_permission_string_permission(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Allow
+        from pyramid.authorization import ACLHelper, Allow
 
         helper = ACLHelper()
         context = DummyContext()
@@ -458,11 +455,13 @@ class TestACLHelper(unittest.TestCase):
         self.assertEqual(list(result), [])
 
     def test_principals_allowed_by_permission(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Allow
-        from pyramid.authorization import Deny
-        from pyramid.authorization import DENY_ALL
-        from pyramid.authorization import ALL_PERMISSIONS
+        from pyramid.authorization import (
+            ALL_PERMISSIONS,
+            DENY_ALL,
+            ACLHelper,
+            Allow,
+            Deny,
+        )
 
         helper = ACLHelper()
         root = DummyContext(__name__='', __parent__=None)
@@ -505,9 +504,7 @@ class TestACLHelper(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_principals_allowed_by_permission_deny_not_permission_in_acl(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Deny
-        from pyramid.authorization import Everyone
+        from pyramid.authorization import ACLHelper, Deny, Everyone
 
         helper = ACLHelper()
         context = DummyContext()
@@ -519,9 +516,7 @@ class TestACLHelper(unittest.TestCase):
         self.assertEqual(result, [])
 
     def test_principals_allowed_by_permission_deny_permission_in_acl(self):
-        from pyramid.authorization import ACLHelper
-        from pyramid.authorization import Deny
-        from pyramid.authorization import Everyone
+        from pyramid.authorization import ACLHelper, Deny, Everyone
 
         helper = ACLHelper()
         context = DummyContext()

--- a/tests/test_config/test_actions.py
+++ b/tests/test_config/test_actions.py
@@ -23,9 +23,12 @@ class ActionConfiguratorMixinTests(unittest.TestCase):
         exception_view=False,
     ):
         from zope.interface import Interface
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IView,
+            IViewClassifier,
+        )
 
         if exception_view:  # pragma: no cover
             classifier = IExceptionViewClassifier
@@ -1041,12 +1044,14 @@ class TestActionInfo(unittest.TestCase):
 
     def test_class_conforms(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IActionInfo
 
         verifyClass(IActionInfo, self._getTargetClass())
 
     def test_instance_conforms(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IActionInfo
 
         verifyObject(IActionInfo, self._makeOne('f', 0, 'f', 'f'))

--- a/tests/test_config/test_adapters.py
+++ b/tests/test_config/test_adapters.py
@@ -11,8 +11,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         return config
 
     def test_add_subscriber_defaults(self):
-        from zope.interface import implementer
-        from zope.interface import Interface
+        from zope.interface import Interface, implementer
 
         class IEvent(Interface):
             pass
@@ -36,8 +35,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(len(L), 2)
 
     def test_add_subscriber_iface_specified(self):
-        from zope.interface import implementer
-        from zope.interface import Interface
+        from zope.interface import Interface, implementer
 
         class IEvent(Interface):
             pass
@@ -61,8 +59,8 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(len(L), 1)
 
     def test_add_subscriber_dottednames(self):
-        import tests.test_config
         from pyramid.interfaces import INewRequest
+        import tests.test_config
 
         config = self._makeOne(autocommit=True)
         config.add_subscriber(
@@ -75,8 +73,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(handler.required, (INewRequest,))
 
     def test_add_object_event_subscriber(self):
-        from zope.interface import implementer
-        from zope.interface import Interface
+        from zope.interface import Interface, implementer
 
         class IEvent(Interface):
             pass
@@ -100,8 +97,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(len(L), 1)
 
     def test_add_subscriber_with_specific_type_and_predicates_True(self):
-        from zope.interface import implementer
-        from zope.interface import Interface
+        from zope.interface import Interface, implementer
 
         class IEvent(Interface):
             pass
@@ -132,8 +128,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(len(L), 1)
 
     def test_add_subscriber_with_default_type_predicates_True(self):
-        from zope.interface import implementer
-        from zope.interface import Interface
+        from zope.interface import Interface, implementer
 
         class IEvent(Interface):
             pass
@@ -164,8 +159,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(len(L), 1)
 
     def test_add_subscriber_with_specific_type_and_predicates_False(self):
-        from zope.interface import implementer
-        from zope.interface import Interface
+        from zope.interface import Interface, implementer
 
         class IEvent(Interface):
             pass
@@ -193,8 +187,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(len(L), 0)
 
     def test_add_subscriber_with_default_type_predicates_False(self):
-        from zope.interface import implementer
-        from zope.interface import Interface
+        from zope.interface import Interface, implementer
 
         class IEvent(Interface):
             pass
@@ -347,6 +340,7 @@ class AdaptersConfiguratorMixinTests(unittest.TestCase):
 
     def test_add_resource_url_nodefault_resource_iface(self):
         from zope.interface import Interface
+
         from pyramid.interfaces import IResourceURL
 
         config = self._makeOne(autocommit=True)

--- a/tests/test_config/test_assets.py
+++ b/tests/test_config/test_assets.py
@@ -536,24 +536,28 @@ class TestPackageOverrides(unittest.TestCase):
 
     def test_class_conforms_to_IPackageOverrides(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IPackageOverrides
 
         verifyClass(IPackageOverrides, self._getTargetClass())
 
     def test_instance_conforms_to_IPackageOverrides(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IPackageOverrides
 
         verifyObject(IPackageOverrides, self._makeOne())
 
     def test_class_conforms_to_IPEP302Loader(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IPEP302Loader
 
         verifyClass(IPEP302Loader, self._getTargetClass())
 
     def test_instance_conforms_to_IPEP302Loader(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IPEP302Loader
 
         verifyObject(IPEP302Loader, self._makeOne())

--- a/tests/test_config/test_init.py
+++ b/tests/test_config/test_init.py
@@ -31,9 +31,11 @@ class ConfiguratorTests(unittest.TestCase):
         name='',
         exception_view=False,
     ):
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IView,
+            IViewClassifier,
+        )
 
         if exception_view:  # pragma: no cover
             classifier = IExceptionViewClassifier
@@ -66,9 +68,9 @@ class ConfiguratorTests(unittest.TestCase):
 
     def test_ctor_no_registry(self):
         import sys
-        from pyramid.interfaces import ISettings
+
         from pyramid.config import Configurator
-        from pyramid.interfaces import IRendererFactory
+        from pyramid.interfaces import IRendererFactory, ISettings
 
         config = Configurator()
         this_pkg = sys.modules['tests.test_config']
@@ -177,6 +179,7 @@ class ConfiguratorTests(unittest.TestCase):
 
     def test_ctor_with_package_registry(self):
         import sys
+
         from pyramid.config import Configurator
 
         pkg = sys.modules['pyramid']
@@ -297,8 +300,8 @@ class ConfiguratorTests(unittest.TestCase):
         )
 
     def test_ctor_httpexception_view_default(self):
-        from pyramid.interfaces import IExceptionResponse
         from pyramid.httpexceptions import default_exceptionresponse_view
+        from pyramid.interfaces import IExceptionResponse
 
         config = self._makeOne()
         view = self._getViewCallable(
@@ -428,8 +431,7 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(reg.events, (1,))
 
     def test__fix_registry_queryAdapterOrSelf(self):
-        from zope.interface import Interface
-        from zope.interface import implementer
+        from zope.interface import Interface, implementer
 
         class IFoo(Interface):
             pass
@@ -494,6 +496,7 @@ class ConfiguratorTests(unittest.TestCase):
 
     def test_setup_registry_registers_default_exceptionresponse_views(self):
         from webob.exc import WSGIHTTPException
+
         from pyramid.interfaces import IExceptionResponse
         from pyramid.view import default_exceptionresponse_view
 
@@ -533,6 +536,7 @@ class ConfiguratorTests(unittest.TestCase):
 
     def test_setup_registry_registers_default_webob_iresponse_adapter(self):
         from webob import Response
+
         from pyramid.interfaces import IResponse
 
         config = self._makeOne()
@@ -543,10 +547,11 @@ class ConfiguratorTests(unittest.TestCase):
         )
 
     def test_setup_registry_explicit_notfound_trumps_iexceptionresponse(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
+
         from pyramid.httpexceptions import HTTPNotFound
         from pyramid.registry import Registry
+        from pyramid.renderers import null_renderer
 
         reg = Registry()
         config = self._makeOne(reg, autocommit=True)
@@ -566,8 +571,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(result, 'OK')
 
     def test_setup_registry_custom_settings(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import ISettings
+        from pyramid.registry import Registry
 
         settings = {'reload_templates': True, 'mysetting': True}
         reg = Registry()
@@ -579,8 +584,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(settings['mysetting'], True)
 
     def test_setup_registry_debug_logger_None_default(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IDebugLogger
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -589,8 +594,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(logger.name, 'tests.test_config')
 
     def test_setup_registry_debug_logger_non_None(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IDebugLogger
+        from pyramid.registry import Registry
 
         logger = object()
         reg = Registry()
@@ -600,8 +605,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(logger, result)
 
     def test_setup_registry_debug_logger_name(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IDebugLogger
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -610,8 +615,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(result.name, 'foo')
 
     def test_setup_registry_authentication_policy(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IAuthenticationPolicy
+        from pyramid.registry import Registry
 
         policy = object()
         reg = Registry()
@@ -622,8 +627,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(policy, result)
 
     def test_setup_registry_authentication_policy_dottedname(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IAuthenticationPolicy
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -635,8 +640,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(result, tests.test_config)
 
     def test_setup_registry_authorization_policy_dottedname(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IAuthorizationPolicy
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -661,8 +666,8 @@ class ConfiguratorTests(unittest.TestCase):
         config = self.assertRaises(ConfigurationExecutionError, config.commit)
 
     def test_setup_registry_no_default_root_factory(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IRootFactory
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -671,8 +676,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(reg.queryUtility(IRootFactory), None)
 
     def test_setup_registry_dottedname_root_factory(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IRootFactory
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -684,8 +689,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(reg.getUtility(IRootFactory), tests.test_config)
 
     def test_setup_registry_locale_negotiator_dottedname(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import ILocaleNegotiator
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -698,8 +703,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(utility, tests.test_config)
 
     def test_setup_registry_locale_negotiator(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import ILocaleNegotiator
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -711,8 +716,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(utility, negotiator)
 
     def test_setup_registry_request_factory(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IRequestFactory
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -724,8 +729,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(utility, factory)
 
     def test_setup_registry_response_factory(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IResponseFactory
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -737,8 +742,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(utility, factory)
 
     def test_setup_registry_request_factory_dottedname(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IRequestFactory
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -751,8 +756,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(utility, tests.test_config)
 
     def test_setup_registry_alternate_renderers(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IRendererFactory
+        from pyramid.registry import Registry
 
         renderer = object()
         reg = Registry()
@@ -762,8 +767,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(reg.getUtility(IRendererFactory, 'yeah'), renderer)
 
     def test_setup_registry_default_permission(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IDefaultPermission
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -829,8 +834,8 @@ test_config.dummy_include2"""
 
     def test_make_wsgi_app(self):
         import pyramid.config
-        from pyramid.router import Router
         from pyramid.interfaces import IApplicationCreated
+        from pyramid.router import Router
 
         manager = DummyThreadLocalManager()
         config = self._makeOne()
@@ -920,8 +925,9 @@ test_config.dummy_include2"""
         root_config.include(dummy_subapp, route_prefix='nested')
 
     def test_include_with_missing_source_file(self):
-        from pyramid.exceptions import ConfigurationError
         import inspect
+
+        from pyramid.exceptions import ConfigurationError
 
         config = self._makeOne()
 
@@ -973,8 +979,9 @@ test_config.dummy_include2"""
 
     def test_scan_integration(self):
         from zope.interface import alsoProvides
+
         from pyramid.view import render_view_to_response
-        import tests.test_config.pkgs.scannable as package
+        from tests.test_config.pkgs import scannable as package
 
         config = self._makeOne(autocommit=True)
         config.scan(package)
@@ -1079,8 +1086,9 @@ test_config.dummy_include2"""
 
     def test_scan_integration_with_ignore(self):
         from zope.interface import alsoProvides
+
         from pyramid.view import render_view_to_response
-        import tests.test_config.pkgs.scannable as package
+        from tests.test_config.pkgs import scannable as package
 
         config = self._makeOne(autocommit=True)
         config.scan(package, ignore='tests.test_config.pkgs.scannable.another')
@@ -1100,6 +1108,7 @@ test_config.dummy_include2"""
 
     def test_scan_integration_dottedname_package(self):
         from zope.interface import alsoProvides
+
         from pyramid.view import render_view_to_response
 
         config = self._makeOne(autocommit=True)
@@ -1143,8 +1152,8 @@ test_config.dummy_include2"""
             sys.path.remove(path)
 
     def test_scan_integration_conflict(self):
-        from tests.test_config.pkgs import selfscan
         from pyramid.config import Configurator
+        from tests.test_config.pkgs import selfscan
 
         c = Configurator()
         c.scan(selfscan)

--- a/tests/test_config/test_predicates.py
+++ b/tests/test_config/test_predicates.py
@@ -5,8 +5,8 @@ from pyramid.util import text_
 
 class TestPredicateList(unittest.TestCase):
     def _makeOne(self):
-        from pyramid.config.predicates import PredicateList
         from pyramid import predicates
+        from pyramid.config.predicates import PredicateList
 
         inst = PredicateList()
         for name, factory in (

--- a/tests/test_config/test_security.py
+++ b/tests/test_config/test_security.py
@@ -20,8 +20,7 @@ class ConfiguratorSecurityMethodsTests(unittest.TestCase):
         self.assertEqual(config.registry.getUtility(ISecurityPolicy), policy)
 
     def test_set_authentication_policy_with_security_policy(self):
-        from pyramid.interfaces import IAuthorizationPolicy
-        from pyramid.interfaces import ISecurityPolicy
+        from pyramid.interfaces import IAuthorizationPolicy, ISecurityPolicy
 
         config = self._makeOne()
         security_policy = object()
@@ -46,9 +45,11 @@ class ConfiguratorSecurityMethodsTests(unittest.TestCase):
         )
 
     def test_set_authentication_policy_with_authz_policy(self):
-        from pyramid.interfaces import IAuthenticationPolicy
-        from pyramid.interfaces import IAuthorizationPolicy
-        from pyramid.interfaces import ISecurityPolicy
+        from pyramid.interfaces import (
+            IAuthenticationPolicy,
+            IAuthorizationPolicy,
+            ISecurityPolicy,
+        )
         from pyramid.security import LegacySecurityPolicy
 
         config = self._makeOne()
@@ -65,9 +66,11 @@ class ConfiguratorSecurityMethodsTests(unittest.TestCase):
         )
 
     def test_set_authentication_policy_with_authz_policy_autocommit(self):
-        from pyramid.interfaces import IAuthenticationPolicy
-        from pyramid.interfaces import IAuthorizationPolicy
-        from pyramid.interfaces import ISecurityPolicy
+        from pyramid.interfaces import (
+            IAuthenticationPolicy,
+            IAuthorizationPolicy,
+            ISecurityPolicy,
+        )
         from pyramid.security import LegacySecurityPolicy
 
         config = self._makeOne(autocommit=True)
@@ -100,8 +103,10 @@ class ConfiguratorSecurityMethodsTests(unittest.TestCase):
         )
 
     def test_set_authorization_policy_with_authn_policy(self):
-        from pyramid.interfaces import IAuthorizationPolicy
-        from pyramid.interfaces import IAuthenticationPolicy
+        from pyramid.interfaces import (
+            IAuthenticationPolicy,
+            IAuthorizationPolicy,
+        )
 
         config = self._makeOne()
         authn_policy = object()
@@ -114,8 +119,10 @@ class ConfiguratorSecurityMethodsTests(unittest.TestCase):
         )
 
     def test_set_authorization_policy_with_authn_policy_autocommit(self):
-        from pyramid.interfaces import IAuthorizationPolicy
-        from pyramid.interfaces import IAuthenticationPolicy
+        from pyramid.interfaces import (
+            IAuthenticationPolicy,
+            IAuthorizationPolicy,
+        )
 
         config = self._makeOne(autocommit=True)
         authn_policy = object()

--- a/tests/test_config/test_settings.py
+++ b/tests/test_config/test_settings.py
@@ -50,8 +50,8 @@ class TestSettingsConfiguratorMixin(unittest.TestCase):
         self.assertEqual(settings['b'], 2)
 
     def test_add_settings_settings_not_yet_registered(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import ISettings
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)
@@ -60,8 +60,8 @@ class TestSettingsConfiguratorMixin(unittest.TestCase):
         self.assertEqual(settings['a'], 1)
 
     def test_add_settings_settings_None(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import ISettings
+        from pyramid.registry import Registry
 
         reg = Registry()
         config = self._makeOne(reg)

--- a/tests/test_config/test_testing.py
+++ b/tests/test_config/test_testing.py
@@ -54,8 +54,8 @@ class TestingConfiguratorMixinTests(unittest.TestCase):
         self.assertEqual(val, True)
 
     def test_testing_resources(self):
-        from pyramid.traversal import find_resource
         from pyramid.interfaces import ITraverser
+        from pyramid.traversal import find_resource
 
         ob1 = object()
         ob2 = object()

--- a/tests/test_config/test_tweens.py
+++ b/tests/test_config/test_tweens.py
@@ -45,8 +45,7 @@ class TestTweensConfiguratorMixin(unittest.TestCase):
 
     def test_add_tweens_names_with_underover(self):
         from pyramid.interfaces import ITweens
-        from pyramid.tweens import excview_tween_factory
-        from pyramid.tweens import MAIN
+        from pyramid.tweens import MAIN, excview_tween_factory
 
         config = self._makeOne()
         config.add_tween('tests.test_config.dummy_tween_factory', over=MAIN)
@@ -316,7 +315,7 @@ class TestTweens(unittest.TestCase):
         )
 
     def test_implicit_ordering_5(self):
-        from pyramid.tweens import MAIN, INGRESS
+        from pyramid.tweens import INGRESS, MAIN
 
         tweens = self._makeOne()
         add = tweens.add_implicit

--- a/tests/test_config/test_views.py
+++ b/tests/test_config/test_views.py
@@ -32,10 +32,13 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         name='',
     ):
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
 
         if exc_iface:
             classifier = IExceptionViewClassifier
@@ -113,9 +116,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         )
 
     def test_add_view_with_request_type(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import directlyProvides
+
         from pyramid.interfaces import IRequest
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         config = self._makeOne(autocommit=True)
@@ -296,6 +300,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_view_with_http_cache(self):
         import datetime
+
         from pyramid.response import Response
 
         response = Response('OK')
@@ -415,8 +420,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(request.__view__.__class__, view)
 
     def test_add_view_context_as_class(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
+
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
 
@@ -464,8 +470,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_view_for_as_class(self):
         # ``for_`` is older spelling for ``context``
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
+
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
 
@@ -505,11 +512,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper, view)
 
     def test_add_view_register_secured_view(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import ISecuredView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import IRequest, ISecuredView, IViewClassifier
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         view.__call_permissive__ = view
@@ -524,11 +530,14 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper, view)
 
     def test_add_view_exception_register_secured_view(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IView,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         view.__call_permissive__ = view
@@ -545,13 +554,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper, view)
 
     def test_add_view_same_phash_overrides_existing_single_view(self):
-        from pyramid.renderers import null_renderer
         from hashlib import md5
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         phash = md5()
         phash.update(b'xhr = True')
@@ -573,13 +585,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_exc_same_phash_overrides_existing_single_view(self):
-        from pyramid.renderers import null_renderer
         from hashlib import md5
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IView,
+        )
+        from pyramid.renderers import null_renderer
 
         phash = md5()
         phash.update(b'xhr = True')
@@ -611,12 +626,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_default_phash_overrides_no_phash(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'NOT OK'
         config = self._makeOne(autocommit=True)
@@ -635,12 +653,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_exc_default_phash_overrides_no_phash(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IView,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'NOT OK'
         config = self._makeOne(autocommit=True)
@@ -666,13 +687,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_default_phash_overrides_default_phash(self):
-        from pyramid.config.predicates import DEFAULT_PHASH
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.config.predicates import DEFAULT_PHASH
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'NOT OK'
         view.__phash__ = DEFAULT_PHASH
@@ -692,13 +716,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_exc_default_phash_overrides_default_phash(self):
-        from pyramid.config.predicates import DEFAULT_PHASH
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.config.predicates import DEFAULT_PHASH
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IView,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'NOT OK'
         view.__phash__ = DEFAULT_PHASH
@@ -725,12 +752,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_multiview_replaces_existing_view(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         view.__phash__ = 'abc'
@@ -744,13 +774,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, None), 'OK')
 
     def test_add_view_exc_multiview_replaces_existing_view(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         view.__phash__ = 'abc'
@@ -777,12 +810,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, None), 'OK')
 
     def test_add_view_multiview_replaces_existing_securedview(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import ISecuredView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            ISecuredView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         view.__phash__ = 'abc'
@@ -796,13 +832,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, None), 'OK')
 
     def test_add_view_exc_multiview_replaces_existing_securedview(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import ISecuredView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            ISecuredView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         view.__phash__ = 'abc'
@@ -829,12 +868,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, None), 'OK')
 
     def test_add_view_with_accept_multiview_replaces_existing_view(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         def view(context, request):
             return 'OK'
@@ -905,13 +947,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK3')
 
     def test_add_view_exc_with_accept_multiview_replaces_existing_view(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         def view(context, request):
             return 'OK'
@@ -950,12 +995,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK2')
 
     def test_add_view_multiview_replaces_existing_view_with___accept__(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         def view(context, request):
             return 'OK'
@@ -980,13 +1028,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_exc_mulview_replaces_existing_view_with___accept__(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         def view(context, request):
             return 'OK'
@@ -1024,11 +1075,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, request), 'OK')
 
     def test_add_view_multiview_replaces_multiview(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import IMultiView, IRequest, IViewClassifier
+        from pyramid.renderers import null_renderer
 
         view = DummyMultiView()
         config = self._makeOne(autocommit=True)
@@ -1045,12 +1095,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, None), 'OK1')
 
     def test_add_view_exc_multiview_replaces_multiviews(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         hot_view = DummyMultiView()
         exc_view = DummyMultiView()
@@ -1090,12 +1143,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(exc_wrapper(None, None), 'OK1')
 
     def test_add_view_exc_multiview_replaces_only_exc_multiview(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         hot_view = DummyMultiView()
         exc_view = DummyMultiView()
@@ -1136,12 +1192,15 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(exc_wrapper(None, None), 'OK1')
 
     def test_add_view_multiview_context_superclass_then_subclass(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         class ISuper(Interface):
             pass
@@ -1168,13 +1227,16 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper(None, None), 'OK2')
 
     def test_add_view_multiview_exception_superclass_then_subclass(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
+        from pyramid.renderers import null_renderer
 
         class Super(Exception):
             pass
@@ -1212,8 +1274,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(wrapper_exc_view(None, None), 'OK2')
 
     def test_add_view_multiview_call_ordering(self):
-        from pyramid.renderers import null_renderer as nr
         from zope.interface import directlyProvides
+
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):
             return 'view1'
@@ -1423,8 +1486,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(response, 'hello')
 
     def test_add_view_multiview___discriminator__(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
+
+        from pyramid.renderers import null_renderer
 
         class IFoo(Interface):
             pass
@@ -1443,10 +1507,12 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         foo = Foo()
         bar = Bar()
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
+        from pyramid.interfaces import (
+            IMultiView,
+            IRequest,
+            IView,
+            IViewClassifier,
+        )
 
         view = lambda *arg: 'OK'
         view.__phash__ = 'abc'
@@ -1465,8 +1531,8 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         )
 
     def test_add_view_with_template_renderer(self):
-        from tests import test_config
         from pyramid.interfaces import ISettings
+        from tests import test_config
 
         class view:
             def __init__(self, context, request):
@@ -1519,8 +1585,8 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(result.body, b'moo')
 
     def test_add_view_with_template_renderer_no_callable(self):
-        from tests import test_config
         from pyramid.interfaces import ISettings
+        from tests import test_config
 
         config = self._makeOne(autocommit=True)
         renderer = self._registerRenderer(config)
@@ -1540,8 +1606,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(result.settings, settings)
 
     def test_add_view_with_request_type_as_iface(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import directlyProvides
+
+        from pyramid.renderers import null_renderer
 
         def view(context, request):
             return 'OK'
@@ -1583,8 +1650,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertRaises(ConfigurationExecutionError, config.commit)
 
     def test_add_view_with_route_name_exception(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
+
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         config = self._makeOne(autocommit=True)
@@ -1867,8 +1935,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         )
 
     def test_add_view_with_containment_true(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import directlyProvides
+
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         config = self._makeOne(autocommit=True)
@@ -1887,8 +1956,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self._assertNotFound(wrapper, context, None)
 
     def test_add_view_with_containment_dottedname(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import directlyProvides
+
+        from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
         config = self._makeOne(autocommit=True)
@@ -1930,6 +2000,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_view_with_custom_predicates_match(self):
         import warnings
+
         from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
@@ -1975,6 +2046,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_view_custom_predicate_bests_standard_predicate(self):
         import warnings
+
         from pyramid.renderers import null_renderer
 
         view = lambda *arg: 'OK'
@@ -2158,9 +2230,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(Mapper.kw['mapper'], Mapper)
 
     def test_add_view_with_view_defaults(self):
-        from pyramid.renderers import null_renderer
-        from pyramid.exceptions import PredicateMismatch
         from zope.interface import directlyProvides
+
+        from pyramid.exceptions import PredicateMismatch
+        from pyramid.renderers import null_renderer
 
         class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
@@ -2183,9 +2256,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertRaises(PredicateMismatch, wrapper, context, request)
 
     def test_add_view_with_view_defaults_viewname_is_dottedname_kwarg(self):
-        from pyramid.renderers import null_renderer
-        from pyramid.exceptions import PredicateMismatch
         from zope.interface import directlyProvides
+
+        from pyramid.exceptions import PredicateMismatch
+        from pyramid.renderers import null_renderer
 
         config = self._makeOne(autocommit=True)
         config.add_view(
@@ -2202,9 +2276,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertRaises(PredicateMismatch, wrapper, context, request)
 
     def test_add_view_with_view_defaults_viewname_is_dottedname_nonkwarg(self):
-        from pyramid.renderers import null_renderer
-        from pyramid.exceptions import PredicateMismatch
         from zope.interface import directlyProvides
+
+        from pyramid.exceptions import PredicateMismatch
+        from pyramid.renderers import null_renderer
 
         config = self._makeOne(autocommit=True)
         config.add_view(
@@ -2249,8 +2324,8 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertRaises(ConfigurationConflictError, config.commit)
 
     def test_add_view_class_method_no_attr(self):
-        from pyramid.renderers import null_renderer
         from pyramid.exceptions import ConfigurationError
+        from pyramid.renderers import null_renderer
 
         config = self._makeOne(autocommit=True)
 
@@ -2265,6 +2340,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_view_exception_only_no_regular_view(self):
         from zope.interface import implementedBy
+
         from pyramid.renderers import null_renderer
 
         view1 = lambda *arg: 'OK'
@@ -2282,6 +2358,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_view_exception_only(self):
         from zope.interface import implementedBy
+
         from pyramid.renderers import null_renderer
 
         view1 = lambda *arg: 'OK'
@@ -2314,6 +2391,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_exception_view(self):
         from zope.interface import implementedBy
+
         from pyramid.renderers import null_renderer
 
         view1 = lambda *arg: 'OK'
@@ -2328,6 +2406,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_exception_view_with_subclass(self):
         from zope.interface import implementedBy
+
         from pyramid.renderers import null_renderer
 
         view1 = lambda *arg: 'OK'
@@ -2388,10 +2467,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         )
 
     def test_add_exception_view_with_view_defaults(self):
-        from pyramid.renderers import null_renderer
+        from zope.interface import directlyProvides, implementedBy
+
         from pyramid.exceptions import PredicateMismatch
-        from zope.interface import directlyProvides
-        from zope.interface import implementedBy
+        from pyramid.renderers import null_renderer
 
         class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
@@ -2482,10 +2561,10 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(result(None, request).body, b'foo')
 
     def test_add_static_view_here_no_utility_registered(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import Interface
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import IView, IViewClassifier
+        from pyramid.renderers import null_renderer
 
         config = self._makeOne(autocommit=True)
         config.add_static_view('static', 'files', renderer=null_renderer)
@@ -2526,6 +2605,7 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_static_view_absolute(self):
         import os
+
         from pyramid.interfaces import IStaticURLInfo
 
         info = DummyStaticURLInfo()
@@ -2537,10 +2617,11 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(info.added, [(config, 'static', static_path, {})])
 
     def test_add_forbidden_view(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
+
         from pyramid.httpexceptions import HTTPForbidden
+        from pyramid.interfaces import IRequest
+        from pyramid.renderers import null_renderer
 
         config = self._makeOne(autocommit=True)
         view = lambda *arg: 'OK'
@@ -2556,8 +2637,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_forbidden_view_no_view_argument(self):
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
+
         from pyramid.httpexceptions import HTTPForbidden
+        from pyramid.interfaces import IRequest
 
         config = self._makeOne(autocommit=True)
         config.setup_registry()
@@ -2611,12 +2693,12 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         )
 
     def test_add_forbidden_view_with_view_defaults(self):
-        from pyramid.interfaces import IRequest
-        from pyramid.renderers import null_renderer
+        from zope.interface import directlyProvides, implementedBy
+
         from pyramid.exceptions import PredicateMismatch
         from pyramid.httpexceptions import HTTPForbidden
-        from zope.interface import directlyProvides
-        from zope.interface import implementedBy
+        from pyramid.interfaces import IRequest
+        from pyramid.renderers import null_renderer
 
         class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
@@ -2643,10 +2725,11 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertRaises(PredicateMismatch, wrapper, context, request)
 
     def test_add_notfound_view(self):
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
+
         from pyramid.httpexceptions import HTTPNotFound
+        from pyramid.interfaces import IRequest
+        from pyramid.renderers import null_renderer
 
         config = self._makeOne(autocommit=True)
         view = lambda *arg: arg
@@ -2662,8 +2745,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_notfound_view_no_view_argument(self):
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
+
         from pyramid.httpexceptions import HTTPNotFound
+        from pyramid.interfaces import IRequest
 
         config = self._makeOne(autocommit=True)
         config.setup_registry()
@@ -2717,11 +2801,12 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         )
 
     def test_add_notfound_view_append_slash(self):
-        from pyramid.response import Response
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
+
+        from pyramid.httpexceptions import HTTPNotFound, HTTPTemporaryRedirect
         from pyramid.interfaces import IRequest
-        from pyramid.httpexceptions import HTTPTemporaryRedirect, HTTPNotFound
+        from pyramid.renderers import null_renderer
+        from pyramid.response import Response
 
         config = self._makeOne(autocommit=True)
         config.add_route('foo', '/foo/')
@@ -2746,11 +2831,12 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(result.location, '/scriptname/foo/?a=1&b=2')
 
     def test_add_notfound_view_append_slash_custom_response(self):
-        from pyramid.response import Response
-        from pyramid.renderers import null_renderer
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
+
         from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
+        from pyramid.interfaces import IRequest
+        from pyramid.renderers import null_renderer
+        from pyramid.response import Response
 
         config = self._makeOne(autocommit=True)
         config.add_route('foo', '/foo/')
@@ -2775,12 +2861,12 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(result.location, '/scriptname/foo/?a=1&b=2')
 
     def test_add_notfound_view_with_view_defaults(self):
-        from pyramid.interfaces import IRequest
-        from pyramid.renderers import null_renderer
+        from zope.interface import directlyProvides, implementedBy
+
         from pyramid.exceptions import PredicateMismatch
         from pyramid.httpexceptions import HTTPNotFound
-        from zope.interface import directlyProvides
-        from zope.interface import implementedBy
+        from pyramid.interfaces import IRequest
+        from pyramid.renderers import null_renderer
 
         class view:
             __view_defaults__ = {'containment': 'tests.test_config.IDummy'}
@@ -2808,8 +2894,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_notfound_view_with_renderer(self):
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
+
         from pyramid.httpexceptions import HTTPNotFound
+        from pyramid.interfaces import IRequest
 
         config = self._makeOne(autocommit=True)
         view = lambda *arg: {}
@@ -2826,8 +2913,9 @@ class TestViewsConfigurationMixin(unittest.TestCase):
 
     def test_add_forbidden_view_with_renderer(self):
         from zope.interface import implementedBy
-        from pyramid.interfaces import IRequest
+
         from pyramid.httpexceptions import HTTPForbidden
+        from pyramid.interfaces import IRequest
 
         config = self._makeOne(autocommit=True)
         view = lambda *arg: {}
@@ -2862,8 +2950,8 @@ class TestViewsConfigurationMixin(unittest.TestCase):
         self.assertEqual(result, test_config)
 
     def test_add_normal_and_exception_view_intr_derived_callable(self):
-        from pyramid.renderers import null_renderer
         from pyramid.exceptions import BadCSRFToken
+        from pyramid.renderers import null_renderer
 
         config = self._makeOne(autocommit=True)
         introspector = DummyIntrospector()
@@ -3114,12 +3202,14 @@ class TestMultiView(unittest.TestCase):
 
     def test_class_implements_ISecuredView(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import ISecuredView
 
         verifyClass(ISecuredView, self._getTargetClass())
 
     def test_instance_implements_ISecuredView(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import ISecuredView
 
         verifyObject(ISecuredView, self._makeOne())
@@ -3772,14 +3862,16 @@ class TestStaticURLInfo(unittest.TestCase):
         return request
 
     def test_verifyClass(self):
-        from pyramid.interfaces import IStaticURLInfo
         from zope.interface.verify import verifyClass
+
+        from pyramid.interfaces import IStaticURLInfo
 
         verifyClass(IStaticURLInfo, self._getTargetClass())
 
     def test_verifyObject(self):
-        from pyramid.interfaces import IStaticURLInfo
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import IStaticURLInfo
 
         verifyObject(IStaticURLInfo, self._makeOne())
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -9,12 +9,12 @@ if 0:
 
         @classmethod
         def test_docs(cls):
+            import manuel.capture
+            import manuel.codeblock
+            import manuel.ignore
+            import manuel.testing
             import os
             import pkg_resources
-            import manuel.testing
-            import manuel.codeblock
-            import manuel.capture
-            import manuel.ignore
 
             m = manuel.ignore.Manuel()
             m += manuel.codeblock.Manuel()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,15 +13,17 @@ class NewRequestEventTests(unittest.TestCase):
         return self._getTargetClass()(request)
 
     def test_class_conforms_to_INewRequest(self):
-        from pyramid.interfaces import INewRequest
         from zope.interface.verify import verifyClass
+
+        from pyramid.interfaces import INewRequest
 
         klass = self._getTargetClass()
         verifyClass(INewRequest, klass)
 
     def test_instance_conforms_to_INewRequest(self):
-        from pyramid.interfaces import INewRequest
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import INewRequest
 
         request = DummyRequest()
         inst = self._makeOne(request)
@@ -43,15 +45,17 @@ class NewResponseEventTests(unittest.TestCase):
         return self._getTargetClass()(request, response)
 
     def test_class_conforms_to_INewResponse(self):
-        from pyramid.interfaces import INewResponse
         from zope.interface.verify import verifyClass
+
+        from pyramid.interfaces import INewResponse
 
         klass = self._getTargetClass()
         verifyClass(INewResponse, klass)
 
     def test_instance_conforms_to_INewResponse(self):
-        from pyramid.interfaces import INewResponse
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import INewResponse
 
         request = DummyRequest()
         response = DummyResponse()
@@ -76,14 +80,16 @@ class ApplicationCreatedEventTests(unittest.TestCase):
         return self._getTargetClass()(context)
 
     def test_class_conforms_to_IApplicationCreated(self):
-        from pyramid.interfaces import IApplicationCreated
         from zope.interface.verify import verifyClass
+
+        from pyramid.interfaces import IApplicationCreated
 
         verifyClass(IApplicationCreated, self._getTargetClass())
 
     def test_object_conforms_to_IApplicationCreated(self):
-        from pyramid.interfaces import IApplicationCreated
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import IApplicationCreated
 
         verifyObject(IApplicationCreated, self._makeOne())
 
@@ -95,14 +101,16 @@ class WSGIApplicationCreatedEventTests(ApplicationCreatedEventTests):
         return WSGIApplicationCreatedEvent
 
     def test_class_conforms_to_IWSGIApplicationCreatedEvent(self):
-        from pyramid.interfaces import IWSGIApplicationCreatedEvent
         from zope.interface.verify import verifyClass
+
+        from pyramid.interfaces import IWSGIApplicationCreatedEvent
 
         verifyClass(IWSGIApplicationCreatedEvent, self._getTargetClass())
 
     def test_object_conforms_to_IWSGIApplicationCreatedEvent(self):
-        from pyramid.interfaces import IWSGIApplicationCreatedEvent
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import IWSGIApplicationCreatedEvent
 
         verifyObject(IWSGIApplicationCreatedEvent, self._makeOne())
 
@@ -120,12 +128,14 @@ class ContextFoundEventTests(unittest.TestCase):
 
     def test_class_conforms_to_IContextFound(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IContextFound
 
         verifyClass(IContextFound, self._getTargetClass())
 
     def test_instance_conforms_to_IContextFound(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IContextFound
 
         verifyObject(IContextFound, self._makeOne())
@@ -139,12 +149,14 @@ class AfterTraversalEventTests(ContextFoundEventTests):
 
     def test_class_conforms_to_IAfterTraversal(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IAfterTraversal
 
         verifyClass(IAfterTraversal, self._getTargetClass())
 
     def test_instance_conforms_to_IAfterTraversal(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IAfterTraversal
 
         verifyObject(IAfterTraversal, self._makeOne())
@@ -163,12 +175,14 @@ class BeforeTraversalEventTests(unittest.TestCase):
 
     def test_class_conforms_to_IBeforeTraversal(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IBeforeTraversal
 
         verifyClass(IBeforeTraversal, self._getTargetClass())
 
     def test_instance_conforms_to_IBeforeTraversal(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IBeforeTraversal
 
         verifyObject(IBeforeTraversal, self._makeOne())
@@ -312,6 +326,7 @@ class TestBeforeRender(unittest.TestCase):
     )  # see https://github.com/Pylons/pyramid/issues/3237
     def test_instance_conforms(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IBeforeRender
 
         event = self._makeOne({})

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -499,8 +499,8 @@ class TestLocalizerRequestMixin(unittest.TestCase):
         self.assertEqual(request.localizer, dummy)
 
     def test_localizer_from_mo(self):
-        from pyramid.interfaces import ITranslationDirectories
         from pyramid.i18n import Localizer
+        from pyramid.interfaces import ITranslationDirectories
 
         localedirs = [localedir]
         self.config.registry.registerUtility(
@@ -517,8 +517,8 @@ class TestLocalizerRequestMixin(unittest.TestCase):
         self.assertTrue(hasattr(result, 'pluralize'))
 
     def test_localizer_from_mo_bad_mo(self):
-        from pyramid.interfaces import ITranslationDirectories
         from pyramid.i18n import Localizer
+        from pyramid.interfaces import ITranslationDirectories
 
         localedirs = [localedir]
         self.config.registry.registerUtility(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,8 +34,8 @@ def wsgiapptest(environ, start_response):
 
 class WGSIAppPlusViewConfigTests(unittest.TestCase):
     def test_it(self):
-        from venusian import ATTACH_ATTR
         import types
+        from venusian import ATTACH_ATTR
 
         self.assertTrue(getattr(wsgiapptest, ATTACH_ATTR))
         self.assertIsInstance(wsgiapptest, types.FunctionType)
@@ -45,10 +45,9 @@ class WGSIAppPlusViewConfigTests(unittest.TestCase):
         self.assertEqual(result, '123')
 
     def test_scanned(self):
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
         from pyramid.config import Configurator
+        from pyramid.interfaces import IRequest, IView, IViewClassifier
+
         from . import test_integration
 
         config = Configurator()
@@ -281,8 +280,9 @@ class TestStaticAppNoSubpath(unittest.TestCase):
     staticapp = static_view(os.path.join(here, 'fixtures'), use_subpath=False)
 
     def _makeRequest(self, extra):
-        from pyramid.request import Request
         from io import BytesIO
+
+        from pyramid.request import Request
 
         kw = {
             'PATH_INFO': '',

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -28,6 +28,7 @@ class TestCallerPath(unittest.TestCase):
 
     def test_memoization_has_abspath(self):
         import os
+
         from . import test_path
 
         test_path.__abspath__ = '/foo/bar'
@@ -36,6 +37,7 @@ class TestCallerPath(unittest.TestCase):
 
     def test_memoization_success(self):
         import os
+
         from . import test_path
 
         result = self._callFUT('a/b/c')
@@ -166,8 +168,8 @@ class TestPackageOf(unittest.TestCase):
         self.assertEqual(result, tests)
 
     def test_it_module(self):
-        import tests.test_path
         import tests
+        import tests.test_path
 
         package = DummyPackageOrModule(tests.test_path)
         result = self._callFUT(package)
@@ -222,8 +224,8 @@ class TestResolver(unittest.TestCase):
         return self._getTargetClass()(package)
 
     def test_get_package_caller_package(self):
-        import tests
         from pyramid.path import CALLER_PACKAGE
+        import tests
 
         self.assertEqual(self._makeOne(CALLER_PACKAGE).get_package(), tests)
 
@@ -295,8 +297,7 @@ class TestAssetResolver(unittest.TestCase):
         self.assertRaises(ValueError, inst.resolve, 'test_asset.py')
 
     def test_resolve_relspec_caller_package(self):
-        from pyramid.path import PkgResourcesAssetDescriptor
-        from pyramid.path import CALLER_PACKAGE
+        from pyramid.path import CALLER_PACKAGE, PkgResourcesAssetDescriptor
 
         inst = self._makeOne(CALLER_PACKAGE)
         r = inst.resolve('test_asset.py')
@@ -314,14 +315,16 @@ class TestPkgResourcesAssetDescriptor(unittest.TestCase):
         return self._getTargetClass()(pkg, path)
 
     def test_class_conforms_to_IAssetDescriptor(self):
-        from pyramid.interfaces import IAssetDescriptor
         from zope.interface.verify import verifyClass
+
+        from pyramid.interfaces import IAssetDescriptor
 
         verifyClass(IAssetDescriptor, self._getTargetClass())
 
     def test_instance_conforms_to_IAssetDescriptor(self):
-        from pyramid.interfaces import IAssetDescriptor
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import IAssetDescriptor
 
         verifyObject(IAssetDescriptor, self._makeOne())
 
@@ -369,14 +372,16 @@ class TestFSAssetDescriptor(unittest.TestCase):
         return self._getTargetClass()(path)
 
     def test_class_conforms_to_IAssetDescriptor(self):
-        from pyramid.interfaces import IAssetDescriptor
         from zope.interface.verify import verifyClass
+
+        from pyramid.interfaces import IAssetDescriptor
 
         verifyClass(IAssetDescriptor, self._getTargetClass())
 
     def test_instance_conforms_to_IAssetDescriptor(self):
-        from pyramid.interfaces import IAssetDescriptor
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import IAssetDescriptor
 
         verifyObject(IAssetDescriptor, self._makeOne())
 
@@ -611,6 +616,7 @@ class TestDottedNameResolver(unittest.TestCase):
 
     def test_ctor_module(self):
         import tests
+
         from . import test_path
 
         typ = self._makeOne(test_path)

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -453,8 +453,8 @@ class Test_EffectivePrincipalsPredicate(unittest.TestCase):
         return EffectivePrincipalsPredicate(val, config)
 
     def _testing_authn_policy(self, userid, groupids=tuple()):
+        from pyramid.authorization import Authenticated, Everyone
         from pyramid.interfaces import IAuthenticationPolicy, ISecurityPolicy
-        from pyramid.authorization import Everyone, Authenticated
         from pyramid.security import LegacySecurityPolicy
 
         class DummyPolicy:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -100,8 +100,8 @@ class TestIntrospector(unittest.TestCase):
         return self._getTargetClass()()
 
     def test_conformance(self):
-        from zope.interface.verify import verifyClass
-        from zope.interface.verify import verifyObject
+        from zope.interface.verify import verifyClass, verifyObject
+
         from pyramid.interfaces import IIntrospector
 
         verifyClass(IIntrospector, self._getTargetClass())
@@ -346,8 +346,8 @@ class TestIntrospectable(unittest.TestCase):
         return self._makeOne('category', 'discrim', 'title', 'type')
 
     def test_conformance(self):
-        from zope.interface.verify import verifyClass
-        from zope.interface.verify import verifyObject
+        from zope.interface.verify import verifyClass, verifyObject
+
         from pyramid.interfaces import IIntrospectable
 
         verifyClass(IIntrospectable, self._getTargetClass())

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -157,6 +157,7 @@ class TestRendererHelper(unittest.TestCase):
 
     def test_instance_conforms(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IRendererInfo
 
         helper = self._makeOne()
@@ -419,8 +420,9 @@ class TestRendererHelper(unittest.TestCase):
         registry = self.config.registry
         settings = {}
         registry.settings = settings
-        from pyramid.interfaces import IRendererFactory
         import os
+
+        from pyramid.interfaces import IRendererFactory
 
         here = os.path.dirname(os.path.abspath(__file__))
         fixture = os.path.join(here, 'fixtures/minimal.pt')
@@ -444,8 +446,9 @@ class TestRendererHelper(unittest.TestCase):
         registry = self.config.registry
         settings = {}
         registry.settings = settings
-        from pyramid.interfaces import IRendererFactory
         import os
+
+        from pyramid.interfaces import IRendererFactory
 
         here = os.path.dirname(os.path.abspath(__file__))
         fixture = os.path.join(here, 'fixtures/minimal.pt')
@@ -482,6 +485,7 @@ class TestNullRendererHelper(unittest.TestCase):
 
     def test_instance_conforms(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IRendererInfo
 
         helper = self._makeOne()

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -23,8 +23,9 @@ class TestRequest(unittest.TestCase):
         return self._getTargetClass()(environ)
 
     def _registerResourceURL(self):
-        from pyramid.interfaces import IResourceURL
         from zope.interface import Interface
+
+        from pyramid.interfaces import IResourceURL
 
         class DummyResourceURL:
             def __init__(self, context, request):
@@ -37,12 +38,14 @@ class TestRequest(unittest.TestCase):
 
     def test_class_conforms_to_IRequest(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import IRequest
 
         verifyClass(IRequest, self._getTargetClass())
 
     def test_instance_conforms_to_IRequest(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import IRequest
 
         verifyObject(IRequest, self._makeOne())
@@ -555,10 +558,11 @@ class Test_subclassing_Request(unittest.TestCase):
         self.assertTrue(hasattr(RequestSub, '__provides__'))
 
     def test_subclass_with_implementer(self):
+        from zope.interface import implementer
+
         from pyramid.interfaces import IRequest
         from pyramid.request import Request
         from pyramid.util import InstancePropertyHelper
-        from zope.interface import implementer
 
         @implementer(IRequest)
         class RequestSub(Request):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -75,6 +75,7 @@ class TestFileResponse(unittest.TestCase):
         # version of Python.  See https://github.com/Pylons/pyramid/issues/1360
         # for more information.
         import mimetypes as old_mimetypes
+
         from pyramid import response
         from pyramid.util import text_
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -161,11 +161,9 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(router.request_factory, DummyRequestFactory)
 
     def test_tween_factories(self):
-        from pyramid.interfaces import ITweens
         from pyramid.config.tweens import Tweens
+        from pyramid.interfaces import IResponse, ITweens, IViewClassifier
         from pyramid.response import Response
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IResponse
 
         tweens = Tweens()
         self.registry.registerUtility(tweens, ITweens)
@@ -346,9 +344,8 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(ValueError, router, environ, start_response)
 
     def test_call_view_returns_adapted_response(self):
+        from pyramid.interfaces import IResponse, IViewClassifier
         from pyramid.response import Response
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IResponse
 
         context = DummyContext()
         self._registerTraverserFactory(context)
@@ -369,9 +366,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(start_response.status, '200 OK')
 
     def test_call_with_request_extensions(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IRequestExtensions
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IRequest,
+            IRequestExtensions,
+            IViewClassifier,
+        )
         from pyramid.request import Request
         from pyramid.util import InstancePropertyHelper
 
@@ -461,14 +460,12 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(request.root, context)
 
     def test_call_view_registered_specific_success(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
 
         class IContext(Interface):
             pass
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         context = DummyContext()
         directlyProvides(context, IContext)
@@ -492,8 +489,8 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(request.root, context)
 
     def test_call_view_registered_specific_fail(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
+
         from pyramid.httpexceptions import HTTPNotFound
         from pyramid.interfaces import IViewClassifier
 
@@ -517,15 +514,14 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(HTTPNotFound, router, environ, start_response)
 
     def test_call_view_raises_forbidden(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
+
         from pyramid.httpexceptions import HTTPForbidden
 
         class IContext(Interface):
             pass
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         context = DummyContext()
         directlyProvides(context, IContext)
@@ -542,15 +538,13 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(why.args[0], 'unauthorized')
 
     def test_call_view_raises_notfound(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
 
         class IContext(Interface):
             pass
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
         from pyramid.httpexceptions import HTTPNotFound
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         context = DummyContext()
         directlyProvides(context, IContext)
@@ -565,15 +559,14 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(why.args[0], 'notfound')
 
     def test_call_view_raises_response_cleared(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
+
         from pyramid.interfaces import IExceptionViewClassifier
 
         class IContext(Interface):
             pass
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         context = DummyContext()
         directlyProvides(context, IContext)
@@ -599,14 +592,12 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(itera, [b'OK'])
 
     def test_call_request_has_response_callbacks(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
 
         class IContext(Interface):
             pass
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         context = DummyContext()
         directlyProvides(context, IContext)
@@ -628,14 +619,12 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(response.called_back, True)
 
     def test_call_request_has_finished_callbacks_when_view_succeeds(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
 
         class IContext(Interface):
             pass
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         context = DummyContext()
         directlyProvides(context, IContext)
@@ -657,14 +646,12 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(environ['called_back'], True)
 
     def test_call_request_has_finished_callbacks_when_view_raises(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
 
         class IContext(Interface):
             pass
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         context = DummyContext()
         directlyProvides(context, IContext)
@@ -697,11 +684,13 @@ class TestRouter(unittest.TestCase):
         exc_raised(NotImplementedError, router, environ, start_response)
 
     def test_call_eventsends(self):
-        from pyramid.interfaces import INewRequest
-        from pyramid.interfaces import INewResponse
-        from pyramid.interfaces import IBeforeTraversal
-        from pyramid.interfaces import IContextFound
-        from pyramid.interfaces import IViewClassifier
+        from pyramid.interfaces import (
+            IBeforeTraversal,
+            IContextFound,
+            INewRequest,
+            INewResponse,
+            IViewClassifier,
+        )
 
         context = DummyContext()
         self._registerTraverserFactory(context)
@@ -730,9 +719,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result, response.app_iter)
 
     def test_call_newrequest_evllist_exc_can_be_caught_by_exceptionview(self):
-        from pyramid.interfaces import INewRequest
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            INewRequest,
+            IRequest,
+        )
 
         context = DummyContext()
         self._registerTraverserFactory(context)
@@ -822,10 +813,9 @@ class TestRouter(unittest.TestCase):
         )
 
     def test_call_route_matches_doesnt_overwrite_subscriber_iface(self):
-        from pyramid.interfaces import INewRequest
-        from pyramid.interfaces import IViewClassifier
-        from zope.interface import alsoProvides
-        from zope.interface import Interface
+        from zope.interface import Interface, alsoProvides
+
+        from pyramid.interfaces import INewRequest, IViewClassifier
 
         self._registerRouteRequest('foo')
 
@@ -867,10 +857,10 @@ class TestRouter(unittest.TestCase):
         self.assertTrue(IFoo.providedBy(request))
 
     def test_root_factory_raises_notfound(self):
-        from pyramid.interfaces import IRootFactory
+        from zope.interface import Interface, directlyProvides
+
         from pyramid.httpexceptions import HTTPNotFound
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from pyramid.interfaces import IRootFactory
 
         def rootfactory(request):
             raise HTTPNotFound('from root factory')
@@ -889,10 +879,10 @@ class TestRouter(unittest.TestCase):
         self.assertTrue('from root factory' in why.args[0])
 
     def test_root_factory_raises_forbidden(self):
-        from pyramid.interfaces import IRootFactory
+        from zope.interface import Interface, directlyProvides
+
         from pyramid.httpexceptions import HTTPForbidden
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from pyramid.interfaces import IRootFactory
 
         def rootfactory(request):
             raise HTTPForbidden('from root factory')
@@ -911,9 +901,9 @@ class TestRouter(unittest.TestCase):
         self.assertTrue('from root factory' in why.args[0])
 
     def test_root_factory_exception_propagating(self):
+        from zope.interface import Interface, directlyProvides
+
         from pyramid.interfaces import IRootFactory
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
 
         def rootfactory(request):
             raise RuntimeError()
@@ -939,16 +929,17 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(RuntimeError, router, environ, start_response)
 
     def test_call_view_exception_propagating(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
 
         class IContext(Interface):
             pass
 
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IRequestFactory
-        from pyramid.interfaces import IExceptionViewClassifier
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IRequestFactory,
+            IViewClassifier,
+        )
 
         def rfactory(environ):
             return request
@@ -989,9 +980,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(request.exc_info[:2], (RuntimeError, error))
 
     def test_call_view_raises_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         response = DummyResponse()
         exception_response = DummyResponse()
@@ -1017,9 +1010,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result, ["Hello, world"])
 
     def test_call_view_raises_super_exception_sub_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         class SuperException(Exception):
             pass
@@ -1046,9 +1041,11 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(SuperException, router, environ, start_response)
 
     def test_call_view_raises_sub_exception_super_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         class SuperException(Exception):
             pass
@@ -1076,9 +1073,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result, ["Hello, world"])
 
     def test_call_view_raises_exception_another_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         class MyException(Exception):
             pass
@@ -1105,9 +1104,11 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(MyException, router, environ, start_response)
 
     def test_root_factory_raises_exception_view(self):
-        from pyramid.interfaces import IRootFactory
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IExceptionViewClassifier
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IRootFactory,
+        )
 
         def rootfactory(request):
             raise RuntimeError()
@@ -1130,8 +1131,7 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(app_iter, ["Hello, world"])
 
     def test_traverser_raises_exception_view(self):
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IExceptionViewClassifier
+        from pyramid.interfaces import IExceptionViewClassifier, IRequest
 
         environ = self._makeEnviron()
         context = DummyContext()
@@ -1152,9 +1152,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result, ["Hello, world"])
 
     def test_exception_view_returns_non_iresponse(self):
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         environ = self._makeEnviron()
         response = DummyResponse()
@@ -1176,8 +1178,10 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(ValueError, router, environ, start_response)
 
     def test_call_route_raises_route_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IViewClassifier,
+        )
 
         req_iface = self._registerRouteRequest('foo')
         self._connectRoute('foo', 'archives/:action/:article', None)
@@ -1200,9 +1204,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result, ["Hello, world"])
 
     def test_call_view_raises_exception_route_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         req_iface = self._registerRouteRequest('foo')
         self._connectRoute('foo', 'archives/:action/:article', None)
@@ -1224,9 +1230,11 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(RuntimeError, router, environ, start_response)
 
     def test_call_route_raises_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         req_iface = self._registerRouteRequest('foo')
         self._connectRoute('foo', 'archives/:action/:article', None)
@@ -1249,9 +1257,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result, ["Hello, world"])
 
     def test_call_route_raises_super_exception_sub_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         class SuperException(Exception):
             pass
@@ -1279,9 +1289,11 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(SuperException, router, environ, start_response)
 
     def test_call_route_raises_sub_exception_super_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         class SuperException(Exception):
             pass
@@ -1310,9 +1322,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result, ["Hello, world"])
 
     def test_call_route_raises_exception_another_exception_view(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         class MyException(Exception):
             pass
@@ -1340,9 +1354,11 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(MyException, router, environ, start_response)
 
     def test_call_route_raises_exception_view_specializing(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         req_iface = self._registerRouteRequest('foo')
         self._connectRoute('foo', 'archives/:action/:article', None)
@@ -1375,8 +1391,10 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result, ["Hello, special world"])
 
     def test_call_route_raises_exception_view_another_route(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IViewClassifier,
+        )
 
         req_iface = self._registerRouteRequest('foo')
         another_req_iface = self._registerRouteRequest('bar')
@@ -1399,9 +1417,11 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(RuntimeError, router, environ, start_response)
 
     def test_call_view_raises_exception_view_route(self):
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         req_iface = self._registerRouteRequest('foo')
         response = DummyResponse()
@@ -1424,8 +1444,7 @@ class TestRouter(unittest.TestCase):
 
     def test_call_view_raises_predicate_mismatch(self):
         from pyramid.exceptions import PredicateMismatch
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         view = DummyView(DummyResponse(), raise_exception=PredicateMismatch)
         self._registerView(view, '', IViewClassifier, IRequest, None)
@@ -1436,8 +1455,7 @@ class TestRouter(unittest.TestCase):
 
     def test_call_view_predicate_mismatch_doesnt_hide_views(self):
         from pyramid.exceptions import PredicateMismatch
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IRequest, IResponse
+        from pyramid.interfaces import IRequest, IResponse, IViewClassifier
         from pyramid.response import Response
 
         class BaseContext:
@@ -1470,11 +1488,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(app_iter, [b'abc'])
 
     def test_call_view_multiple_predicate_mismatches_dont_hide_views(self):
-        from pyramid.exceptions import PredicateMismatch
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IRequest, IResponse
-        from pyramid.response import Response
         from zope.interface import Interface, implementer
+
+        from pyramid.exceptions import PredicateMismatch
+        from pyramid.interfaces import IRequest, IResponse, IViewClassifier
+        from pyramid.response import Response
 
         class IBaseContext(Interface):
             pass
@@ -1512,10 +1530,10 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(app_iter, [b'abc'])
 
     def test_call_view_predicate_mismatch_doesnt_find_unrelated_views(self):
-        from pyramid.exceptions import PredicateMismatch
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IRequest
         from zope.interface import Interface, implementer
+
+        from pyramid.exceptions import PredicateMismatch
+        from pyramid.interfaces import IRequest, IViewClassifier
 
         class IContext(Interface):
             pass
@@ -1562,9 +1580,11 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(resp.body, b'foo')
 
     def test_execution_policy_bubbles_exception(self):
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IExceptionViewClassifier
-        from pyramid.interfaces import IRequest
+        from pyramid.interfaces import (
+            IExceptionViewClassifier,
+            IRequest,
+            IViewClassifier,
+        )
 
         class Exception1(Exception):
             pass
@@ -1594,10 +1614,10 @@ class TestRouter(unittest.TestCase):
         self.assertRaises(Exception2, lambda: router(environ, start_response))
 
     def test_request_context_with_statement(self):
-        from pyramid.threadlocal import get_current_request
         from pyramid.interfaces import IExecutionPolicy
         from pyramid.request import Request
         from pyramid.response import Response
+        from pyramid.threadlocal import get_current_request
 
         registry = self.config.registry
         result = []
@@ -1617,10 +1637,10 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(result[1], None)
 
     def test_request_context_manually(self):
-        from pyramid.threadlocal import get_current_request
         from pyramid.interfaces import IExecutionPolicy
         from pyramid.request import Request
         from pyramid.response import Response
+        from pyramid.threadlocal import get_current_request
 
         registry = self.config.registry
         result = []

--- a/tests/test_scripts/test_proutes.py
+++ b/tests/test_scripts/test_proutes.py
@@ -118,6 +118,7 @@ class TestPRoutesCommand(unittest.TestCase):
 
     def test_single_route_no_views_registered(self):
         from zope.interface import Interface
+
         from pyramid.interfaces import IRouteRequest
 
         registry = self._makeRegistry()
@@ -143,9 +144,8 @@ class TestPRoutesCommand(unittest.TestCase):
 
     def test_single_route_one_view_registered(self):
         from zope.interface import Interface
-        from pyramid.interfaces import IRouteRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IView
+
+        from pyramid.interfaces import IRouteRequest, IView, IViewClassifier
 
         registry = self._makeRegistry()
 
@@ -176,9 +176,8 @@ class TestPRoutesCommand(unittest.TestCase):
 
     def test_one_route_with_long_name_one_view_registered(self):
         from zope.interface import Interface
-        from pyramid.interfaces import IRouteRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IView
+
+        from pyramid.interfaces import IRouteRequest, IView, IViewClassifier
 
         registry = self._makeRegistry()
 
@@ -249,9 +248,8 @@ class TestPRoutesCommand(unittest.TestCase):
 
     def test_single_route_one_view_registered_with_factory(self):
         from zope.interface import Interface
-        from pyramid.interfaces import IRouteRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IView
+
+        from pyramid.interfaces import IRouteRequest, IView, IViewClassifier
 
         registry = self._makeRegistry()
 
@@ -286,9 +284,12 @@ class TestPRoutesCommand(unittest.TestCase):
 
     def test_single_route_multiview_registered(self):
         from zope.interface import Interface
-        from pyramid.interfaces import IRouteRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRouteRequest,
+            IViewClassifier,
+        )
 
         registry = self._makeRegistry()
 
@@ -526,8 +527,8 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(compare_to, expected)
 
     def test_route_is_get_view_request_method_not_post(self):
-        from pyramid.renderers import null_renderer as nr
         from pyramid.config import not_
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):  # pragma: no cover
             return 'view1'
@@ -558,8 +559,8 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(compare_to, expected)
 
     def test_view_request_method_not_post(self):
-        from pyramid.renderers import null_renderer as nr
         from pyramid.config import not_
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):  # pragma: no cover
             return 'view1'
@@ -590,8 +591,8 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(compare_to, expected)
 
     def test_view_glob(self):
-        from pyramid.renderers import null_renderer as nr
         from pyramid.config import not_
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):  # pragma: no cover
             return 'view1'
@@ -635,8 +636,8 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(compare_to, expected)
 
     def test_good_format(self):
-        from pyramid.renderers import null_renderer as nr
         from pyramid.config import not_
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):  # pragma: no cover
             return 'view1'
@@ -666,8 +667,8 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(L[0].split(), ['Method', 'Name'])
 
     def test_bad_format(self):
-        from pyramid.renderers import null_renderer as nr
         from pyramid.config import not_
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):  # pragma: no cover
             return 'view1'
@@ -696,8 +697,8 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(L[0], expected)
 
     def test_config_format_ini_newlines(self):
-        from pyramid.renderers import null_renderer as nr
         from pyramid.config import not_
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):  # pragma: no cover
             return 'view1'
@@ -730,8 +731,8 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(L[0].split(), ['Method', 'Name'])
 
     def test_config_format_ini_spaces(self):
-        from pyramid.renderers import null_renderer as nr
         from pyramid.config import not_
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):  # pragma: no cover
             return 'view1'
@@ -764,8 +765,8 @@ class TestPRoutesCommand(unittest.TestCase):
         self.assertEqual(L[0].split(), ['Method', 'Name'])
 
     def test_config_format_ini_commas(self):
-        from pyramid.renderers import null_renderer as nr
         from pyramid.config import not_
+        from pyramid.renderers import null_renderer as nr
 
         def view1(context, request):  # pragma: no cover
             return 'view1'

--- a/tests/test_scripts/test_pviews.py
+++ b/tests/test_scripts/test_pviews.py
@@ -40,13 +40,11 @@ class TestPViewsCommand(unittest.TestCase):
         self.assertEqual(result, None)
 
     def test__find_view_no_match_multiview_registered(self):
-        from zope.interface import implementer
-        from zope.interface import providedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
-        from pyramid.traversal import DefaultRootFactory
+        from zope.interface import implementer, providedBy
+
+        from pyramid.interfaces import IMultiView, IRequest, IViewClassifier
         from pyramid.registry import Registry
+        from pyramid.traversal import DefaultRootFactory
 
         registry = Registry()
 
@@ -69,11 +67,10 @@ class TestPViewsCommand(unittest.TestCase):
 
     def test__find_view_traversal(self):
         from zope.interface import providedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IView
-        from pyramid.traversal import DefaultRootFactory
+
+        from pyramid.interfaces import IRequest, IView, IViewClassifier
         from pyramid.registry import Registry
+        from pyramid.traversal import DefaultRootFactory
 
         registry = Registry()
 
@@ -94,13 +91,11 @@ class TestPViewsCommand(unittest.TestCase):
         self.assertEqual(result, view1)
 
     def test__find_view_traversal_multiview(self):
-        from zope.interface import implementer
-        from zope.interface import providedBy
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IMultiView
-        from pyramid.traversal import DefaultRootFactory
+        from zope.interface import implementer, providedBy
+
+        from pyramid.interfaces import IMultiView, IRequest, IViewClassifier
         from pyramid.registry import Registry
+        from pyramid.traversal import DefaultRootFactory
 
         registry = Registry()
 
@@ -123,11 +118,9 @@ class TestPViewsCommand(unittest.TestCase):
         self.assertEqual(result, view)
 
     def test__find_view_route_no_multiview(self):
-        from zope.interface import Interface
-        from zope.interface import implementer
-        from pyramid.interfaces import IRouteRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IView
+        from zope.interface import Interface, implementer
+
+        from pyramid.interfaces import IRouteRequest, IView, IViewClassifier
         from pyramid.registry import Registry
 
         registry = Registry()
@@ -162,11 +155,9 @@ class TestPViewsCommand(unittest.TestCase):
         self.assertEqual(result, view)
 
     def test__find_view_route_multiview_no_view_registered(self):
-        from zope.interface import Interface
-        from zope.interface import implementer
-        from pyramid.interfaces import IRouteRequest
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IRootFactory
+        from zope.interface import Interface, implementer
+
+        from pyramid.interfaces import IMultiView, IRootFactory, IRouteRequest
         from pyramid.registry import Registry
 
         registry = Registry()
@@ -206,13 +197,15 @@ class TestPViewsCommand(unittest.TestCase):
         self.assertTrue(IMultiView.providedBy(result))
 
     def test__find_view_route_multiview(self):
-        from zope.interface import Interface
-        from zope.interface import implementer
-        from pyramid.interfaces import IRouteRequest
-        from pyramid.interfaces import IViewClassifier
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IMultiView
-        from pyramid.interfaces import IRootFactory
+        from zope.interface import Interface, implementer
+
+        from pyramid.interfaces import (
+            IMultiView,
+            IRootFactory,
+            IRouteRequest,
+            IView,
+            IViewClassifier,
+        )
         from pyramid.registry import Registry
 
         registry = Registry()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -243,10 +243,10 @@ class TestViewExecutionPermitted(unittest.TestCase):
         return view_execution_permitted(*arg, **kw)
 
     def _registerSecuredView(self, view_name, allow=True):
-        from pyramid.threadlocal import get_current_registry
         from zope.interface import Interface
-        from pyramid.interfaces import ISecuredView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import ISecuredView, IViewClassifier
+        from pyramid.threadlocal import get_current_registry
 
         class Checker:
             def __permitted__(self, context, request):
@@ -266,10 +266,9 @@ class TestViewExecutionPermitted(unittest.TestCase):
 
     def test_no_permission(self):
         from zope.interface import Interface
+
+        from pyramid.interfaces import ISettings, IView, IViewClassifier
         from pyramid.threadlocal import get_current_registry
-        from pyramid.interfaces import ISettings
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
 
         settings = dict(debug_authorization=True)
         reg = get_current_registry()
@@ -291,8 +290,8 @@ class TestViewExecutionPermitted(unittest.TestCase):
         self.assertEqual(result, True)
 
     def test_no_view_registered(self):
-        from pyramid.threadlocal import get_current_registry
         from pyramid.interfaces import ISettings
+        from pyramid.threadlocal import get_current_registry
 
         settings = dict(debug_authorization=True)
         reg = get_current_registry()
@@ -302,8 +301,8 @@ class TestViewExecutionPermitted(unittest.TestCase):
         self.assertRaises(TypeError, self._callFUT, context, request, '')
 
     def test_with_permission(self):
-        from zope.interface import Interface
-        from zope.interface import directlyProvides
+        from zope.interface import Interface, directlyProvides
+
         from pyramid.interfaces import IRequest
 
         class IContext(Interface):
@@ -459,8 +458,8 @@ class TestHasPermission(unittest.TestCase):
         testing.tearDown()
 
     def _makeOne(self):
-        from pyramid.security import SecurityAPIMixin
         from pyramid.registry import Registry
+        from pyramid.security import SecurityAPIMixin
 
         mixin = SecurityAPIMixin()
         mixin.registry = Registry()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -14,6 +14,7 @@ class SharedCookieSessionTests:
 
     def test_instance_conforms(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import ISession
 
         request = testing.DummyRequest()
@@ -477,8 +478,8 @@ class TestSignedCookieSession(SharedCookieSessionTests, unittest.TestCase):
         self.assertEqual(session['state'], 1)
 
     def test_invalid_data_size(self):
-        from hashlib import sha512
         import base64
+        from hashlib import sha512
 
         request = testing.DummyRequest()
         num_bytes = sha512().digest_size - 1

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -134,8 +134,8 @@ class TestDummyRequest(unittest.TestCase):
         self.assertEqual(request.environ['PATH_INFO'], '/foo')
 
     def test_defaults(self):
-        from pyramid.threadlocal import get_current_registry
         from pyramid.testing import DummySession
+        from pyramid.threadlocal import get_current_registry
 
         request = self._makeOne()
         self.assertEqual(request.method, 'GET')
@@ -214,8 +214,8 @@ class TestDummyRequest(unittest.TestCase):
 
     def test_registry_is_config_registry_when_setup_is_called_after_ctor(self):
         # see https://github.com/Pylons/pyramid/issues/165
-        from pyramid.registry import Registry
         from pyramid.config import Configurator
+        from pyramid.registry import Registry
 
         request = self._makeOne()
         try:
@@ -233,8 +233,8 @@ class TestDummyRequest(unittest.TestCase):
 
     def test_del_registry(self):
         # see https://github.com/Pylons/pyramid/issues/165
-        from pyramid.registry import Registry
         from pyramid.config import Configurator
+        from pyramid.registry import Registry
 
         request = self._makeOne()
         request.registry = 'abc'
@@ -249,8 +249,8 @@ class TestDummyRequest(unittest.TestCase):
             config.end()
 
     def test_response_with_responsefactory(self):
-        from pyramid.registry import Registry
         from pyramid.interfaces import IResponseFactory
+        from pyramid.registry import Registry
 
         registry = Registry('this_test')
 
@@ -351,9 +351,8 @@ class Test_setUp(unittest.TestCase):
         self.assertEqual(result, hook)
 
     def test_it_defaults(self):
-        from pyramid.threadlocal import manager
-        from pyramid.threadlocal import get_current_registry
         from pyramid.registry import Registry
+        from pyramid.threadlocal import get_current_registry, manager
 
         old = True
         manager.push(old)
@@ -597,6 +596,7 @@ class TestDummySession(unittest.TestCase):
     )  # see https://github.com/Pylons/pyramid/issues/3237
     def test_instance_conforms(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import ISession
 
         session = self._makeOne()

--- a/tests/test_traversal.py
+++ b/tests/test_traversal.py
@@ -119,12 +119,14 @@ class ResourceTreeTraverserTests(unittest.TestCase):
 
     def test_class_conforms_to_ITraverser(self):
         from zope.interface.verify import verifyClass
+
         from pyramid.interfaces import ITraverser
 
         verifyClass(ITraverser, self._getTargetClass())
 
     def test_instance_conforms_to_ITraverser(self):
         from zope.interface.verify import verifyObject
+
         from pyramid.interfaces import ITraverser
 
         context = DummyContext()
@@ -494,8 +496,7 @@ class FindInterfaceTests(unittest.TestCase):
         bar.__name__ = 'bar'
         baz.__parent__ = bar
         baz.__name__ = 'baz'
-        from zope.interface import directlyProvides
-        from zope.interface import Interface
+        from zope.interface import Interface, directlyProvides
 
         class IFoo(Interface):
             pass
@@ -552,8 +553,9 @@ class FindResourceTests(unittest.TestCase):
         from pyramid.threadlocal import get_current_registry
 
         reg = get_current_registry()
-        from pyramid.interfaces import ITraverser
         from zope.interface import Interface
+
+        from pyramid.interfaces import ITraverser
 
         reg.registerAdapter(traverser, (Interface,), ITraverser)
 
@@ -888,8 +890,9 @@ class ResourceURLTests(unittest.TestCase):
         return ResourceURL
 
     def test_instance_conforms_to_IResourceURL(self):
-        from pyramid.interfaces import IResourceURL
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import IResourceURL
 
         context = DummyContext()
         request = DummyRequest()
@@ -978,8 +981,9 @@ class TestVirtualRoot(unittest.TestCase):
         from pyramid.threadlocal import get_current_registry
 
         reg = get_current_registry()
-        from pyramid.interfaces import ITraverser
         from zope.interface import Interface
+
+        from pyramid.interfaces import ITraverser
 
         reg.registerAdapter(traverser, (Interface,), ITraverser)
 
@@ -1051,8 +1055,9 @@ class TraverseTests(unittest.TestCase):
         from pyramid.threadlocal import get_current_registry
 
         reg = get_current_registry()
-        from pyramid.interfaces import ITraverser
         from zope.interface import Interface
+
+        from pyramid.interfaces import ITraverser
 
         reg.registerAdapter(traverser, (Interface,), ITraverser)
 

--- a/tests/test_tweens.py
+++ b/tests/test_tweens.py
@@ -31,8 +31,8 @@ class Test_excview_tween_factory(unittest.TestCase):
         self.assertIsNone(request.exc_info)
 
     def test_it_catches_notfound(self):
-        from pyramid.request import Request
         from pyramid.httpexceptions import HTTPNotFound
+        from pyramid.request import Request
 
         self.config.add_notfound_view(lambda exc, request: exc)
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -31,8 +31,9 @@ class TestURLMethodsMixin(unittest.TestCase):
         return request
 
     def _registerResourceURL(self, reg):
-        from pyramid.interfaces import IResourceURL
         from zope.interface import Interface
+
+        from pyramid.interfaces import IResourceURL
 
         class DummyResourceURL:
             physical_path = '/context/'
@@ -684,8 +685,9 @@ class TestURLMethodsMixin(unittest.TestCase):
         )
 
     def test_current_route_url_with_request_query(self):
-        from pyramid.interfaces import IRoutesMapper
         from webob.multidict import GetDict
+
+        from pyramid.interfaces import IRoutesMapper
 
         request = self._makeOne()
         request.GET = GetDict([('q', '123')], {})
@@ -698,8 +700,9 @@ class TestURLMethodsMixin(unittest.TestCase):
         self.assertEqual(result, 'http://example.com:5432/1/2/3?q=123')
 
     def test_current_route_url_with_request_query_duplicate_entries(self):
-        from pyramid.interfaces import IRoutesMapper
         from webob.multidict import GetDict
+
+        from pyramid.interfaces import IRoutesMapper
 
         request = self._makeOne()
         request.GET = GetDict(
@@ -716,8 +719,9 @@ class TestURLMethodsMixin(unittest.TestCase):
         )
 
     def test_current_route_url_with_query_override(self):
-        from pyramid.interfaces import IRoutesMapper
         from webob.multidict import GetDict
+
+        from pyramid.interfaces import IRoutesMapper
 
         request = self._makeOne()
         request.GET = GetDict([('q', '123')], {})
@@ -834,8 +838,8 @@ class TestURLMethodsMixin(unittest.TestCase):
         self.assertEqual(info.args, ('tests:static/foo.css', request, {}))
 
     def test_static_url_abspath_integration_with_staticurlinfo(self):
-        from pyramid.interfaces import IStaticURLInfo
         from pyramid.config.views import StaticURLInfo
+        from pyramid.interfaces import IStaticURLInfo
 
         info = StaticURLInfo()
         here = os.path.abspath(os.path.dirname(__file__))
@@ -850,8 +854,8 @@ class TestURLMethodsMixin(unittest.TestCase):
         )
 
     def test_static_url_noscheme_uses_scheme_from_request(self):
-        from pyramid.interfaces import IStaticURLInfo
         from pyramid.config.views import StaticURLInfo
+        from pyramid.interfaces import IStaticURLInfo
 
         info = StaticURLInfo()
         here = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -14,8 +14,9 @@ class TestRoute(unittest.TestCase):
         return self._getTargetClass()(*arg)
 
     def test_provides_IRoute(self):
-        from pyramid.interfaces import IRoute
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import IRoute
 
         verifyObject(IRoute, self._makeOne('name', 'pattern'))
 
@@ -75,8 +76,9 @@ class RoutesMapperTests(unittest.TestCase):
         return klass()
 
     def test_provides_IRoutesMapper(self):
-        from pyramid.interfaces import IRoutesMapper
         from zope.interface.verify import verifyObject
+
+        from pyramid.interfaces import IRoutesMapper
 
         verifyObject(IRoutesMapper, self._makeOne())
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -630,7 +630,7 @@ class TestTopologicalSorter(unittest.TestCase):
         )
 
     def test_sorted_ordering_5(self):
-        from pyramid.util import LAST, FIRST
+        from pyramid.util import FIRST, LAST
 
         sorter = self._makeOne()
         add = sorter.add

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -34,8 +34,8 @@ class BaseTest:
         return environ
 
     def _makeRequest(self, **environ):
-        from pyramid.request import Request
         from pyramid.registry import Registry
+        from pyramid.request import Request
 
         environ = self._makeEnviron(**environ)
         request = Request(environ)
@@ -412,8 +412,8 @@ class RenderViewToIterableTests(BaseTest, unittest.TestCase):
         self.assertEqual(iterable, [b'anotherview'])
 
     def test_verify_output_bytestring(self):
-        from pyramid.request import Request
         from pyramid.config import Configurator
+        from pyramid.request import Request
         from pyramid.view import render_view
 
         config = Configurator(settings={})
@@ -711,8 +711,8 @@ class TestViewConfigDecorator(unittest.TestCase):
         self.assertEqual(config.pkg, tests)
 
     def test_call_with_renderer_IRendererInfo(self):
-        import tests
         from pyramid.interfaces import IRendererInfo
+        import tests
 
         @implementer(IRendererInfo)
         class DummyRendererHelper:

--- a/tests/test_viewderivers.py
+++ b/tests/test_viewderivers.py
@@ -877,9 +877,8 @@ class TestDeriveView(unittest.TestCase):
         self.assertEqual(predicates, [True, True])
 
     def test_with_wrapper_viewname(self):
+        from pyramid.interfaces import IView, IViewClassifier
         from pyramid.response import Response
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
 
         inner_response = Response('OK')
 
@@ -1192,6 +1191,7 @@ class TestDeriveView(unittest.TestCase):
 
     def test_http_cached_view_integer(self):
         import datetime
+
         from pyramid.response import Response
 
         response = Response('OK')
@@ -1214,6 +1214,7 @@ class TestDeriveView(unittest.TestCase):
 
     def test_http_cached_view_timedelta(self):
         import datetime
+
         from pyramid.response import Response
 
         response = Response('OK')
@@ -1238,6 +1239,7 @@ class TestDeriveView(unittest.TestCase):
 
     def test_http_cached_view_tuple(self):
         import datetime
+
         from pyramid.response import Response
 
         response = Response('OK')
@@ -1984,9 +1986,8 @@ class TestDeriverIntegration(unittest.TestCase):
         self, config, ctx_iface=None, request_iface=None, name=''
     ):
         from zope.interface import Interface
-        from pyramid.interfaces import IRequest
-        from pyramid.interfaces import IView
-        from pyramid.interfaces import IViewClassifier
+
+        from pyramid.interfaces import IRequest, IView, IViewClassifier
 
         classifier = IViewClassifier
         if ctx_iface is None:

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
 skip_install = true
 commands =
     flake8 src/pyramid tests setup.py
-    isort --check -rc src/pyramid tests setup.py
+    isort --check-only --df  src/pyramid tests setup.py
     black --check --diff src/pyramid tests setup.py
     python setup.py check -r -s -m
     check-manifest
@@ -63,7 +63,7 @@ depends = py38-cover
 [testenv:format]
 skip_install = true
 commands =
-    isort -rc src/pyramid tests setup.py
+    isort src/pyramid tests setup.py
     black src/pyramid tests setup.py
 deps =
     black


### PR DESCRIPTION
This updates `isort` compatibility to version 5.x.

Closes https://github.com/Pylons/pyramid/issues/3602