### PR TITLE
add optional scope to `ISession.changed()`

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -354,3 +354,5 @@ Contributors
 - Sergey Maranchuk, 2020/04/18
 
 - Thibault Ravera, 2020/06/03
+
+- Gouji Ochiai, 2021/06/12

--- a/docs/narr/sessions.rst
+++ b/docs/narr/sessions.rst
@@ -116,8 +116,10 @@ Extra attributes:
 Extra methods:
 
 ``changed()``
-  Call this when you mutate a mutable value in the session namespace. See the
-  gotchas below for details on when and why you should call this.
+  Call this when you mutate a mutable value in the session namespace.
+  You can specify which key has been changed by specifying the optional
+  argument ``key``.
+  See the gotchas below for details on when and why you should call this.
 
 ``invalidate()``
   Call this when you want to invalidate the session (dump all data, and perhaps

--- a/src/pyramid/interfaces.py
+++ b/src/pyramid/interfaces.py
@@ -1182,7 +1182,7 @@ class ISession(IDict):
         case of changing privilege levels or preventing fixation attacks.
         """
 
-    def changed():
+    def changed(key=None):
         """Mark the session as changed. A user of a session should
         call this method after he or she mutates a mutable object that
         is *a value of the session* (it should not be required after
@@ -1192,7 +1192,9 @@ class ISession(IDict):
         be called.  However, if subsequently he or she does
         ``session['foo']['a'] = 1``, ``changed()`` must be called for
         the sessioning machinery to notice the mutation of the
-        internal dictionary."""
+        internal dictionary.  The ``key`` argument can be used to notify
+        the sessioning machinery of which keys have been changed.
+        """
 
     def flash(msg, queue='', allow_duplicate=True):
         """Push a flash message onto the end of the flash queue represented

--- a/src/pyramid/session.py
+++ b/src/pyramid/session.py
@@ -250,7 +250,7 @@ def BaseCookieSessionFactory(
             dict.__init__(self, state)
 
         # ISession methods
-        def changed(self):
+        def changed(self, key=None):
             if not self._dirty:
                 self._dirty = True
 

--- a/src/pyramid/testing.py
+++ b/src/pyramid/testing.py
@@ -238,7 +238,7 @@ class DummySession(dict):
     created = None
     new = True
 
-    def changed(self):
+    def changed(self, key=None):
         pass
 
     def invalidate(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -90,6 +90,12 @@ class SharedCookieSessionTests:
         self.assertEqual(session.changed(), None)
         self.assertTrue(session._dirty)
 
+    def test_changed_scoped(self):
+        request = testing.DummyRequest()
+        session = self._makeOne(request)
+        self.assertEqual(session.changed("some_scope"), None)
+        self.assertTrue(session._dirty)
+
     def test_invalidate(self):
         request = testing.DummyRequest()
         session = self._makeOne(request)


### PR DESCRIPTION
I'd like to create an `ISession` implementation that persists session data, split by key.
In the current interface, when `ISession.changed()` is called, all the data will be persisted. If we can get the key that was changed during `ISession.changed()`, we can narrow down the scope of persistence.