### PR TITLE
Fix API documentation links to webob, and rename the objects with the…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,6 +76,7 @@ intersphinx_mapping = {
     'tutorials': ('https://docs.pylonsproject.org/projects/pyramid-tutorials/en/latest/', None),
     'venusian': ('https://docs.pylonsproject.org/projects/venusian/en/latest/', None),
     'webtest': ('https://docs.pylonsproject.org/projects/webtest/en/latest/', None),
+    'webob': ('https://docs.pylonsproject.org/projects/webob/en/latest/', None),
     'zcml': (
     'https://docs.pylonsproject.org/projects/pyramid-zcml/en/latest/', None),
 }

--- a/docs/narr/hooks.rst
+++ b/docs/narr/hooks.rst
@@ -852,11 +852,11 @@ callable, if that object asserts that it implements
 ``zope.interface.implementer(IResponse)``) , an adapter needn't be registered
 for the object; Pyramid will use it directly.
 
-An IResponse adapter for ``webob.Response`` (as opposed to
+An IResponse adapter for ``webob.reponse.Response`` (as opposed to
 :class:`pyramid.response.Response`) is registered by Pyramid by default at
 startup time, as by their nature, instances of this class (and instances of
 subclasses of the class) will natively provide IResponse.  The adapter
-registered for ``webob.Response`` simply returns the response object.
+registered for ``webob.reponse.Response`` simply returns the response object.
 
 Instead of using :meth:`pyramid.config.Configurator.add_response_adapter`, you
 can use the :class:`pyramid.response.response_adapter` decorator:

--- a/docs/narr/webob.rst
+++ b/docs/narr/webob.rst
@@ -14,10 +14,10 @@ Request and Response Objects
 :term:`request` and :term:`response` object implementations.  The
 :term:`request` object that is passed to a :app:`Pyramid` :term:`view` is an
 instance of the :class:`pyramid.request.Request` class, which is a subclass of
-:class:`webob.Request`.  The :term:`response` returned from a :app:`Pyramid`
+:class:`webob.request.Request`.  The :term:`response` returned from a :app:`Pyramid`
 :term:`view` :term:`renderer` is an instance of the
 :mod:`pyramid.response.Response` class, which is a subclass of the
-:class:`webob.Response` class.  Users can also return an instance of
+:class:`webob.response.Response` class.  Users can also return an instance of
 :class:`pyramid.response.Response` directly from a view as necessary.
 
 WebOb is a project separate from :app:`Pyramid` with a separate set of authors
@@ -369,7 +369,7 @@ Response
 
 The :app:`Pyramid` response object can be imported as
 :class:`pyramid.response.Response`.  This class is a subclass of the
-``webob.Response`` class.  The subclass does not add or change any
+``webob.reponse.Response`` class.  The subclass does not add or change any
 functionality, so the WebOb Response documentation will be completely relevant
 for this class as well.
 


### PR DESCRIPTION
…ir full and correct namespace

backport of #3673