### PR TITLE
update SQLAlchemy logger in quick tutorial fixes #3706

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -358,3 +358,5 @@ Contributors
 - Jens Troeger, 2021/04/08
 
 - Karthikeyan Singaravelan, 2021/08/24
+
+- Camill Kaipf, 2022/08/12

--- a/docs/quick_tutorial/databases.rst
+++ b/docs/quick_tutorial/databases.rst
@@ -87,13 +87,13 @@ Steps
 
         $VENV/bin/initialize_tutorial_db development.ini
 
-        2016-04-16 13:01:33,055 INFO  [sqlalchemy.engine.base.Engine][MainThread] SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
-        2016-04-16 13:01:33,055 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
-        2016-04-16 13:01:33,056 INFO  [sqlalchemy.engine.base.Engine][MainThread] SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
-        2016-04-16 13:01:33,056 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
-        2016-04-16 13:01:33,057 INFO  [sqlalchemy.engine.base.Engine][MainThread] PRAGMA table_info("wikipages")
-        2016-04-16 13:01:33,057 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
-        2016-04-16 13:01:33,058 INFO  [sqlalchemy.engine.base.Engine][MainThread]
+        2016-04-16 13:01:33,055 INFO  [sqlalchemy.engine.Engine][MainThread] SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
+        2016-04-16 13:01:33,055 INFO  [sqlalchemy.engine.Engine][MainThread] ()
+        2016-04-16 13:01:33,056 INFO  [sqlalchemy.engine.Engine][MainThread] SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
+        2016-04-16 13:01:33,056 INFO  [sqlalchemy.engine.Engine][MainThread] ()
+        2016-04-16 13:01:33,057 INFO  [sqlalchemy.engine.Engine][MainThread] PRAGMA table_info("wikipages")
+        2016-04-16 13:01:33,057 INFO  [sqlalchemy.engine.Engine][MainThread] ()
+        2016-04-16 13:01:33,058 INFO  [sqlalchemy.engine.Engine][MainThread]
         CREATE TABLE wikipages (
                uid INTEGER NOT NULL,
                title TEXT,
@@ -103,12 +103,12 @@ Steps
         )
 
 
-        2016-04-16 13:01:33,058 INFO  [sqlalchemy.engine.base.Engine][MainThread] ()
-        2016-04-16 13:01:33,059 INFO  [sqlalchemy.engine.base.Engine][MainThread] COMMIT
-        2016-04-16 13:01:33,062 INFO  [sqlalchemy.engine.base.Engine][MainThread] BEGIN (implicit)
-        2016-04-16 13:01:33,062 INFO  [sqlalchemy.engine.base.Engine][MainThread] INSERT INTO wikipages (title, body) VALUES (?, ?)
-        2016-04-16 13:01:33,063 INFO  [sqlalchemy.engine.base.Engine][MainThread] ('Root', '<p>Root</p>')
-        2016-04-16 13:01:33,063 INFO  [sqlalchemy.engine.base.Engine][MainThread] COMMIT
+        2016-04-16 13:01:33,058 INFO  [sqlalchemy.engine.Engine][MainThread] ()
+        2016-04-16 13:01:33,059 INFO  [sqlalchemy.engine.Engine][MainThread] COMMIT
+        2016-04-16 13:01:33,062 INFO  [sqlalchemy.engine.Engine][MainThread] BEGIN (implicit)
+        2016-04-16 13:01:33,062 INFO  [sqlalchemy.engine.Engine][MainThread] INSERT INTO wikipages (title, body) VALUES (?, ?)
+        2016-04-16 13:01:33,063 INFO  [sqlalchemy.engine.Engine][MainThread] ('Root', '<p>Root</p>')
+        2016-04-16 13:01:33,063 INFO  [sqlalchemy.engine.Engine][MainThread] COMMIT
 
 #.  With our data now driven by SQLAlchemy queries, we need to update our ``databases/tutorial/views.py``:
 

--- a/docs/quick_tutorial/databases/development.ini
+++ b/docs/quick_tutorial/databases/development.ini
@@ -14,7 +14,7 @@ listen = localhost:6543
 # Begin logging configuration
 
 [loggers]
-keys = root, tutorial, sqlalchemy.engine.base.Engine
+keys = root, tutorial, sqlalchemy.engine.Engine
 
 [logger_tutorial]
 level = DEBUG
@@ -31,10 +31,10 @@ keys = generic
 level = INFO
 handlers = console
 
-[logger_sqlalchemy.engine.base.Engine]
+[logger_sqlalchemy.engine.Engine]
 level = INFO
 handlers =
-qualname = sqlalchemy.engine.base.Engine
+qualname = sqlalchemy.engine.Engine
 
 [handler_console]
 class = StreamHandler


### PR DESCRIPTION
Updates the logger for `SQLAlchemy in the Quick Tutorial: Chapter 19`