### PR TITLE
Add version constraints to black, flake8, and isort

### DIFF
--- a/HACKING.txt
+++ b/HACKING.txt
@@ -69,6 +69,10 @@ Coding Style
 
     $ $TOX -e format
 
+- Pyramid uses flake8 (https://pypi.org/project/flake8/) to enforce PEP8 style guidelines.
+  To run flake8, as well as running checks for Black and isort:
+
+    $ $TOX -e lint
 
 Running Tests
 -------------

--- a/HACKING.txt
+++ b/HACKING.txt
@@ -74,6 +74,8 @@ Coding Style
 
     $ $TOX -e lint
 
+Black, isort, and flake8 versions are pinned for stability and reproducibility.
+
 Running Tests
 -------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
     check-manifest
 deps =
     flake8~=4.0.1
-    black==21.12b0
+    black~=22.1.0
     isort~=5.10
     readme_renderer
     check-manifest
@@ -66,7 +66,7 @@ commands =
     isort src/pyramid tests setup.py
     black src/pyramid tests setup.py
 deps =
-    black==21.12b0
+    black~=22.1.0
     isort~=5.10
 
 [testenv:build]

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,9 @@ commands =
     python setup.py check -r -s -m
     check-manifest
 deps =
-    flake8
-    black
-    isort
+    flake8~=4.0.1
+    black==21.12b0
+    isort~=5.10
     readme_renderer
     check-manifest
 
@@ -66,8 +66,8 @@ commands =
     isort src/pyramid tests setup.py
     black src/pyramid tests setup.py
 deps =
-    black
-    isort
+    black==21.12b0
+    isort~=5.10
 
 [testenv:build]
 skip_install = true


### PR DESCRIPTION
#3689 got me thinking that formatting/linting should be stable, PRs shouldn't be required to reformat the entire project to get the tests to pass.  This PR adds version constraints to the black, flake8, and isort to produce stable results, according their release policies:

- flake8:  Stable within a minor release.  https://flake8.pycqa.org/en/latest/faq.html#why-does-flake8-use-ranges-for-its-dependencies
- black:  Beta, no stability guarantees.  https://black.readthedocs.io/en/stable/
- isort:  Stable within a major release.  https://pycqa.github.io/isort/docs/major_releases/release_policy.html