### PR TITLE
Fix p* scripts to produce an error when given a bad config_uri

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,14 @@ Bug Fixes
 
   See https://github.com/Pylons/pyramid/pull/3742
 
+- When a bad settings URI (usually a path to a non-existant file) is
+  supplied to one of pyramid's command line programs, and in general
+  when there is a reason why a settings file cannot be used, produce
+  an error message instead of a traceback.
+
+  Applications which import pyramid.paster must handle the
+  plaster.exceptions.PlasterError exception themselves.
+
 Backward Incompatibilities
 --------------------------
 

--- a/docs/narr/commandline.rst
+++ b/docs/narr/commandline.rst
@@ -715,7 +715,16 @@ your application and tries to run it, there just is no request data, because
 there isn't any real web request.  Therefore some parts of your application and
 some Pyramid APIs will not work.
 
-For this reason, :app:`Pyramid` makes it possible to run a script in an
+To assist with script writing :app:`Pyramid` provides the
+:mod:`paster <pyramid.paster>` module.
+
+.. versionchanged:: 2.0
+   Users of :mod:`paster <pyramid.paster>` are expected to themselves
+   handle any exceptions that might be raised by the :term:`plaster`
+   library, reporting to the user any problems (non-existant files,
+   etc.) with obtaining settings.
+
+:app:`Pyramid` makes it possible to run a script in an
 environment much like the environment produced when a particular
 :term:`request` reaches your :app:`Pyramid` application.  This is achieved by
 using the :func:`pyramid.paster.bootstrap` command in the body of your script.

--- a/src/pyramid/scripts/common.py
+++ b/src/pyramid/scripts/common.py
@@ -1,4 +1,6 @@
 import plaster
+import plaster.exceptions
+import sys
 
 
 def parse_vars(args):
@@ -15,9 +17,22 @@ def parse_vars(args):
     return result
 
 
-def get_config_loader(config_uri):
+def get_config_loader(config_uri, out=None):
     """
     Find a ``plaster.ILoader`` object supporting the "wsgi" protocol.
 
+    ``out``, if passed, must be a function of one argument, a string.
+    The function is called with an error message when the ``config_uri``
+    cannot be used to obtain settings.  After ``out`` is called the
+    program exits with a ``1`` (failure) status code.
+
+    When ``out`` is not passed, or is None, the caller is expected
+    to handle PlasterError exceptions raised by :term:`plaster`.
     """
-    return plaster.get_loader(config_uri, protocols=['wsgi'])
+    try:
+        return plaster.get_loader(config_uri, protocols=['wsgi'])
+    except plaster.exceptions.PlasterError as e:
+        if not out:
+            raise e
+        out(f'The settings given are not available: {e}')
+        sys.exit(1)

--- a/src/pyramid/scripts/prequest.py
+++ b/src/pyramid/scripts/prequest.py
@@ -140,7 +140,7 @@ class PRequestCommand:
         config_vars.setdefault('__script__', self.script_name)
         path = self.args.path_info
 
-        loader = self._get_config_loader(config_uri)
+        loader = self._get_config_loader(config_uri, self.out)
         loader.setup_logging(config_vars)
 
         app = loader.get_wsgi_app(self.args.app_name, config_vars)

--- a/src/pyramid/scripts/proutes.py
+++ b/src/pyramid/scripts/proutes.py
@@ -318,7 +318,7 @@ class PRoutesCommand:
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         config_vars.setdefault('__script__', self.script_name)
-        loader = self.get_config_loader(config_uri)
+        loader = self.get_config_loader(config_uri, self.out)
         loader.setup_logging(config_vars)
         self.proutes_file_config(loader, config_vars)
 

--- a/src/pyramid/scripts/pserve.py
+++ b/src/pyramid/scripts/pserve.py
@@ -187,7 +187,7 @@ class PServeCommand:
         app_spec = self.args.config_uri
         app_name = self.args.app_name
 
-        loader = self._get_config_loader(config_uri)
+        loader = self._get_config_loader(config_uri, self.out)
 
         # setup logging only in the worker process incase the logging config
         # opens files which should not be opened by multiple processes at once

--- a/src/pyramid/scripts/pshell.py
+++ b/src/pyramid/scripts/pshell.py
@@ -132,7 +132,7 @@ class PShellCommand:
         config_uri = self.args.config_uri
         config_vars = parse_vars(self.args.config_vars)
         config_vars.setdefault('__script__', self.script_name)
-        loader = self.get_config_loader(config_uri)
+        loader = self.get_config_loader(config_uri, self.out)
         loader.setup_logging(config_vars)
         self.pshell_file_config(loader, config_vars)
 

--- a/tests/test_scripts/dummy.py
+++ b/tests/test_scripts/dummy.py
@@ -174,7 +174,7 @@ class DummyLoader:
         self.server = server
         self.calls = []
 
-    def __call__(self, uri):
+    def __call__(self, uri, out=None):
         import plaster
 
         self.uri = plaster.parse_uri(uri)

--- a/tests/test_scripts/test_common.py
+++ b/tests/test_scripts/test_common.py
@@ -1,3 +1,5 @@
+from plaster.exceptions import PlasterError
+import pytest
 import unittest
 
 
@@ -14,3 +16,26 @@ class TestParseVars(unittest.TestCase):
 
         vars = ['a']
         self.assertRaises(ValueError, parse_vars, vars)
+
+
+def test_get_config_loader_raises():
+    from pyramid.scripts.common import get_config_loader
+
+    with pytest.raises(PlasterError):
+        get_config_loader('invalidscheme:/foo')
+
+
+def test_get_config_loader_calls():
+    from pyramid.scripts.common import get_config_loader
+
+    def reporter(text):
+        nonlocal reporter_called
+        reporter_called = True
+
+    reporter_called = False
+    with pytest.raises(SystemExit) as execinfo:
+        get_config_loader('invalidscheme:/foo', reporter)
+
+        assert execinfo.code == 1
+
+    assert reporter_called is True


### PR DESCRIPTION
When a bad settings URI (usually a path to a non-existant file) is
  supplied to one of pyramid's command line programs, and in general
  when there is a reason why a settings file cannot be used, produce
  an error message instead of a traceback.

  Applications which import pyramid.paster must handle the
  plaster.exceptions.PlasterError exception themselves.