### PR TITLE
Remove update_wrapper from reify

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Unreleased
 - Break potential reference cycle between ``request`` and ``context``.
   See https://github.com/Pylons/pyramid/pull/3649
 
+- Remove ``update_wrapper`` from ``pyramid.decorator.reify``.
+  See https://github.com/Pylons/pyramid/pull/3657
+
 2.0b0 (2020-12-15)
 ==================
 

--- a/src/pyramid/decorator.py
+++ b/src/pyramid/decorator.py
@@ -1,6 +1,3 @@
-from functools import update_wrapper
-
-
 class reify:
     """Use as a class method decorator.  It operates almost exactly like the
     Python ``@property`` decorator, but it puts the result of the method it
@@ -35,7 +32,7 @@ class reify:
 
     def __init__(self, wrapped):
         self.wrapped = wrapped
-        update_wrapper(self, wrapped)
+        self.__doc__ = wrapped.__doc__
 
     def __get__(self, inst, objtype=None):
         if inst is None:

--- a/tests/test_config/test_views.py
+++ b/tests/test_config/test_views.py
@@ -4289,21 +4289,6 @@ class Test_view_description(unittest.TestCase):
         self.assertEqual(result, 'function tests.test_config.test_views.view')
 
 
-class Test_viewdefaults(unittest.TestCase):
-    def _makeOne(self, wrapped):
-        from pyramid.decorator import reify
-
-        return reify(wrapped)
-
-    def test_dunder_attrs_copied(self):
-        from pyramid.config.views import viewdefaults
-
-        decorator = self._makeOne(viewdefaults)
-        self.assertEqual(decorator.__doc__, viewdefaults.__doc__)
-        self.assertEqual(decorator.__name__, viewdefaults.__name__)
-        self.assertEqual(decorator.__module__, viewdefaults.__module__)
-
-
 class DummyRegistry:
     utility = None
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 
 
@@ -24,6 +25,28 @@ class TestReify(unittest.TestCase):
         decorator = self._makeOne(wrapped)
         result = decorator.__get__(None)
         self.assertEqual(result, decorator)
+
+    def test_copy_docstring(self):
+        def wrapped(inst):
+            """Test doc"""
+            return 'a'  # pragma: no cover
+
+        decorator = self._makeOne(wrapped)
+        assert decorator.__doc__ == 'Test doc'
+
+    def test_not_function(self):
+        """
+        Because reify'd methods act as attributes, it's important that they
+        aren't recognized as a function.  Otherwise tools like Sphinx may
+        misbehave, like in https://github.com/Pylons/pyramid/issues/3655
+
+        """
+
+        def wrapped(inst):
+            return 'a'  # pragma: no cover
+
+        decorator = self._makeOne(wrapped)
+        assert not inspect.isfunction(inspect.unwrap(decorator))
 
 
 class Dummy:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -46,7 +46,7 @@ class TestReify(unittest.TestCase):
             return 'a'  # pragma: no cover
 
         decorator = self._makeOne(wrapped)
-        assert not inspect.isfunction(inspect.unwrap(decorator))
+        assert not inspect.isfunction(decorator)
 
 
 class Dummy:


### PR DESCRIPTION
Reify uses `update_wrapper`, which makes the descriptor look like the wrapped method.  However, this isn't the desired behavior, because reify changes the method to act like the property.

This causes problems with Sphinx autodoc as reported in #3655, because Sphinx sees the reify'd attribute as a method and throws an error when attempting to get a signature.  You can see the problem here:

```python
import inspect
from pyramid.decorator import reify
from functools import cached_property
from sphinx.util.inspect import isattributedescriptor


class Widget:
    @property
    def prop(self):
        return 'Foo'

    @cached_property
    def cached(self):
        return 'Foo'

    @reify
    def reify(self):
        return 'Foo'


print(isattributedescriptor(Widget.prop))
print(isattributedescriptor(Widget.cached))
print(isattributedescriptor(Widget.reify))
```

Output is:

```
True
True
False
```

This fix removes `update_wrapper` from reify and just sets `__doc__` manually.  This is in line with stdlib's implementation of [functools.cached_property](https://github.com/python/cpython/blob/ebe20d9e7eb138c053958bc0a3058d34c6e1a679/Lib/functools.py#L933).

Fixes #3655.