### PR TITLE
fix secured views to avoid being applied to exception views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,14 @@ Bug Fixes
 
   Thanks to Masashi Yamane of LAC Co., Ltd for reporting this issue.
 
+- Fix issues where permissions may be checked on exception views. This is not
+  supposed to happen in normal circumstances.
+
+  This also prevents issues where a ``request.url`` fails to be decoded when
+  logging info when ``pyramid.debug_authorization`` is enabled.
+
+  See https://github.com/Pylons/pyramid/pull/3741/files
+
 Backward Incompatibilities
 --------------------------
 


### PR DESCRIPTION
fixes https://github.com/Pylons/pyramid/issues/3736

Found some scenarios in which an exception view was wrapped in secure views which is not intended after info.exception_only was added. The main issue encountered is that there were tests for `info.exception_only and permission is None` but actually a default exception view has `permission == NO_PERMISSION_REQUIRED` so this new logic normalizes that.

While in there, I was able to re-order a bunch of the logic to early-out quicker.

Because exception views are no longer involved in security checks, this avoids the issue ran into via #3736 where an invalid URL was tested, which shouldn't happen while processing any normal exception views.