### PR TITLE
Break reference cycle between request and context.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Unreleased
 ==========
 
-- Break potential reference cycle between `request` and `context`.
+- Break potential reference cycle between ``request`` and ``context``.
   See https://github.com/Pylons/pyramid/pull/3649
 
 2.0b0 (2020-12-15)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Unreleased
+==========
+
+- Break potential reference cycle between `request` and `context`.
+  See https://github.com/Pylons/pyramid/pull/3649
+
 2.0b0 (2020-12-15)
 ==================
 

--- a/src/pyramid/router.py
+++ b/src/pyramid/router.py
@@ -252,8 +252,12 @@ class Router:
             return response
 
         finally:
-            if request.finished_callbacks:
-                request._process_finished_callbacks()
+            self.finish_request(request)
+
+    def finish_request(self, request):
+        if request.finished_callbacks:
+            request._process_finished_callbacks()
+        request.__dict__.pop('context', None)
 
     def __call__(self, environ, start_response):
         """

--- a/src/pyramid/router.py
+++ b/src/pyramid/router.py
@@ -257,7 +257,7 @@ class Router:
     def finish_request(self, request):
         if request.finished_callbacks:
             request._process_finished_callbacks()
-        request.__dict__.pop('context', None)
+        request.__dict__.pop('context', None)  # Break potential ref cycle
 
     def __call__(self, environ, start_response):
         """

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -634,7 +634,7 @@ class TestRouter(unittest.TestCase):
         router(environ, start_response)
         self.assertEqual(response.called_back, True)
 
-    def test_call_request_has_finished_callbacks_when_view_succeeds(self):
+    def test_finish_request_when_view_succeeds(self):
         from zope.interface import Interface, directlyProvides
 
         class IContext(Interface):
@@ -652,6 +652,7 @@ class TestRouter(unittest.TestCase):
                 request.environ['called_back'] = True
 
             request.add_finished_callback(callback)
+            request.environ['request'] = request
             return response
 
         environ = self._makeEnviron()
@@ -660,8 +661,9 @@ class TestRouter(unittest.TestCase):
         start_response = DummyStartResponse()
         router(environ, start_response)
         self.assertEqual(environ['called_back'], True)
+        self.assertFalse(hasattr(environ['request'], 'context'))
 
-    def test_call_request_has_finished_callbacks_when_view_raises(self):
+    def test_finish_request_when_view_raises(self):
         from zope.interface import Interface, directlyProvides
 
         class IContext(Interface):
@@ -678,6 +680,7 @@ class TestRouter(unittest.TestCase):
                 request.environ['called_back'] = True
 
             request.add_finished_callback(callback)
+            request.environ['request'] = request
             raise NotImplementedError
 
         environ = self._makeEnviron()
@@ -686,6 +689,7 @@ class TestRouter(unittest.TestCase):
         start_response = DummyStartResponse()
         exc_raised(NotImplementedError, router, environ, start_response)
         self.assertEqual(environ['called_back'], True)
+        self.assertFalse(hasattr(environ['request'], 'context'))
 
     def test_call_request_factory_raises(self):
         # making sure finally doesnt barf when a request cannot be created

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -124,6 +124,19 @@ class TestRouter(unittest.TestCase):
         klass = self._getTargetClass()
         return klass(self.registry)
 
+    def _mockFinishRequest(self, router):
+        """
+        Mock :meth:`pyramid.router.Router.finish_request` to be a no-op.  This
+        prevents :prop:`pyramid.request.Request.context` from being removed, so
+        we can write assertions against it.
+
+        """
+
+        def mock_finish_request(request):
+            pass
+
+        router.finish_request = mock_finish_request
+
     def _makeEnviron(self, **extras):
         environ = {
             'wsgi.url_scheme': 'http',
@@ -421,6 +434,7 @@ class TestRouter(unittest.TestCase):
         )
         self._registerRootFactory(context)
         router = self._makeOne()
+        self._mockFinishRequest(router)
         start_response = DummyStartResponse()
         result = router(environ, start_response)
         self.assertEqual(result, ['Hello world'])
@@ -448,6 +462,7 @@ class TestRouter(unittest.TestCase):
         environ = self._makeEnviron()
         self._registerView(view, 'foo', IViewClassifier, None, None)
         router = self._makeOne()
+        self._mockFinishRequest(router)
         start_response = DummyStartResponse()
         result = router(environ, start_response)
         self.assertEqual(result, ['Hello world'])
@@ -477,6 +492,7 @@ class TestRouter(unittest.TestCase):
         environ = self._makeEnviron()
         self._registerView(view, '', IViewClassifier, IRequest, IContext)
         router = self._makeOne()
+        self._mockFinishRequest(router)
         start_response = DummyStartResponse()
         result = router(environ, start_response)
         self.assertEqual(result, ['Hello world'])
@@ -704,6 +720,7 @@ class TestRouter(unittest.TestCase):
         context_found_events = self._registerEventListener(IContextFound)
         response_events = self._registerEventListener(INewResponse)
         router = self._makeOne()
+        self._mockFinishRequest(router)
         start_response = DummyStartResponse()
         result = router(environ, start_response)
         self.assertEqual(len(request_events), 1)
@@ -767,6 +784,7 @@ class TestRouter(unittest.TestCase):
         self._registerView(view, '', IViewClassifier, None, None)
         self._registerRootFactory(context)
         router = self._makeOne()
+        self._mockFinishRequest(router)
         start_response = DummyStartResponse()
         result = router(environ, start_response)
         self.assertEqual(result, ['Hello world'])
@@ -841,6 +859,7 @@ class TestRouter(unittest.TestCase):
         self._registerView(view, '', IViewClassifier, None, None)
         self._registerRootFactory(context)
         router = self._makeOne()
+        self._mockFinishRequest(router)
         start_response = DummyStartResponse()
         result = router(environ, start_response)
         self.assertEqual(result, ['Hello world'])


### PR DESCRIPTION
When implementing traversal, it's common (at least for me) to store the request in the resource objects so you can do things like database lookups.

```python
class MyResource:
    def __init__(self, request):
        self.request = request

    def __getitem__(self, key):
        if self.request.db.lookup(key):
            return ChildResource(self.request, key)
        else:
            raise KeyError()
```

I realized this morning that this will cause a reference cycle between `request.context` and `context.request`.  Not the end of the world, obviously, but unnecessary pressure on the GC.

Maybe this is the user's responsibility?  We could document not to store the request in the context, or to use a WeakRef.

The framework can also prevent this by breaking the cycle once the request has been processed, which is what this PR does.  Really it's just a single line (`request.__dict__.pop('context', None)`), but it got a bit more complicated than that because several router tests rely on the context object being in the request.