### PR TITLE
stop overidding custom signatures defined in the docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ unreleased
   ``pyramid.decorator.reify``.
   See https://github.com/Pylons/pyramid/pull/3660
 
+- Fix method signatures in docs for
+  ``pyramid.config.Configurator.add_static_view`` and
+  ``pyramid.config.Configurator.override_asset``.
+  See https://github.com/Pylons/pyramid/pull/3699
+
 2.0 (2021-02-28)
 ================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@
 import sys
 import os
 import datetime
-import inspect
 import warnings
 
 warnings.simplefilter('ignore', DeprecationWarning)
@@ -385,19 +384,7 @@ def setup(app):
     app.add_directive('frontmatter', FrontMatter)
     app.add_directive('mainmatter', MainMatter)
     app.add_directive('backmatter', BackMatter)
-    app.connect('autodoc-process-signature', resig)
 
-
-def resig(app, what, name, obj, options, signature, return_annotation):
-    """ Allow for preservation of ``@action_method`` decorated methods
-    in configurator """
-    docobj = getattr(obj, '__docobj__', None)
-    if docobj is not None:
-        argspec = inspect.getargspec(docobj)
-        if argspec[0] and argspec[0][0] in ('cls', 'self'):
-            del argspec[0][0]
-        signature = inspect.formatargspec(*argspec)
-    return signature, return_annotation
 
 # turn off all line numbers in latex formatting
 


### PR DESCRIPTION
backport #3696 to 2.0-branch