### PR TITLE
Clarify that the string 'None' should be the value for `samesite`

### DIFF
--- a/src/pyramid/authentication.py
+++ b/src/pyramid/authentication.py
@@ -571,7 +571,7 @@ class AuthTktAuthenticationPolicy(CallbackAuthenticationPolicy):
     ``samesite``
 
         Default: ``'Lax'``.  The 'samesite' option of the session cookie. Set
-        the value to ``None`` to turn off the samesite option.
+        the value to the string ``'None'`` to turn off the samesite option.
 
     .. versionchanged:: 1.4
 


### PR DESCRIPTION
- See https://github.com/Pylons/pyramid/issues/2733#issuecomment-672936565