### PR TITLE
Update SQLAlchemy integration tutorial to remove `sqlalchemy.MetaData.bind`'s usage

### DIFF
--- a/docs/quick_tutorial/databases/tutorial/__init__.py
+++ b/docs/quick_tutorial/databases/tutorial/__init__.py
@@ -7,7 +7,6 @@ from .models import DBSession, Base
 def main(global_config, **settings):
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
-    Base.metadata.bind = engine
 
     config = Configurator(settings=settings,
                           root_factory='tutorial.models.Root')


### PR DESCRIPTION
The concept of "bound metadata" is deprecated in SQLAlchemy 1.4 and removed in 2.0, which means that the `MetaData.bind` no longer exists and its usage should be removed.

References:
- https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed
- https://github.com/sqlalchemy/sqlalchemy/issues/4634
- https://gerrit.sqlalchemy.org/c/sqlalchemy/sqlalchemy/+/2302