### PR TITLE
Remove pkg resources from scripts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Features
 - Replace usage of ``pkg_resources`` in ``pyramid.path.DottedNameResolver``.
   See https://github.com/Pylons/pyramid/pull/3748
 
+- Replace usage of ``pkg_resources`` in ``pdistreport`` and ``pshell`` CLI
+  commands. See https://github.com/Pylons/pyramid/pull/3749
+
 Bug Fixes
 ---------
 

--- a/src/pyramid/scripts/pdistreport.py
+++ b/src/pyramid/scripts/pdistreport.py
@@ -1,6 +1,6 @@
 import argparse
+import importlib.metadata
 from operator import itemgetter
-import pkg_resources
 import platform
 import sys
 
@@ -21,7 +21,7 @@ def get_parser():
 
 def main(
     argv=sys.argv,
-    pkg_resources=pkg_resources,
+    importlib_metadata=importlib.metadata,
     platform=platform.platform,
     out=out,
 ):
@@ -29,25 +29,25 @@ def main(
     parser = get_parser()
     parser.parse_args(argv[1:])
     packages = []
-    for distribution in pkg_resources.working_set:
-        name = distribution.project_name
+    for distribution in importlib_metadata.distributions():
+        name = distribution.metadata['Name']
         packages.append(
             {
                 'version': distribution.version,
                 'lowername': name.lower(),
                 'name': name,
-                'location': distribution.location,
+                'summary': distribution.metadata.get('Summary'),
             }
         )
     packages = sorted(packages, key=itemgetter('lowername'))
-    pyramid_version = pkg_resources.get_distribution('pyramid').version
+    pyramid_version = importlib_metadata.distribution('pyramid').version
     plat = platform()
     out('Pyramid version:', pyramid_version)
     out('Platform:', plat)
     out('Packages:')
     for package in packages:
         out(' ', package['name'], package['version'])
-        out('   ', package['location'])
+        out('   ', package['summary'])
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_scripts/dummy.py
+++ b/tests/test_scripts/dummy.py
@@ -154,26 +154,6 @@ class DummyBootstrap:
         }
 
 
-class DummyEntryPoint:
-    def __init__(self, name, module):
-        self.name = name
-        self.module = module
-
-    def load(self):
-        return self.module
-
-
-class DummyPkgResources:
-    def __init__(self, entry_point_values):
-        self.entry_points = []
-
-        for name, module in entry_point_values.items():
-            self.entry_points.append(DummyEntryPoint(name, module))
-
-    def iter_entry_points(self, name):
-        return self.entry_points
-
-
 class dummy_setup_logging:
     def __call__(self, config_uri, global_conf):
         self.config_uri = config_uri

--- a/tests/test_scripts/test_pdistreport.py
+++ b/tests/test_scripts/test_pdistreport.py
@@ -1,3 +1,4 @@
+import email.message
 import unittest
 
 
@@ -12,14 +13,14 @@ class TestPDistReportCommand(unittest.TestCase):
         def platform():
             return 'myplatform'
 
-        pkg_resources = DummyPkgResources()
+        importlib_metadata = DummyImportlibMetadata()
         L = []
 
         def out(*args):
             L.extend(args)
 
         result = self._callFUT(
-            pkg_resources=pkg_resources, platform=platform, out=out
+            importlib_metadata=importlib_metadata, platform=platform, out=out
         )
         self.assertEqual(result, None)
         self.assertEqual(
@@ -32,14 +33,14 @@ class TestPDistReportCommand(unittest.TestCase):
             return 'myplatform'
 
         working_set = (DummyDistribution('abc'), DummyDistribution('def'))
-        pkg_resources = DummyPkgResources(working_set)
+        importlib_metadata = DummyImportlibMetadata(working_set)
         L = []
 
         def out(*args):
             L.extend(args)
 
         result = self._callFUT(
-            pkg_resources=pkg_resources, platform=platform, out=out
+            importlib_metadata=importlib_metadata, platform=platform, out=out
         )
         self.assertEqual(result, None)
         self.assertEqual(
@@ -54,31 +55,30 @@ class TestPDistReportCommand(unittest.TestCase):
                 'abc',
                 '1',
                 '   ',
-                '/projects/abc',
+                'summary for name=\'abc\'',
                 ' ',
                 'def',
                 '1',
                 '   ',
-                '/projects/def',
+                'summary for name=\'def\'',
             ],
         )
 
 
-class DummyPkgResources:
-    def __init__(self, working_set=()):
-        self.working_set = working_set
+class DummyImportlibMetadata:
+    def __init__(self, distributions=()):
+        self._distributions = distributions
 
-    def get_distribution(self, name):
-        return Version('1')
+    def distribution(self, name):
+        return DummyDistribution(name)
 
-
-class Version:
-    def __init__(self, version):
-        self.version = version
+    def distributions(self):
+        return iter(self._distributions)
 
 
 class DummyDistribution:
     def __init__(self, name):
-        self.project_name = name
         self.version = '1'
-        self.location = '/projects/%s' % name
+        self.metadata = email.message.Message()
+        self.metadata['Name'] = name
+        self.metadata['Summary'] = f'summary for {name=}'


### PR DESCRIPTION
Similar to https://github.com/Pylons/pyramid/pull/3748, remove pkg_resources from pdistreport and pshell scripts.

Sadly importlib.metadata provides no way to find the location on disk of a package so I had to change that functionality in `pdistreport`. Decided to just show the package summary string instead.