### PR TITLE
Fix csrf 400 status lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,13 @@ Bug Fixes
 
   Thanks to Masashi Yamane of LAC Co., Ltd for reporting this issue.
 
+- Applications raising ``pyramid.exceptions.BadCSRFToken`` and
+  ``pyramid.exceptions.BadCSRFOrigin`` were returning invalid HTTP status
+  lines with values like ``400 Bad CSRF Origin`` instead of
+  ``400 Bad Request``.
+
+  See https://github.com/Pylons/pyramid/pull/3742
+
 Backward Incompatibilities
 --------------------------
 

--- a/src/pyramid/exceptions.py
+++ b/src/pyramid/exceptions.py
@@ -10,12 +10,11 @@ class BadCSRFOrigin(HTTPBadRequest):
     origin validation.
     """
 
-    title = "Bad CSRF Origin"
     explanation = (
-        "Access is denied. This server can not verify that the origin or "
-        "referrer of your request matches the current site. Either your "
-        "browser supplied the wrong Origin or Referrer or it did not supply "
-        "one at all."
+        "Bad CSRF Origin. Access is denied. This server can not verify that "
+        "the origin or referrer of your request matches the current site. "
+        "Either your browser supplied the wrong Origin or Referrer or it did "
+        "not supply one at all."
     )
 
 
@@ -25,14 +24,13 @@ class BadCSRFToken(HTTPBadRequest):
     forgery token validation.
     """
 
-    title = 'Bad CSRF Token'
     explanation = (
-        'Access is denied.  This server can not verify that your cross-site '
-        'request forgery token belongs to your login session.  Either you '
-        'supplied the wrong cross-site request forgery token or your session '
-        'no longer exists.  This may be due to session timeout or because '
-        'browser is not supplying the credentials required, as can happen '
-        'when the browser has cookies turned off.'
+        'Bad CSRF token received. Access is denied. This server can not '
+        'verify that your cross-site request forgery token belongs to your '
+        'login session. Either you supplied the wrong cross-site request '
+        'forgery token or your session no longer exists. This may be due to '
+        'session timeout or because browser is not supplying the credentials '
+        'required, as can happen when the browser has cookies turned off.'
     )
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -16,12 +16,22 @@ class TestBWCompat(unittest.TestCase):
         self.assertTrue(one is two)
 
 
+class TestBadCSRFOrigin(unittest.TestCase):
+    def test_response_equivalence(self):
+        from pyramid.exceptions import BadCSRFOrigin
+        from pyramid.httpexceptions import HTTPBadRequest
+
+        self.assertTrue(isinstance(BadCSRFOrigin(), HTTPBadRequest))
+        self.assertEqual(BadCSRFOrigin().status, HTTPBadRequest().status)
+
+
 class TestBadCSRFToken(unittest.TestCase):
     def test_response_equivalence(self):
         from pyramid.exceptions import BadCSRFToken
         from pyramid.httpexceptions import HTTPBadRequest
 
         self.assertTrue(isinstance(BadCSRFToken(), HTTPBadRequest))
+        self.assertEqual(BadCSRFToken().status, HTTPBadRequest().status)
 
 
 class TestNotFound(unittest.TestCase):


### PR DESCRIPTION
BadCSRFToken and BadCSRFOrigin were previously returning things like `400 Bad CSRF Origin` instead of `400 Bad Request`. This PR moves the details to the body instead of the HTTP status line.