### PR TITLE
issue a warning if a static view is referencing a package that doesn't exist

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,17 @@ Backward Incompatibilities
   These have been deprecated in Python's gettext module since 3.8, and
   removed in Python 3.11.
 
+Deprecations
+------------
+
+- Deprecated the ability to use a non-existent package with
+  ``pyramid.config.Configurator.add_static_view`` and
+  ``pyramid.static.static_view``. This can be fixed by choosing a path
+  located within a real package as the ``root_dir`` for your static files.
+  This is almost always either a misconfig or an attempt to define an alias
+  location for use with ``pyramid.config.Configurator.override_asset``.
+  See https://github.com/Pylons/pyramid/pull/3752
+
 Documentation Changes
 ---------------------
 

--- a/src/pyramid/static.py
+++ b/src/pyramid/static.py
@@ -104,7 +104,7 @@ class static_view:
                     f' If this is done to override an asset, you must adjust'
                     f' this to override a location inside a real package.',
                     DeprecationWarning,
-                    stacklevel=1,
+                    stacklevel=2,
                 )
         self.use_subpath = use_subpath
         self.package_name = package_name

--- a/src/pyramid/static.py
+++ b/src/pyramid/static.py
@@ -4,6 +4,7 @@ import mimetypes
 import os
 from os.path import exists, getmtime, getsize, isdir, join, normcase, normpath
 from pkg_resources import resource_exists, resource_filename, resource_isdir
+import warnings
 
 from pyramid.asset import abspath_from_asset_spec, resolve_asset_spec
 from pyramid.httpexceptions import HTTPMovedPermanently, HTTPNotFound
@@ -92,6 +93,19 @@ class static_view:
         if package_name is None:
             package_name = caller_package().__name__
         package_name, docroot = resolve_asset_spec(root_dir, package_name)
+        if package_name:
+            try:
+                __import__(package_name)
+            except ImportError:
+                warnings.warn(
+                    f'A "pyramid.static.static_view" is being created with an'
+                    f' asset spec referencing a package "{package_name}" that'
+                    f' does not exist. This will break in the future.'
+                    f' If this is done to override an asset, you must adjust'
+                    f' this to override a location inside a real package.',
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
         self.use_subpath = use_subpath
         self.package_name = package_name
         self.docroot = docroot


### PR DESCRIPTION
in order to prepare for the static_view being switched to using the AssetResolver API, I would like to deprecate the ability to use non-existent packages with a static view. This would only make sense for asset overrides where a user defines some random non-existent package as an alias target. They could just as easily define a location inside a real package.