### PR TITLE
rename "master" to "main"

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,10 +1,10 @@
 name: Build and test
 
 on:
-    # Only on pushes to master or one of the release branches we build on push
+    # Only on pushes to main or one of the release branches we build on push
     push:
         branches:
-            - master
+            - main
             - "[0-9].[0-9]+-branch"
         tags:
     # Build pull requests

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
 Pyramid
 =======
 
-.. image:: https://github.com/Pylons/Pyramid/workflows/Build%20and%20test/badge.svg?branch=master
+.. image:: https://github.com/Pylons/Pyramid/workflows/Build%20and%20test/badge.svg?branch=main
         :target: https://github.com/Pylons/Pyramid/actions?query=workflow%3A%22Build+and+test%22
-        :alt: master CI Status
+        :alt: main CI Status
 
-.. image:: https://readthedocs.org/projects/pyramid/badge/?version=master
-        :target: https://docs.pylonsproject.org/projects/pyramid/en/master
-        :alt: master Documentation Status
+.. image:: https://readthedocs.org/projects/pyramid/badge/?version=main
+        :target: https://docs.pylonsproject.org/projects/pyramid/en/main
+        :alt: main Documentation Status
 
 .. image:: https://img.shields.io/badge/IRC-Libera.Chat-blue.svg
         :target: https://web.libera.chat/#pyramid
@@ -47,8 +47,8 @@ for documentation, reporting bugs, and getting support.
 Developing and Contributing
 ---------------------------
 
-See `HACKING.txt <https://github.com/Pylons/pyramid/blob/master/HACKING.txt>`_ and
-`contributing.md <https://github.com/Pylons/pyramid/blob/master/contributing.md>`_
+See `HACKING.txt <https://github.com/Pylons/pyramid/blob/main/HACKING.txt>`_ and
+`contributing.md <https://github.com/Pylons/pyramid/blob/main/contributing.md>`_
 for guidelines on running tests, adding features, coding style, and updating
 documentation when developing in or contributing to Pyramid.
 

--- a/RELEASING.txt
+++ b/RELEASING.txt
@@ -19,7 +19,7 @@ Prepare new release branch
 
 - Create a new release branch, incrementing the version number.
 
-- Do any necessary branch merges (e.g., master to branch, branch to master).
+- Do any necessary branch merges (e.g., main to branch, branch to main).
 
 - On release branch:
 
@@ -33,7 +33,7 @@ Prepare new release branch
 
 - Run tests on Windows if feasible.
 
-- For each ``pyramid-cookiecutter-*``, make a new branch off "master" with the
+- For each ``pyramid-cookiecutter-*``, make a new branch off "main" with the
   same name to align with the new Pyramid release branch name.
 
 - In the docs, update the ``cookiecutter`` command with the new branch name,
@@ -60,7 +60,7 @@ Prepare new release branch
 - For major version releases, in contributing.md, update branch descriptions.
 
 - For major version releases, in docs/conf.py, update values under
-  html_theme_options for in_progress and outdated across master, releasing
+  html_theme_options for in_progress and outdated across main, releasing
   branch, and previously released branch. Also in the previously released
   branch only, uncomment the sections to enable pylons_sphinx_latesturl.
 
@@ -84,10 +84,10 @@ Prepare new release branch
 
 - Configure RTD to publish the new release version of the docs.
 
-Prepare master for further development (major releases only)
+Prepare "main" for further development (major releases only)
 ------------------------------------------------------------
 
-- Checkout master.
+- Checkout "main".
 
 - In CHANGES.rst, preserve headings but clear out content. Add heading
   "unreleased" for the version number.
@@ -103,11 +103,11 @@ Prepare master for further development (major releases only)
 - Change setup.py version to the next version number.
 
 - Update README.rst to use correct versions of badges, URLs, and ALT option
-  for "master" instead of the major release version.
+  for "main" instead of the major release version.
 
-- In the docs, update the ``cookiecutter`` command with ``master``,
+- In the docs, update the ``cookiecutter`` command with ``main``,
   for example, ``cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout
-  master``. A search for ``cookiecutter gh:Pylons/pyramid-cookiecutter-``
+  main``. A search for ``cookiecutter gh:Pylons/pyramid-cookiecutter-``
   should return all instances to be updated.
 
 Update previous version (final releases only)

--- a/contributing.md
+++ b/contributing.md
@@ -5,14 +5,14 @@ All projects under the Pylons Projects, including this one, follow the guideline
 You can contribute to this project in several ways.
 
 * [File an Issue on GitHub](https://github.com/Pylons/pyramid/issues)
-* Fork this project and create a branch with your suggested change. When ready, submit a pull request for consideration. [GitHub Flow](https://guides.github.com/introduction/flow/index.html) describes the workflow process and why it's a good practice. When submitting a pull request, sign [CONTRIBUTORS.txt](https://github.com/Pylons/pyramid/blob/master/CONTRIBUTORS.txt) if you have not yet done so.
+* Fork this project and create a branch with your suggested change. When ready, submit a pull request for consideration. [GitHub Flow](https://guides.github.com/introduction/flow/index.html) describes the workflow process and why it's a good practice. When submitting a pull request, sign [CONTRIBUTORS.txt](https://github.com/Pylons/pyramid/blob/main/CONTRIBUTORS.txt) if you have not yet done so.
 * Join the [IRC channel #pyramid on irc.libera.chat](https://web.libera.chat/#pyramid).
 
 ## Git Branches
 
 Git branches and their purpose and status at the time of this writing are listed below.
 
-* [master](https://github.com/Pylons/pyramid/) - The branch on which further development takes place. The default branch on GitHub.
+* [main](https://github.com/Pylons/pyramid/) - The branch on which further development takes place. The default branch on GitHub.
 * [2.0-branch](https://github.com/Pylons/pyramid/tree/2.0-branch) - The branch classified as "stable" or "latest".
 * [1.10-branch](https://github.com/Pylons/pyramid/tree/1.10-branch) - The oldest actively maintained and stable branch.
 
@@ -20,4 +20,4 @@ Older branches are not actively maintained. In general, two stable branches and 
 
 ## Developing
 
-Follow the instructions in [HACKING.txt](https://github.com/Pylons/pyramid/blob/master/HACKING.txt) to install Pyramid and the tools needed to run its tests and build its documentation.
+Follow the instructions in [HACKING.txt](https://github.com/Pylons/pyramid/blob/main/HACKING.txt) to install Pyramid and the tools needed to run its tests and build its documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ templates_path = ['_templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
+# The main toctree document.
 master_doc = 'index'
 
 # General substitutions.
@@ -150,7 +150,7 @@ html_theme = 'pyramid'
 html_theme_path = pylons_sphinx_themes.get_html_themes_path()
 html_theme_options = dict(
     github_url='https://github.com/Pylons/pyramid',
-    # On master branch and new branch still in
+    # On main branch and new branch still in
     # pre-release status: true; else: false.
     in_progress='true',
     # On branches previous to "latest": true; else: false.

--- a/docs/narr/cookiecutters.rst
+++ b/docs/narr/cookiecutters.rst
@@ -36,6 +36,6 @@ See `Cookiecutter Installation <https://cookiecutter.readthedocs.io/en/latest/in
 
 Then see the `README <https://github.com/Pylons/pyramid-cookiecutter-starter#pyramid-cookiecutter-starter>`_ of ``pyramid-cookiecutter-starter`` for its usage to generate a starter project.
 
-The ``pyramid-cookiecutter-starter`` on its ``master`` branch is a good starting point to develop your own cookiecutter.
+The ``pyramid-cookiecutter-starter`` on its ``main`` branch is a good starting point to develop your own cookiecutter.
 Development of cookiecutters is documented under `Learn the Basics of Cookiecutter by Creating a Cookiecutter <https://cookiecutter.readthedocs.io/en/latest/first_steps.html>`_.
 See `Cookiecutter Features <https://cookiecutter.readthedocs.io/en/latest/README.html#features>`_ for details of what is possible.

--- a/docs/narr/project.rst
+++ b/docs/narr/project.rst
@@ -83,7 +83,7 @@ On all platforms, generate a project using cookiecutter.
 
 .. code-block:: bash
 
-    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
 If prompted for the first item, accept the default ``yes`` by hitting return.
 

--- a/docs/quick_tour.rst
+++ b/docs/quick_tour.rst
@@ -505,7 +505,7 @@ Let's use the cookiecutter ``pyramid-cookiecutter-starter`` to create a starter 
 
 .. code-block:: bash
 
-    $VENV/bin/cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+    $VENV/bin/cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
 If prompted for the first item, accept the default ``yes`` by hitting return.
 
@@ -865,7 +865,7 @@ Pyramid and SQLAlchemy are great friends. That friendship includes a cookiecutte
 .. code-block:: bash
 
     cd ~
-    env/bin/cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+    env/bin/cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
 If prompted for the first item, accept the default ``yes`` by hitting return.
 

--- a/docs/quick_tutorial/cookiecutters.rst
+++ b/docs/quick_tutorial/cookiecutters.rst
@@ -28,7 +28,7 @@ Steps
 
     .. code-block:: bash
 
-        $VENV/bin/cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+        $VENV/bin/cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
     If prompted for the first item, accept the default ``yes`` by hitting return.
 

--- a/docs/quick_tutorial/databases.rst
+++ b/docs/quick_tutorial/databases.rst
@@ -13,7 +13,7 @@ Background
 Our Pyramid-based wiki application now needs database-backed storage of pages.
 This frequently means an SQL database. The Pyramid community strongly supports
 the :ref:`SQLAlchemy <sqla:index_toplevel>` project and its
-:ref:`object-relational mapper (ORM) <sqla:ormtutorial_toplevel>` as a
+:ref:`object-relational mapper (ORM) <sqla:orm_quickstart>` as a
 convenient, Pythonic way to interface to databases.
 
 In this step we hook up SQLAlchemy to a SQLite database table, providing

--- a/docs/tutorials/modwsgi/index.rst
+++ b/docs/tutorials/modwsgi/index.rst
@@ -39,7 +39,7 @@ specific path information for commands and files.
     .. code-block:: bash
 
         cd ~
-        cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+        cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
     If prompted for the first item, accept the default ``yes`` by hitting return.
 

--- a/docs/tutorials/wiki/installation.rst
+++ b/docs/tutorials/wiki/installation.rst
@@ -36,7 +36,7 @@ On Unix
 .. code-block:: bash
 
     cd ~
-    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
 
 On Windows
@@ -45,7 +45,7 @@ On Windows
 .. code-block:: doscon
 
     cd \
-    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
 
 On all operating systems

--- a/docs/tutorials/wiki2/installation.rst
+++ b/docs/tutorials/wiki2/installation.rst
@@ -273,7 +273,7 @@ On Windows
 
 There should be no output to your console.
 You should now have a ``tutorial.sqlite`` file in your current working directory.
-This is an SQLite database with three tables defined in it, ``alembic_version``, ``models``, and ``main``, where the first two tables each have single record inside of them.
+This is an SQLite database with three tables defined in it, ``alembic_version``, ``models``, where the first two tables each have single record inside of them.
 
 
 .. _sql_running_tests:

--- a/docs/tutorials/wiki2/installation.rst
+++ b/docs/tutorials/wiki2/installation.rst
@@ -43,7 +43,7 @@ On Unix
 .. code-block:: bash
 
     cd ~
-    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
 On Windows
 ^^^^^^^^^^
@@ -51,7 +51,7 @@ On Windows
 .. code-block:: doscon
 
     cd \
-    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout master
+    cookiecutter gh:Pylons/pyramid-cookiecutter-starter --checkout main
 
 On all operating systems
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -273,7 +273,7 @@ On Windows
 
 There should be no output to your console.
 You should now have a ``tutorial.sqlite`` file in your current working directory.
-This is an SQLite database with three tables defined in it, ``alembic_version``, ``models``, and ``master``, where the first two tables each have single record inside of them.
+This is an SQLite database with three tables defined in it, ``alembic_version``, ``models``, and ``main``, where the first two tables each have single record inside of them.
 
 
 .. _sql_running_tests:


### PR DESCRIPTION
This PR replaces all the relevant "master" branch usage to "main" in Docs and CI.

See:: https://github.com/Pylons/pyramid/issues/3712