### PR TITLE
Change some  URL from '-' to '_' 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,22 +61,22 @@ extensions = [
 # Looks for objects in external projects
 intersphinx_mapping = {
     'colander': ('https://docs.pylonsproject.org/projects/colander/en/latest/', None),
-    'cookbook': ('https://docs.pylonsproject.org/projects/pyramid-cookbook/en/latest/', None),
+    'cookbook': ('https://docs.pylonsproject.org/projects/pyramid_cookbook/en/latest/', None),
     'deform': ('https://docs.pylonsproject.org/projects/deform/en/latest/', None),
-    'jinja2': ('https://docs.pylonsproject.org/projects/pyramid-jinja2/en/latest/', None),
+    'jinja2': ('https://docs.pylonsproject.org/projects/pyramid_jinja2/en/latest/', None),
     'pylonswebframework': ('https://docs.pylonsproject.org/projects/pylons-webframework/en/latest/', None),
     'python': ('https://docs.python.org/3/', None),
     'pytest': ('https://docs.pytest.org/en/latest/', None),
     'sqla': ('https://docs.sqlalchemy.org/en/latest/', None),
-    'tm': ('https://docs.pylonsproject.org/projects/pyramid-tm/en/latest/', None),
-    'toolbar': ('https://docs.pylonsproject.org/projects/pyramid-debugtoolbar/en/latest/', None),
+    'tm': ('https://docs.pylonsproject.org/projects/pyramid_tm/en/latest/', None),
+    'toolbar': ('https://docs.pylonsproject.org/projects/pyramid_debugtoolbar/en/latest/', None),
     'transaction': ('https://transaction.readthedocs.io/en/latest/', None),
-    'tutorials': ('https://docs.pylonsproject.org/projects/pyramid-tutorials/en/latest/', None),
+    'tutorials': ('https://docs.pylonsproject.org/projects/pyramid_tutorials/en/latest/', None),
     'venusian': ('https://docs.pylonsproject.org/projects/venusian/en/latest/', None),
     'webtest': ('https://docs.pylonsproject.org/projects/webtest/en/latest/', None),
     'webob': ('https://docs.pylonsproject.org/projects/webob/en/latest/', None),
     'zcml': (
-    'https://docs.pylonsproject.org/projects/pyramid-zcml/en/latest/', None),
+    'https://docs.pylonsproject.org/projects/pyramid_zcml/en/latest/', None),
 }
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ speed right away.
 * Like learning by example? Visit the official :ref:`html_tutorials` as well as
   the community-contributed :ref:`Pyramid Tutorials
   <tutorials:pyramid-tutorials>` and :ref:`Pyramid Community Cookbook
-  <cookbook:pyramid-cookbook>`.
+  <cookbook:pyramid_cookbook>`.
 
 * For help getting Pyramid set up, try :ref:`installing_chapter`.
 


### PR DESCRIPTION
Change URL from '-' to '_' except for https://docs.pylonsproject.org/projects/pylons-webframework/en/latest/. This is because all other URLs have replaced  '-'  between words in their names with underscore symbols.

index.rst needn't change that but I don't know howto uncommit it ...