### PR TITLE
use AssetResolver internally

### DIFF
--- a/src/pyramid/asset.py
+++ b/src/pyramid/asset.py
@@ -1,7 +1,6 @@
 import os
-import pkg_resources
 
-from pyramid.path import package_name, package_path
+from pyramid.path import AssetResolver, package_name, package_path
 
 
 def resolve_asset_spec(spec, pname='__main__'):
@@ -37,7 +36,4 @@ def asset_spec_from_abspath(abspath, package):
 def abspath_from_asset_spec(spec, pname='__main__'):
     if pname is None:
         return spec
-    pname, filename = resolve_asset_spec(spec, pname)
-    if pname is None:
-        return filename
-    return pkg_resources.resource_filename(pname, filename)
+    return AssetResolver(pname).resolve(spec).abspath()

--- a/src/pyramid/static.py
+++ b/src/pyramid/static.py
@@ -5,9 +5,9 @@ import os
 from os.path import exists, getmtime, getsize, isdir, join, normcase, normpath
 from pkg_resources import resource_exists, resource_filename, resource_isdir
 
-from pyramid.asset import abspath_from_asset_spec, resolve_asset_spec
+from pyramid.asset import resolve_asset_spec
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
-from pyramid.path import caller_package
+from pyramid.path import AssetResolver, caller_package
 from pyramid.response import FileResponse, _guess_type
 from pyramid.traversal import traversal_path_info
 
@@ -381,8 +381,8 @@ class ManifestCacheBuster:
 
     def __init__(self, manifest_spec, reload=False):
         package_name = caller_package().__name__
-        self.manifest_path = abspath_from_asset_spec(
-            manifest_spec, package_name
+        self.manifest_path = (
+            AssetResolver(package_name).resolve(manifest_spec).abspath()
         )
         self.reload = reload
 


### PR DESCRIPTION
- abspath_from_asset_spec no longer uses pkg_resources directly
- ManifestCacheBuster now uses AssetResolver instead of pkg_resources directly
- rewrite static_view to use asset resolver

Changing the static_view is bw-incompat, and I'm not there yet with it being a good idea. I think it is - but hey.

The issue with AssetResolver in general is that it tries to import the package. This is bw-incompat. On previous versions, you could `add_static_view('does_not_exist:', 'static')` and it would work. You could then `config.override_asset(to_override='does_not_exist:', override_with='something_that_exists:')`. This change requires the initial `does_not_exist` package to be importable no matter what.