### PR TITLE
Do not include segment_name in allowed values in doc example.

### DIFF
--- a/docs/narr/urldispatch.rst
+++ b/docs/narr/urldispatch.rst
@@ -1109,7 +1109,7 @@ See this code:
     class AnyOfPredicate:
         def __init__(self, val, info):
             self.segment_name = val[0]
-            self.allowed = tuple(val[0:])
+            self.allowed = tuple(val[1:])
 
         def text(self):
             args = (self.segment_name,) + self.allowed


### PR DESCRIPTION
This is just a tiny doc change that accidentally placed the name of the segment to match against into the list of allowed matches for a custom route predicate.

I should be in [Contributors.txt](https://github.com/Pylons/pyramid/blob/2.0/CONTRIBUTORS.txt#L184) as 
`Ian Wilson, 2012/06/17`.