### PR TITLE
Adding script name to 'global_config' during application setup 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,17 @@ Features
 
 - Coverage reports in tests based on Python 3.11 instead of Python 3.8.
 
+- All scripts now pass a new option ``__script__`` when loading the WSGI app.
+  For example, ``pserve`` sets ``__script__ == 'pserve'``. This works for
+  ``pserve``, ``pshell``, ``prequest``, ``proutes``, ``ptweens``, ``pviews``,
+  as well as when using ``pyramid.paster.bootstrap`` directly.
+
+  When using ``plaster-pastedeploy`` to load an INI file, this option will
+  manifest as a new value passed into the ``global_conf`` arg of your
+  application factory, where you can use it as part of initializing your app.
+
+  See https://github.com/Pylons/pyramid/pull/3735
+
 Bug Fixes
 ---------
 

--- a/docs/narr/startup.rst
+++ b/docs/narr/startup.rst
@@ -101,7 +101,9 @@ Here's a high-level time-ordered overview of what happens when you press
    Note that the constructor function accepts a ``global_config`` argument,
    which is a dictionary of key/value pairs mentioned in the ``[DEFAULT]``
    section of an ``.ini`` file (if :ref:`[DEFAULT]
-   <defaults_section_of_pastedeploy_file>` is present).  It also accepts a
+   <defaults_section_of_pastedeploy_file>` is present) and the executing
+   script name ``__script__`` like ``pserve``, ``prequest`` or ``pshell``.
+   It also accepts a
    ``**settings`` argument, which collects another set of arbitrary key/value
    pairs.  The arbitrary key/value pairs received by this function in
    ``**settings`` will be composed of all the key/value pairs that are present

--- a/src/pyramid/paster.py
+++ b/src/pyramid/paster.py
@@ -114,6 +114,8 @@ def bootstrap(config_uri, request=None, options=None):
        by the ``closer``.
 
     """
+    options = dict(options or {})
+    options.setdefault('__script__', 'bootstrap')
     app = get_app(config_uri, options=options)
     env = prepare(request)
     env['app'] = app

--- a/src/pyramid/scripts/prequest.py
+++ b/src/pyramid/scripts/prequest.py
@@ -137,9 +137,7 @@ class PRequestCommand:
             return 2
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
-        # bw update 2.1 don't overwrite if set
-        if '__script__' not in config_vars:
-            config_vars['__script__'] = self.script_name
+        config_vars.setdefault('__script__', self.script_name)
         path = self.args.path_info
 
         loader = self._get_config_loader(config_uri)

--- a/src/pyramid/scripts/prequest.py
+++ b/src/pyramid/scripts/prequest.py
@@ -45,6 +45,7 @@ class PRequestCommand:
     the request's WSGI environment, so your application can distinguish these
     calls from normal requests.
     """
+    script_name = 'prequest'
 
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
@@ -136,6 +137,9 @@ class PRequestCommand:
             return 2
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
+        # bw update 2.1 don't overwrite if set
+        if not '__script__' in config_vars:
+            config_vars['__script__'] = self.script_name
         path = self.args.path_info
 
         loader = self._get_config_loader(config_uri)

--- a/src/pyramid/scripts/prequest.py
+++ b/src/pyramid/scripts/prequest.py
@@ -138,7 +138,7 @@ class PRequestCommand:
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         # bw update 2.1 don't overwrite if set
-        if not '__script__' in config_vars:
+        if '__script__' not in config_vars:
             config_vars['__script__'] = self.script_name
         path = self.args.path_info
 

--- a/src/pyramid/scripts/proutes.py
+++ b/src/pyramid/scripts/proutes.py
@@ -318,7 +318,7 @@ class PRoutesCommand:
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         # bw update 2.1 don't overwrite if set
-        if not '__script__' in config_vars:
+        if '__script__' not in config_vars:
             config_vars['__script__'] = self.script_name
         loader = self.get_config_loader(config_uri)
         loader.setup_logging(config_vars)

--- a/src/pyramid/scripts/proutes.py
+++ b/src/pyramid/scripts/proutes.py
@@ -317,9 +317,7 @@ class PRoutesCommand:
 
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
-        # bw update 2.1 don't overwrite if set
-        if '__script__' not in config_vars:
-            config_vars['__script__'] = self.script_name
+        config_vars.setdefault('__script__', self.script_name)
         loader = self.get_config_loader(config_uri)
         loader.setup_logging(config_vars)
         self.proutes_file_config(loader, config_vars)

--- a/src/pyramid/scripts/proutes.py
+++ b/src/pyramid/scripts/proutes.py
@@ -224,6 +224,7 @@ class PRoutesCommand:
     will be assumed.  Example: 'proutes myapp.ini'.
 
     """
+    script_name = 'proutes'
     bootstrap = staticmethod(bootstrap)  # testing
     get_config_loader = staticmethod(get_config_loader)  # testing
     stdout = sys.stdout
@@ -316,6 +317,9 @@ class PRoutesCommand:
 
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
+        # bw update 2.1 don't overwrite if set
+        if not '__script__' in config_vars:
+            config_vars['__script__'] = self.script_name
         loader = self.get_config_loader(config_uri)
         loader.setup_logging(config_vars)
         self.proutes_file_config(loader, config_vars)

--- a/src/pyramid/scripts/pserve.py
+++ b/src/pyramid/scripts/pserve.py
@@ -185,7 +185,7 @@ class PServeCommand:
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         # bw update 2.1 don't overwrite if set
-        if not '__script__' in config_vars:
+        if '__script__' not in config_vars:
             config_vars['__script__'] = self.script_name
         app_spec = self.args.config_uri
         app_name = self.args.app_name

--- a/src/pyramid/scripts/pserve.py
+++ b/src/pyramid/scripts/pserve.py
@@ -184,9 +184,7 @@ class PServeCommand:
             return 2
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
-        # bw update 2.1 don't overwrite if set
-        if '__script__' not in config_vars:
-            config_vars['__script__'] = self.script_name
+        config_vars.setdefault('__script__', self.script_name)
         app_spec = self.args.config_uri
         app_name = self.args.app_name
 

--- a/src/pyramid/scripts/pserve.py
+++ b/src/pyramid/scripts/pserve.py
@@ -39,6 +39,7 @@ class PServeCommand:
     You can also include variable assignments like 'http_port=8080'
     and then use %(http_port)s in your config files.
     """
+    script_name = 'pserve'
     default_verbosity = 1
 
     parser = argparse.ArgumentParser(
@@ -183,6 +184,9 @@ class PServeCommand:
             return 2
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
+        # bw update 2.1 don't overwrite if set
+        if not '__script__' in config_vars:
+            config_vars['__script__'] = self.script_name
         app_spec = self.args.config_uri
         app_name = self.args.app_name
 

--- a/src/pyramid/scripts/pshell.py
+++ b/src/pyramid/scripts/pshell.py
@@ -131,9 +131,7 @@ class PShellCommand:
 
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
-        # bw update 2.1 don't overwrite if set
-        if '__script__' not in config_vars:
-            config_vars['__script__'] = self.script_name
+        config_vars.setdefault('__script__', self.script_name)
         loader = self.get_config_loader(config_uri)
         loader.setup_logging(config_vars)
         self.pshell_file_config(loader, config_vars)

--- a/src/pyramid/scripts/pshell.py
+++ b/src/pyramid/scripts/pshell.py
@@ -132,7 +132,7 @@ class PShellCommand:
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         # bw update 2.1 don't overwrite if set
-        if not '__script__' in config_vars:
+        if '__script__' not in config_vars:
             config_vars['__script__'] = self.script_name
         loader = self.get_config_loader(config_uri)
         loader.setup_logging(config_vars)

--- a/src/pyramid/scripts/pshell.py
+++ b/src/pyramid/scripts/pshell.py
@@ -38,6 +38,7 @@ class PShellCommand:
     than one Pyramid application within it, the loader will use the
     last one.
     """
+    script_name = 'pshell'
     bootstrap = staticmethod(bootstrap)  # for testing
     get_config_loader = staticmethod(get_config_loader)  # for testing
     pkg_resources = pkg_resources  # for testing
@@ -130,6 +131,9 @@ class PShellCommand:
 
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
+        # bw update 2.1 don't overwrite if set
+        if not '__script__' in config_vars:
+            config_vars['__script__'] = self.script_name
         loader = self.get_config_loader(config_uri)
         loader.setup_logging(config_vars)
         self.pshell_file_config(loader, config_vars)

--- a/src/pyramid/scripts/ptweens.py
+++ b/src/pyramid/scripts/ptweens.py
@@ -27,6 +27,7 @@ class PTweensCommand:
     will be assumed.  Example: "ptweens myapp.ini#main".
 
     """
+    script_name = 'ptweens'
     parser = argparse.ArgumentParser(
         description=textwrap.dedent(description),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -81,6 +82,9 @@ class PTweensCommand:
             return 2
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
+        # bw update 2.1 don't overwrite if set
+        if not '__script__' in config_vars:
+            config_vars['__script__'] = self.script_name
         self.setup_logging(config_uri, global_conf=config_vars)
         env = self.bootstrap(config_uri, options=config_vars)
         registry = env['registry']

--- a/src/pyramid/scripts/ptweens.py
+++ b/src/pyramid/scripts/ptweens.py
@@ -82,9 +82,7 @@ class PTweensCommand:
             return 2
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
-        # bw update 2.1 don't overwrite if set
-        if '__script__' not in config_vars:
-            config_vars['__script__'] = self.script_name
+        config_vars.setdefault('__script__', self.script_name)
         self.setup_logging(config_uri, global_conf=config_vars)
         env = self.bootstrap(config_uri, options=config_vars)
         registry = env['registry']

--- a/src/pyramid/scripts/ptweens.py
+++ b/src/pyramid/scripts/ptweens.py
@@ -83,7 +83,7 @@ class PTweensCommand:
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         # bw update 2.1 don't overwrite if set
-        if not '__script__' in config_vars:
+        if '__script__' not in config_vars:
             config_vars['__script__'] = self.script_name
         self.setup_logging(config_uri, global_conf=config_vars)
         env = self.bootstrap(config_uri, options=config_vars)

--- a/src/pyramid/scripts/pviews.py
+++ b/src/pyramid/scripts/pviews.py
@@ -27,6 +27,7 @@ class PViewsCommand:
     specifies the path info portion of a URL that will be used to find
     matching views.  Example: 'proutes myapp.ini#main /url'
     """
+    script_name = 'pviews'
     stdout = sys.stdout
 
     parser = argparse.ArgumentParser(
@@ -248,6 +249,9 @@ class PViewsCommand:
             return 2
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
+        # bw update 2.1 don't overwrite if set
+        if not '__script__' in config_vars:
+            config_vars['__script__'] = self.script_name
         url = self.args.url
 
         self.setup_logging(config_uri, global_conf=config_vars)

--- a/src/pyramid/scripts/pviews.py
+++ b/src/pyramid/scripts/pviews.py
@@ -250,7 +250,7 @@ class PViewsCommand:
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         # bw update 2.1 don't overwrite if set
-        if not '__script__' in config_vars:
+        if '__script__' not in config_vars:
             config_vars['__script__'] = self.script_name
         url = self.args.url
 

--- a/src/pyramid/scripts/pviews.py
+++ b/src/pyramid/scripts/pviews.py
@@ -249,9 +249,7 @@ class PViewsCommand:
             return 2
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
-        # bw update 2.1 don't overwrite if set
-        if '__script__' not in config_vars:
-            config_vars['__script__'] = self.script_name
+        config_vars.setdefault('__script__', self.script_name)
         url = self.args.url
 
         self.setup_logging(config_uri, global_conf=config_vars)

--- a/tests/test_paster.py
+++ b/tests/test_paster.py
@@ -159,6 +159,7 @@ class Test_bootstrap(unittest.TestCase):
         result = self._callFUT('/foo/bar/myapp.ini', request)
         self.assertEqual(result['app'], self.app)
         self.assertEqual(result['root'], self.root)
+        self.assertEqual(self.get_app.kw['options']['__script__'], 'bootstrap')
         self.assertTrue('closer' in result)
 
 

--- a/tests/test_scripts/test_prequest.py
+++ b/tests/test_scripts/test_prequest.py
@@ -234,9 +234,14 @@ class TestPRequestCommand(unittest.TestCase):
         self.assertEqual(self._out, [b'abc'])
 
     def test_command_method_configures_logging(self):
-        command = self._makeOne(['', 'development.ini', '/'])
+        command = self._makeOne(['', '--method=GET', 'development.ini', '/'])
         command.run()
         self.assertEqual(self.loader.calls[0]['op'], 'logging')
+
+    def test_command_script_name(self):
+        command = self._makeOne(['', '--method=GET', 'development.ini', '/'],)
+        command.run()
+        self.assertEqual(self.loader.calls[0]['defaults']['__script__'], 'prequest')
 
 
 class Test_main(unittest.TestCase):

--- a/tests/test_scripts/test_prequest.py
+++ b/tests/test_scripts/test_prequest.py
@@ -241,7 +241,10 @@ class TestPRequestCommand(unittest.TestCase):
     def test_command_script_name(self):
         command = self._makeOne(['', '--method=GET', 'development.ini', '/'],)
         command.run()
-        self.assertEqual(self.loader.calls[0]['defaults']['__script__'], 'prequest')
+        self.assertEqual(
+            self.loader.calls[0]['defaults']['__script__'],
+            'prequest'
+        )
 
 
 class Test_main(unittest.TestCase):

--- a/tests/test_scripts/test_prequest.py
+++ b/tests/test_scripts/test_prequest.py
@@ -239,11 +239,10 @@ class TestPRequestCommand(unittest.TestCase):
         self.assertEqual(self.loader.calls[0]['op'], 'logging')
 
     def test_command_script_name(self):
-        command = self._makeOne(['', '--method=GET', 'development.ini', '/'],)
+        command = self._makeOne(['', '--method=GET', 'development.ini', '/'])
         command.run()
         self.assertEqual(
-            self.loader.calls[0]['defaults']['__script__'],
-            'prequest'
+            self.loader.calls[0]['defaults']['__script__'], 'prequest'
         )
 
 

--- a/tests/test_scripts/test_pserve.py
+++ b/tests/test_scripts/test_pserve.py
@@ -47,7 +47,7 @@ class TestPServeCommand(unittest.TestCase):
         self.loader.server = lambda x: x
 
         inst.run()
-        self.assertEqual(app.global_conf, {'a': '1', 'b': '2'})
+        self.assertEqual(app.global_conf, {'a': '1', 'b': '2', '__script__': 'pserve'})
 
     def test_original_ignore_files(self):
         msg = 'A change to "ignore_files" was detected'

--- a/tests/test_scripts/test_pserve.py
+++ b/tests/test_scripts/test_pserve.py
@@ -47,7 +47,10 @@ class TestPServeCommand(unittest.TestCase):
         self.loader.server = lambda x: x
 
         inst.run()
-        self.assertEqual(app.global_conf, {'a': '1', 'b': '2', '__script__': 'pserve'})
+        self.assertEqual(
+            app.global_conf,
+            {'a': '1', 'b': '2', '__script__': 'pserve'}
+        )
 
     def test_original_ignore_files(self):
         msg = 'A change to "ignore_files" was detected'

--- a/tests/test_scripts/test_pserve.py
+++ b/tests/test_scripts/test_pserve.py
@@ -48,8 +48,7 @@ class TestPServeCommand(unittest.TestCase):
 
         inst.run()
         self.assertEqual(
-            app.global_conf,
-            {'a': '1', 'b': '2', '__script__': 'pserve'}
+            app.global_conf, {'a': '1', 'b': '2', '__script__': 'pserve'}
         )
 
     def test_original_ignore_files(self):


### PR DESCRIPTION
This code extends pyramid startup scripts in python/bin directory (pserve, prequest, pshell, pviews, proutes, ptweens) with additional info about the calling script.  The additional info is passed to the **main(global_config, **settings)** function as part of global_config dict during wsgi setup as '__script__'.
``global_config`` can contain custom values loaded from the ini file, so to avoid unwanted overwriting of a existing '__script__' value I've added a extra condition for comapatibility. 

In some cases it makes sense to call different code whether the application is created as server (bin/pserve) or for a single request (bin/prequest). For example setting up internal caching modules, maintenance or other background functions.