### PR TITLE
in reify also copy wrapped function __name__

### DIFF
--- a/src/pyramid/decorator.py
+++ b/src/pyramid/decorator.py
@@ -32,6 +32,7 @@ class reify:
 
     def __init__(self, wrapped):
         self.wrapped = wrapped
+        self.__name__ = wrapped.__name__
         self.__doc__ = wrapped.__doc__
 
     def __get__(self, inst, objtype=None):


### PR DESCRIPTION
Hello,

The `reify` class decorator already copy the `__doc__` attribute of the wrapped method but is missing the `__name__` attribute. This breaks introspection code that tries to grab a callable name by accessing the `__name__` of the callable (like some decorators) for example and according to python `functools.update_wrapper` (used by `@wraps`) this is one of the needed magical attribute to copy: https://github.com/python/cpython/blob/145bf269df3530176f6ebeab1324890ef7070bf8/Lib/functools.py#L32-L37

I've only backported `__name__` but I can also update to this PR to uses `functools.WRAPPER_ASSIGNMENTS` to make the code more generic and robust if wanted.

Kind regards and thanks for your work,