### PR TITLE
Pass documentation around.

### DIFF
--- a/src/pyramid/decorator.py
+++ b/src/pyramid/decorator.py
@@ -36,6 +36,7 @@ class reify:
     def __init__(self, wrapped):
         self.wrapped = wrapped
         update_wrapper(self, wrapped)
+        self.__doc__ = wrapped.__doc__
 
     def __get__(self, inst, objtype=None):
         if inst is None:


### PR DESCRIPTION
Fixes #3655 

Use [wraps](https://github.com/python/cpython/blob/master/Lib/functools.py#L65) which also link the documentation.