### PR TITLE
Remove request.user from wiki2

### DIFF
--- a/docs/tutorials/wiki2/authentication.rst
+++ b/docs/tutorials/wiki2/authentication.rst
@@ -10,8 +10,7 @@ APIs to add login and logout functionality to our wiki.
 
 We will implement authentication with the following steps:
 
-* Add a :term:`security policy` and a ``request.user`` computed property
-  (``security.py``).
+* Add a :term:`security policy` (``security.py``).
 * Add routes for ``/login`` and ``/logout`` (``routes.py``).
 * Add login and logout views (``views/auth.py``).
 * Add a login template (``login.jinja2``).
@@ -41,10 +40,8 @@ Update ``tutorial/security.py`` with the following content:
    :linenos:
    :language: python
 
-Here we've defined:
-
-* A new security policy named ``MySecurityPolicy``, which is implementing most of the :class:`pyramid.interfaces.ISecurityPolicy` interface by tracking a :term:`identity` using a signed cookie implemented by :class:`pyramid.authentication.AuthTktCookieHelper` (lines 8-34).
-* The ``request.user`` computed property is registered for use throughout our application as the authenticated ``tutorial.models.User`` object for the logged-in user (line 42-44).
+Here we've defined a new security policy named ``MySecurityPolicy``, which is implementing most of the :class:`pyramid.interfaces.ISecurityPolicy` interface by tracking a :term:`identity` using a signed cookie implemented by :class:`pyramid.authentication.AuthTktCookieHelper` (lines 8-34).
+The security policy outputs the authenticated ``tutorial.models.User`` object for the logged-in user as the :term:`identity`, which is available as ``request.identity``.
 
 Our new :term:`security policy` defines how our application will remember, forget, and identify users.
 It also handles authorization, which we'll cover in the next chapter (if you're wondering why we didn't implement the ``permits`` method yet).
@@ -64,7 +61,7 @@ Identifying the current user is done in a few steps:
 
 #. The result is stored in the ``identity_cache`` which ensures that subsequent invocations return the same identity object for the request.
 
-Finally, :attr:`pyramid.request.Request.identity` contains either ``None`` or a ``tutorial.models.User`` instance and that value is aliased to ``request.user`` for convenience in our application.
+Finally, :attr:`pyramid.request.Request.identity` contains either ``None`` or a ``tutorial.models.User`` instance.
 
 Note the usage of the ``identity_cache`` is optional, but it has several advantages in most scenarios:
 
@@ -156,7 +153,7 @@ Only the highlighted lines need to be changed.
 
 If the user either is not logged in or is not in the ``basic`` or ``editor`` roles, then we raise ``HTTPForbidden``, which will trigger our forbidden view to compute a response.
 However, we will hook this later to redirect to the login page.
-Also, now that we have ``request.user``, we no longer have to hard-code the creator as the ``editor`` user, so we can finally drop that hack.
+Also, now that we have ``request.identity``, we no longer have to hard-code the creator as the ``editor`` user, so we can finally drop that hack.
 
 These simple checks should protect our views.
 
@@ -266,7 +263,7 @@ indicated by the highlighted lines.
    :emphasize-lines: 2-12
    :language: html
 
-The ``request.user`` will be ``None`` if the user is not authenticated, or a
+The ``request.identity`` will be ``None`` if the user is not authenticated, or a
 ``tutorial.models.User`` object if the user is authenticated. This check will
 make the logout link shown only when the user is logged in, and conversely the
 login link is only shown when the user is logged out.

--- a/docs/tutorials/wiki2/authorization.rst
+++ b/docs/tutorials/wiki2/authorization.rst
@@ -5,7 +5,7 @@ Adding authorization
 ====================
 
 In the last chapter we built :term:`authentication` into our wiki. We also
-went one step further and used the ``request.user`` object to perform some
+went one step further and used the ``request.identity`` object to perform some
 explicit :term:`authorization` checks. This is fine for a lot of applications,
 but :app:`Pyramid` provides some facilities for cleaning this up and decoupling
 the constraints from the view function itself.
@@ -24,7 +24,7 @@ We will implement access control with the following steps:
 Add ACL support
 ---------------
 
-A :term:`principal` is a level of abstraction on top of the raw :term:`userid`
+A :term:`principal` is a level of abstraction on top of the raw :term:`identity`
 that describes the user in terms of its capabilities, roles, or other
 identifiers that are easier to generalize. The permissions are then written
 against the principals without focusing on the exact user involved.

--- a/docs/tutorials/wiki2/src/authentication/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/authentication/tests/conftest.py
@@ -4,7 +4,7 @@ import alembic.command
 import os
 from pyramid.paster import get_appsettings
 from pyramid.scripting import prepare
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
 from webob.cookies import Cookie
@@ -103,7 +103,7 @@ def app_request(app, tm, dbsession):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app, tm, dbsession):
+def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
@@ -117,9 +117,13 @@ def dummy_request(app, tm, dbsession):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.dbsession = dbsession
     request.tm = tm
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/docs/tutorials/wiki2/src/authentication/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/authentication/tests/conftest.py
@@ -3,6 +3,7 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
+from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -78,6 +79,28 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
+
+@pytest.fixture
+def app_request(app, tm, dbsession):
+    """
+    A real request.
+
+    This request is almost identical to a real request but it has some
+    drawbacks in tests as it's harder to mock data and is heavier.
+
+    """
+    env = prepare(registry=app.registry)
+    request = env['request']
+    request.host = 'example.com'
+
+    # without this, request.dbsession will be joined to the same transaction
+    # manager but it will be using a different sqlalchemy.orm.Session using
+    # a separate database transaction
+    request.dbsession = dbsession
+    request.tm = tm
+
+    yield request
+    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/authentication/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/authentication/tests/conftest.py
@@ -3,7 +3,6 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
-from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -79,28 +78,6 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
-
-@pytest.fixture
-def app_request(app, tm, dbsession):
-    """
-    A real request.
-
-    This request is almost identical to a real request but it has some
-    drawbacks in tests as it's harder to mock data and is heavier.
-
-    """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
-
-    yield request
-    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/authentication/tutorial/security.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/security.py
@@ -40,5 +40,3 @@ def includeme(config):
     config.set_default_csrf_options(require_csrf=True)
 
     config.set_security_policy(MySecurityPolicy(settings['auth.secret']))
-    config.add_request_method(
-        lambda request: request.identity, 'user', property=True)

--- a/docs/tutorials/wiki2/src/authentication/tutorial/templates/layout.jinja2
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/templates/layout.jinja2
@@ -33,7 +33,7 @@
           </div>
           <div class="col-md-10">
             <div class="content">
-            {% if request.identity is none %}
+            {% if not request.is_authenticated %}
             <p class="pull-right">
               <a href="{{ request.route_url('login') }}">Login</a>
             </p>

--- a/docs/tutorials/wiki2/src/authentication/tutorial/templates/layout.jinja2
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/templates/layout.jinja2
@@ -33,13 +33,13 @@
           </div>
           <div class="col-md-10">
             <div class="content">
-            {% if request.user is none %}
+            {% if request.identity is none %}
             <p class="pull-right">
               <a href="{{ request.route_url('login') }}">Login</a>
             </p>
             {% else %}
             <form class="pull-right" action="{{ request.route_url('logout') }}" method="post">
-              {{request.user.name}}
+              {{request.identity.name}}
               <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
               <button class="btn btn-link" type="submit">Logout</button>
             </form>

--- a/docs/tutorials/wiki2/src/authentication/tutorial/views/auth.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/views/auth.py
@@ -53,7 +53,7 @@ def logout(request):
 
 @forbidden_view_config(renderer='tutorial:templates/403.jinja2')
 def forbidden_view(exc, request):
-    if request.user is None:
+    if request.identity is None:
         next_url = request.route_url('login', _query={'next': request.url})
         return HTTPSeeOther(location=next_url)
 

--- a/docs/tutorials/wiki2/src/authentication/tutorial/views/auth.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/views/auth.py
@@ -53,7 +53,7 @@ def logout(request):
 
 @forbidden_view_config(renderer='tutorial:templates/403.jinja2')
 def forbidden_view(exc, request):
-    if request.identity is None:
+    if not request.is_authenticated:
         next_url = request.route_url('login', _query={'next': request.url})
         return HTTPSeeOther(location=next_url)
 

--- a/docs/tutorials/wiki2/src/authentication/tutorial/views/default.py
+++ b/docs/tutorials/wiki2/src/authentication/tutorial/views/default.py
@@ -45,7 +45,7 @@ def view_page(request):
 def edit_page(request):
     pagename = request.matchdict['pagename']
     page = request.dbsession.query(models.Page).filter_by(name=pagename).one()
-    user = request.user
+    user = request.identity
     if user is None or (user.role != 'editor' and page.creator != user):
         raise HTTPForbidden
     if request.method == 'POST':
@@ -60,7 +60,7 @@ def edit_page(request):
 
 @view_config(route_name='add_page', renderer='tutorial:templates/edit.jinja2')
 def add_page(request):
-    user = request.user
+    user = request.identity
     if user is None or user.role not in ('editor', 'basic'):
         raise HTTPForbidden
     pagename = request.matchdict['pagename']
@@ -70,7 +70,7 @@ def add_page(request):
     if request.method == 'POST':
         body = request.params['body']
         page = models.Page(name=pagename, data=body)
-        page.creator = request.user
+        page.creator = request.identity
         request.dbsession.add(page)
         next_url = request.route_url('view_page', pagename=pagename)
         return HTTPSeeOther(location=next_url)

--- a/docs/tutorials/wiki2/src/authorization/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/authorization/tests/conftest.py
@@ -4,7 +4,7 @@ import alembic.command
 import os
 from pyramid.paster import get_appsettings
 from pyramid.scripting import prepare
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
 from webob.cookies import Cookie
@@ -103,7 +103,7 @@ def app_request(app, tm, dbsession):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app, tm, dbsession):
+def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
@@ -117,9 +117,13 @@ def dummy_request(app, tm, dbsession):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.dbsession = dbsession
     request.tm = tm
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/docs/tutorials/wiki2/src/authorization/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/authorization/tests/conftest.py
@@ -3,6 +3,7 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
+from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -78,6 +79,28 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
+
+@pytest.fixture
+def app_request(app, tm, dbsession):
+    """
+    A real request.
+
+    This request is almost identical to a real request but it has some
+    drawbacks in tests as it's harder to mock data and is heavier.
+
+    """
+    env = prepare(registry=app.registry)
+    request = env['request']
+    request.host = 'example.com'
+
+    # without this, request.dbsession will be joined to the same transaction
+    # manager but it will be using a different sqlalchemy.orm.Session using
+    # a separate database transaction
+    request.dbsession = dbsession
+    request.tm = tm
+
+    yield request
+    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/authorization/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/authorization/tests/conftest.py
@@ -3,7 +3,6 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
-from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -79,28 +78,6 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
-
-@pytest.fixture
-def app_request(app, tm, dbsession):
-    """
-    A real request.
-
-    This request is almost identical to a real request but it has some
-    drawbacks in tests as it's harder to mock data and is heavier.
-
-    """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
-
-    yield request
-    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/authorization/tutorial/security.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/security.py
@@ -59,5 +59,3 @@ def includeme(config):
     config.set_default_csrf_options(require_csrf=True)
 
     config.set_security_policy(MySecurityPolicy(settings['auth.secret']))
-    config.add_request_method(
-        lambda request: request.identity, 'user', property=True)

--- a/docs/tutorials/wiki2/src/authorization/tutorial/templates/layout.jinja2
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/templates/layout.jinja2
@@ -33,7 +33,7 @@
           </div>
           <div class="col-md-10">
             <div class="content">
-            {% if request.identity is none %}
+            {% if not request.is_authenticated %}
             <p class="pull-right">
               <a href="{{ request.route_url('login') }}">Login</a>
             </p>

--- a/docs/tutorials/wiki2/src/authorization/tutorial/templates/layout.jinja2
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/templates/layout.jinja2
@@ -33,13 +33,13 @@
           </div>
           <div class="col-md-10">
             <div class="content">
-            {% if request.user is none %}
+            {% if request.identity is none %}
             <p class="pull-right">
               <a href="{{ request.route_url('login') }}">Login</a>
             </p>
             {% else %}
             <form class="pull-right" action="{{ request.route_url('logout') }}" method="post">
-              {{request.user.name}}
+              {{request.identity.name}}
               <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
               <button class="btn btn-link" type="submit">Logout</button>
             </form>

--- a/docs/tutorials/wiki2/src/authorization/tutorial/views/auth.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/views/auth.py
@@ -53,7 +53,7 @@ def logout(request):
 
 @forbidden_view_config(renderer='tutorial:templates/403.jinja2')
 def forbidden_view(exc, request):
-    if request.user is None:
+    if request.identity is None:
         next_url = request.route_url('login', _query={'next': request.url})
         return HTTPSeeOther(location=next_url)
 

--- a/docs/tutorials/wiki2/src/authorization/tutorial/views/auth.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/views/auth.py
@@ -53,7 +53,7 @@ def logout(request):
 
 @forbidden_view_config(renderer='tutorial:templates/403.jinja2')
 def forbidden_view(exc, request):
-    if request.identity is None:
+    if not request.is_authenticated:
         next_url = request.route_url('login', _query={'next': request.url})
         return HTTPSeeOther(location=next_url)
 

--- a/docs/tutorials/wiki2/src/authorization/tutorial/views/default.py
+++ b/docs/tutorials/wiki2/src/authorization/tutorial/views/default.py
@@ -56,7 +56,7 @@ def add_page(request):
     if request.method == 'POST':
         body = request.params['body']
         page = models.Page(name=pagename, data=body)
-        page.creator = request.user
+        page.creator = request.identity
         request.dbsession.add(page)
         next_url = request.route_url('view_page', pagename=pagename)
         return HTTPSeeOther(location=next_url)

--- a/docs/tutorials/wiki2/src/basiclayout/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/basiclayout/tests/conftest.py
@@ -4,7 +4,7 @@ import alembic.command
 import os
 from pyramid.paster import get_appsettings
 from pyramid.scripting import prepare
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
 from webob.cookies import Cookie
@@ -103,7 +103,7 @@ def app_request(app, tm, dbsession):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app, tm, dbsession):
+def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
@@ -117,9 +117,13 @@ def dummy_request(app, tm, dbsession):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.dbsession = dbsession
     request.tm = tm
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/docs/tutorials/wiki2/src/basiclayout/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/basiclayout/tests/conftest.py
@@ -3,6 +3,7 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
+from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -78,6 +79,28 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
+
+@pytest.fixture
+def app_request(app, tm, dbsession):
+    """
+    A real request.
+
+    This request is almost identical to a real request but it has some
+    drawbacks in tests as it's harder to mock data and is heavier.
+
+    """
+    env = prepare(registry=app.registry)
+    request = env['request']
+    request.host = 'example.com'
+
+    # without this, request.dbsession will be joined to the same transaction
+    # manager but it will be using a different sqlalchemy.orm.Session using
+    # a separate database transaction
+    request.dbsession = dbsession
+    request.tm = tm
+
+    yield request
+    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/basiclayout/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/basiclayout/tests/conftest.py
@@ -3,7 +3,6 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
-from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -79,28 +78,6 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
-
-@pytest.fixture
-def app_request(app, tm, dbsession):
-    """
-    A real request.
-
-    This request is almost identical to a real request but it has some
-    drawbacks in tests as it's harder to mock data and is heavier.
-
-    """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
-
-    yield request
-    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/installation/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/installation/tests/conftest.py
@@ -4,7 +4,7 @@ import alembic.command
 import os
 from pyramid.paster import get_appsettings
 from pyramid.scripting import prepare
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
 from webob.cookies import Cookie
@@ -103,7 +103,7 @@ def app_request(app, tm, dbsession):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app, tm, dbsession):
+def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
@@ -117,9 +117,13 @@ def dummy_request(app, tm, dbsession):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.dbsession = dbsession
     request.tm = tm
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/docs/tutorials/wiki2/src/installation/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/installation/tests/conftest.py
@@ -3,6 +3,7 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
+from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -78,6 +79,28 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
+
+@pytest.fixture
+def app_request(app, tm, dbsession):
+    """
+    A real request.
+
+    This request is almost identical to a real request but it has some
+    drawbacks in tests as it's harder to mock data and is heavier.
+
+    """
+    env = prepare(registry=app.registry)
+    request = env['request']
+    request.host = 'example.com'
+
+    # without this, request.dbsession will be joined to the same transaction
+    # manager but it will be using a different sqlalchemy.orm.Session using
+    # a separate database transaction
+    request.dbsession = dbsession
+    request.tm = tm
+
+    yield request
+    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/installation/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/installation/tests/conftest.py
@@ -3,7 +3,6 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
-from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -79,28 +78,6 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
-
-@pytest.fixture
-def app_request(app, tm, dbsession):
-    """
-    A real request.
-
-    This request is almost identical to a real request but it has some
-    drawbacks in tests as it's harder to mock data and is heavier.
-
-    """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
-
-    yield request
-    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/models/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/models/tests/conftest.py
@@ -4,7 +4,7 @@ import alembic.command
 import os
 from pyramid.paster import get_appsettings
 from pyramid.scripting import prepare
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
 from webob.cookies import Cookie
@@ -103,7 +103,7 @@ def app_request(app, tm, dbsession):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app, tm, dbsession):
+def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
@@ -117,9 +117,13 @@ def dummy_request(app, tm, dbsession):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.dbsession = dbsession
     request.tm = tm
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/docs/tutorials/wiki2/src/models/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/models/tests/conftest.py
@@ -3,6 +3,7 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
+from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -78,6 +79,28 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
+
+@pytest.fixture
+def app_request(app, tm, dbsession):
+    """
+    A real request.
+
+    This request is almost identical to a real request but it has some
+    drawbacks in tests as it's harder to mock data and is heavier.
+
+    """
+    env = prepare(registry=app.registry)
+    request = env['request']
+    request.host = 'example.com'
+
+    # without this, request.dbsession will be joined to the same transaction
+    # manager but it will be using a different sqlalchemy.orm.Session using
+    # a separate database transaction
+    request.dbsession = dbsession
+    request.tm = tm
+
+    yield request
+    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/models/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/models/tests/conftest.py
@@ -3,7 +3,6 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
-from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -79,28 +78,6 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
-
-@pytest.fixture
-def app_request(app, tm, dbsession):
-    """
-    A real request.
-
-    This request is almost identical to a real request but it has some
-    drawbacks in tests as it's harder to mock data and is heavier.
-
-    """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
-
-    yield request
-    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/tests/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/tests/tests/conftest.py
@@ -4,7 +4,7 @@ import alembic.command
 import os
 from pyramid.paster import get_appsettings
 from pyramid.scripting import prepare
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
 from webob.cookies import Cookie
@@ -143,8 +143,9 @@ def app_request(app, tm, dbsession):
     yield request
     env['closer']()
 
+
 @pytest.fixture
-def dummy_request(app, tm, dbsession):
+def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
@@ -158,9 +159,15 @@ def dummy_request(app, tm, dbsession):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.dbsession = dbsession
     request.tm = tm
 
     return request
+
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    with testConfig(request=dummy_request) as config:
+        config.include('tutorial.routes')  # Current workaround, feels wrong.
+        yield config

--- a/docs/tutorials/wiki2/src/tests/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/tests/tests/conftest.py
@@ -143,7 +143,6 @@ def app_request(app, tm, dbsession):
     yield request
     env['closer']()
 
-
 @pytest.fixture
 def dummy_request(tm, dbsession):
     """
@@ -164,7 +163,6 @@ def dummy_request(tm, dbsession):
     request.tm = tm
 
     return request
-
 
 @pytest.yield_fixture
 def dummy_config(dummy_request):

--- a/docs/tutorials/wiki2/src/tests/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/tests/tests/conftest.py
@@ -3,7 +3,6 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
-from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -120,28 +119,6 @@ def testapp(app, tm, dbsession):
     testapp.set_cookie('csrf_token', 'dummy_csrf_token')
 
     return testapp
-
-@pytest.fixture
-def app_request(app, tm, dbsession):
-    """
-    A real request.
-
-    This request is almost identical to a real request but it has some
-    drawbacks in tests as it's harder to mock data and is heavier.
-
-    """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
-
-    yield request
-    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/tests/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/tests/tests/conftest.py
@@ -130,28 +130,26 @@ def app_request(app, tm, dbsession):
     drawbacks in tests as it's harder to mock data and is heavier.
 
     """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
+    with prepare(registry=app.registry) as env:
+        request = env['request']
+        request.host = 'example.com'
 
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
+        # without this, request.dbsession will be joined to the same transaction
+        # manager but it will be using a different sqlalchemy.orm.Session using
+        # a separate database transaction
+        request.dbsession = dbsession
+        request.tm = tm
 
-    yield request
-    env['closer']()
+        yield request
 
 @pytest.fixture
 def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
-    This request is ultra-lightweight and should be used only when the
-    request itself is not a large focus in the call-stack.
-
-    It is way easier to mock and control side-effects using this object.
+    This request is ultra-lightweight and should be used only when the request
+    itself is not a large focus in the call-stack.  It is much easier to mock
+    and control side-effects using this object, however:
 
     - It does not have request extensions applied.
     - Threadlocals are not properly pushed.
@@ -164,7 +162,13 @@ def dummy_request(tm, dbsession):
 
     return request
 
-@pytest.yield_fixture
+@pytest.fixture
 def dummy_config(dummy_request):
+    """
+    A dummy :class:`pyramid.config.Configurator` object.  This allows for
+    mock configuration, including configuration for ``dummy_request``, as well
+    as pushing the appropriate threadlocals.
+
+    """
     with testConfig(request=dummy_request) as config:
         yield config

--- a/docs/tutorials/wiki2/src/tests/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/tests/tests/conftest.py
@@ -169,5 +169,4 @@ def dummy_request(tm, dbsession):
 @pytest.yield_fixture
 def dummy_config(dummy_request):
     with testConfig(request=dummy_request) as config:
-        config.include('tutorial.routes')  # Current workaround, feels wrong.
         yield config

--- a/docs/tutorials/wiki2/src/tests/tests/test_views.py
+++ b/docs/tutorials/wiki2/src/tests/tests/test_views.py
@@ -57,7 +57,7 @@ class Test_add_page:
         return NewPage(pagename)
 
     def test_get(self, dummy_request, dbsession):
-        dummy_request.user = makeUser('foo', 'editor')
+        dummy_request.identity = makeUser('foo', 'editor')
         dummy_request.context = self._makeContext('AnotherPage')
         info = self._callFUT(dummy_request)
         assert info['pagedata'] == ''
@@ -67,7 +67,7 @@ class Test_add_page:
         dummy_request.method = 'POST'
         dummy_request.POST['body'] = 'Hello yo!'
         dummy_request.context = self._makeContext('AnotherPage')
-        dummy_request.user = makeUser('foo', 'editor')
+        dummy_request.identity = makeUser('foo', 'editor')
         self._callFUT(dummy_request)
         page = (
             dbsession.query(models.Page)
@@ -102,7 +102,7 @@ class Test_edit_page:
 
         dummy_request.method = 'POST'
         dummy_request.POST['body'] = 'Hello yo!'
-        dummy_request.user = user
+        dummy_request.identity = user
         dummy_request.context = self._makeContext(page)
         response = self._callFUT(dummy_request)
         assert response.location == 'http://example.com/abc'

--- a/docs/tutorials/wiki2/src/tests/tutorial/security.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/security.py
@@ -59,5 +59,3 @@ def includeme(config):
     config.set_default_csrf_options(require_csrf=True)
 
     config.set_security_policy(MySecurityPolicy(settings['auth.secret']))
-    config.add_request_method(
-        lambda request: request.identity, 'user', property=True)

--- a/docs/tutorials/wiki2/src/tests/tutorial/templates/layout.jinja2
+++ b/docs/tutorials/wiki2/src/tests/tutorial/templates/layout.jinja2
@@ -33,7 +33,7 @@
           </div>
           <div class="col-md-10">
             <div class="content">
-            {% if request.identity is none %}
+            {% if not request.is_authenticated %}
             <p class="pull-right">
               <a href="{{ request.route_url('login') }}">Login</a>
             </p>

--- a/docs/tutorials/wiki2/src/tests/tutorial/templates/layout.jinja2
+++ b/docs/tutorials/wiki2/src/tests/tutorial/templates/layout.jinja2
@@ -33,13 +33,13 @@
           </div>
           <div class="col-md-10">
             <div class="content">
-            {% if request.user is none %}
+            {% if request.identity is none %}
             <p class="pull-right">
               <a href="{{ request.route_url('login') }}">Login</a>
             </p>
             {% else %}
             <form class="pull-right" action="{{ request.route_url('logout') }}" method="post">
-              {{request.user.name}}
+              {{request.identity.name}}
               <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
               <button class="btn btn-link" type="submit">Logout</button>
             </form>

--- a/docs/tutorials/wiki2/src/tests/tutorial/views/auth.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/views/auth.py
@@ -53,7 +53,7 @@ def logout(request):
 
 @forbidden_view_config(renderer='tutorial:templates/403.jinja2')
 def forbidden_view(exc, request):
-    if request.user is None:
+    if request.identity is None:
         next_url = request.route_url('login', _query={'next': request.url})
         return HTTPSeeOther(location=next_url)
 

--- a/docs/tutorials/wiki2/src/tests/tutorial/views/auth.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/views/auth.py
@@ -53,7 +53,7 @@ def logout(request):
 
 @forbidden_view_config(renderer='tutorial:templates/403.jinja2')
 def forbidden_view(exc, request):
-    if request.identity is None:
+    if not request.is_authenticated:
         next_url = request.route_url('login', _query={'next': request.url})
         return HTTPSeeOther(location=next_url)
 

--- a/docs/tutorials/wiki2/src/tests/tutorial/views/default.py
+++ b/docs/tutorials/wiki2/src/tests/tutorial/views/default.py
@@ -56,7 +56,7 @@ def add_page(request):
     if request.method == 'POST':
         body = request.params['body']
         page = models.Page(name=pagename, data=body)
-        page.creator = request.user
+        page.creator = request.identity
         request.dbsession.add(page)
         next_url = request.route_url('view_page', pagename=pagename)
         return HTTPSeeOther(location=next_url)

--- a/docs/tutorials/wiki2/src/views/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/views/tests/conftest.py
@@ -4,7 +4,7 @@ import alembic.command
 import os
 from pyramid.paster import get_appsettings
 from pyramid.scripting import prepare
-from pyramid.testing import DummyRequest
+from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
 from webob.cookies import Cookie
@@ -103,7 +103,7 @@ def app_request(app, tm, dbsession):
     env['closer']()
 
 @pytest.fixture
-def dummy_request(app, tm, dbsession):
+def dummy_request(tm, dbsession):
     """
     A lightweight dummy request.
 
@@ -117,9 +117,13 @@ def dummy_request(app, tm, dbsession):
 
     """
     request = DummyRequest()
-    request.registry = app.registry
     request.host = 'example.com'
     request.dbsession = dbsession
     request.tm = tm
 
     return request
+
+@pytest.yield_fixture
+def dummy_config(dummy_request):
+    with testConfig(request=dummy_request) as config:
+        yield config

--- a/docs/tutorials/wiki2/src/views/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/views/tests/conftest.py
@@ -3,6 +3,7 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
+from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -78,6 +79,28 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
+
+@pytest.fixture
+def app_request(app, tm, dbsession):
+    """
+    A real request.
+
+    This request is almost identical to a real request but it has some
+    drawbacks in tests as it's harder to mock data and is heavier.
+
+    """
+    env = prepare(registry=app.registry)
+    request = env['request']
+    request.host = 'example.com'
+
+    # without this, request.dbsession will be joined to the same transaction
+    # manager but it will be using a different sqlalchemy.orm.Session using
+    # a separate database transaction
+    request.dbsession = dbsession
+    request.tm = tm
+
+    yield request
+    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/src/views/tests/conftest.py
+++ b/docs/tutorials/wiki2/src/views/tests/conftest.py
@@ -3,7 +3,6 @@ import alembic.config
 import alembic.command
 import os
 from pyramid.paster import get_appsettings
-from pyramid.scripting import prepare
 from pyramid.testing import DummyRequest, testConfig
 import pytest
 import transaction
@@ -79,28 +78,6 @@ def testapp(app, tm, dbsession):
     })
 
     return testapp
-
-@pytest.fixture
-def app_request(app, tm, dbsession):
-    """
-    A real request.
-
-    This request is almost identical to a real request but it has some
-    drawbacks in tests as it's harder to mock data and is heavier.
-
-    """
-    env = prepare(registry=app.registry)
-    request = env['request']
-    request.host = 'example.com'
-
-    # without this, request.dbsession will be joined to the same transaction
-    # manager but it will be using a different sqlalchemy.orm.Session using
-    # a separate database transaction
-    request.dbsession = dbsession
-    request.tm = tm
-
-    yield request
-    env['closer']()
 
 @pytest.fixture
 def dummy_request(tm, dbsession):

--- a/docs/tutorials/wiki2/tests.rst
+++ b/docs/tutorials/wiki2/tests.rst
@@ -110,7 +110,7 @@ Integration tests
 
 We can directly execute the view code, bypassing :app:`Pyramid` and testing just the code that we've written.
 These tests use dummy requests that we'll prepare appropriately to set the conditions each view expects.
-For example, setting ``request.user``, or adding some dummy data to the session.
+For example, setting ``request.identity``, or adding some dummy data to the session.
 
 Update ``tests/test_views.py`` such that it appears as follows:
 

--- a/docs/tutorials/wiki2/tests.rst
+++ b/docs/tutorials/wiki2/tests.rst
@@ -63,9 +63,6 @@ Per-test fixtures
   The ``testapp`` is able to mutate the request environ such that the ``dbsession`` and ``tm`` fixtures are injected and used by any code that's touching ``request.dbsession`` and ``request.tm``.
   The ``testapp`` maintains a cookiejar, so it can be used to share state across requests, as well as the transaction database connection.
 
-- ``app_request`` - a :class:`pyramid.request.Request` object that can be used for more lightweight tests versus the full ``testapp``.
-  The ``app_request`` can be passed to view functions and other code that need a fully functional request object.
-
 - ``dummy_request`` - a :class:`pyramid.testing.DummyRequest` object that is very lightweight.
   This is a great object to pass to view functions that have minimal side-effects as it'll be fast and simple.
 

--- a/docs/tutorials/wiki2/tests.rst
+++ b/docs/tutorials/wiki2/tests.rst
@@ -63,6 +63,9 @@ Per-test fixtures
   The ``testapp`` is able to mutate the request environ such that the ``dbsession`` and ``tm`` fixtures are injected and used by any code that's touching ``request.dbsession`` and ``request.tm``.
   The ``testapp`` maintains a cookiejar, so it can be used to share state across requests, as well as the transaction database connection.
 
+- ``app_request`` - a :class:`pyramid.request.Request` object that can be used for more lightweight tests versus the full ``testapp``.
+  The ``app_request`` can be passed to view functions and other code that need a fully functional request object.
+
 - ``dummy_request`` - a :class:`pyramid.testing.DummyRequest` object that is very lightweight.
   This is a great object to pass to view functions that have minimal side-effects as it'll be fast and simple.
 

--- a/docs/tutorials/wiki2/tests.rst
+++ b/docs/tutorials/wiki2/tests.rst
@@ -69,6 +69,9 @@ Per-test fixtures
 - ``dummy_request`` - a :class:`pyramid.testing.DummyRequest` object that is very lightweight.
   This is a great object to pass to view functions that have minimal side-effects as it'll be fast and simple.
 
+- ``dummy_config`` — a :class:`pyramid.config.Configurator` object used as configuration by ``dummy_request``.
+  Useful for mocking configuration like routes and security policies.
+
 
 Modifying the fixtures
 ----------------------
@@ -109,8 +112,8 @@ Integration tests
 =================
 
 We can directly execute the view code, bypassing :app:`Pyramid` and testing just the code that we've written.
-These tests use dummy requests that we'll prepare appropriately to set the conditions each view expects.
-For example, setting ``request.identity``, or adding some dummy data to the session.
+These tests use dummy requests that we'll prepare appropriately to set the conditions each view expects, such as adding dummy data to the session.
+We'll be using ``dummy_config`` to configure the necessary routes, as well as setting the security policy as :class:`pyramid.testing.DummySecurityPolicy` to mock ``dummy_request.identity``.
 
 Update ``tests/test_views.py`` such that it appears as follows:
 


### PR DESCRIPTION
WIP, I need to fix the testing tutorial.  Right now it gives an error on setting `identity`, I need to add a dummy security policy to the tutorial.  (Useful thing for the tutorial to cover anyways.)

But wanted to get the discussion going because I feel like people will have opinions.  I can see both sides.  In my opinion, the tutorial should be as "pure" Pyramid as possible.  `request.user` is a nice convenience that a lot of people will opt for, but I think it's important to emphasize `request.identity` for new users, as that's the construct the framework uses.

Thoughts?