### PR TITLE
Change != to is not in pshell initialization

### DIFF
--- a/src/pyramid/scripts/pshell.py
+++ b/src/pyramid/scripts/pshell.py
@@ -188,7 +188,7 @@ class PShellCommand:
         with setup_manager(env):
             # remove any objects from default help that were overidden
             for k, v in env.items():
-                if k not in orig_env or v != orig_env[k]:
+                if k not in orig_env or v is not orig_env[k]:
                     if getattr(v, '__doc__', False):
                         env_help[k] = v.__doc__.replace("\n", " ")
                     else:


### PR DESCRIPTION
I had a curious problem: I had thrown an object that was wrapped in lazy_object_proxy added into the `pshell` environment. It had worked before but for some reason stopped working here merely due to updates in either Python version or some of the dependent libraries. The error thrown was `AttributeError: __wrapped__` on this line. As `is not` is likely the more correct solution here, here's the pull request.