### PR TITLE
remove pkg_resources from DottedNameResolver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Features
 
   See https://github.com/Pylons/pyramid/pull/3745
 
+- Replace usage of ``pkg_resources`` in ``pyramid.path.DottedNameResolver``.
+  See https://github.com/Pylons/pyramid/pull/3748
+
 Bug Fixes
 ---------
 


### PR DESCRIPTION
This is just one step in removing pkg_resources, but looking for some of the easier cases like this first.