### PR TITLE
Add sphinx-copybutton to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
     'sphinxcontrib.autoprogram',
+    'sphinx_copybutton',
     # enable pylons_sphinx_latesturl when this branch is no longer "latest"
     # 'pylons_sphinx_latesturl',
     ]

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ docs_extras = [
     'pylons-sphinx-themes >= 1.0.8',  # Ethical Ads
     'pylons_sphinx_latesturl',
     'repoze.sphinx.autointerface',
+    'sphinx-copybutton',
     'sphinxcontrib-autoprogram',
 ]
 


### PR DESCRIPTION
This nifty extension would have been very useful for the training for PloneConf.

https://sphinx-copybutton.readthedocs.io/en/latest/