### PR TITLE
chore: bump ubuntu image for CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -22,7 +22,7 @@ jobs:
                     - "3.12"
                     - "pypy-3.8"
                 os:
-                    - "ubuntu-20.04"
+                    - "ubuntu-24.04"
                     - "windows-2022"
                     - "macos-11"
                 architecture:
@@ -30,16 +30,16 @@ jobs:
                     - x86
 
                 include:
-                    # Only run coverage on ubuntu-20.04, except on pypy3
-                    - os: "ubuntu-20.04"
+                    # Only run coverage on ubuntu-24.04, except on pypy3
+                    - os: "ubuntu-24.04"
                       pytest-args: "--cov"
-                    - os: "ubuntu-20.04"
+                    - os: "ubuntu-24.04"
                       py: "pypy-3.8"
                       pytest-args: ""
 
                 exclude:
                     # Linux and macOS don't have x86 python
-                    - os: "ubuntu-20.04"
+                    - os: "ubuntu-24.04"
                       architecture: x86
                     - os: "macos-11"
                       architecture: x86
@@ -57,7 +57,7 @@ jobs:
             - name: Running tox
               run: tox -e py -- ${{ matrix.pytest-args }}
     coverage:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Validate coverage
         steps:
             - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
             - run: pip install tox
             - run: tox -e py312-cover,coverage
     docs:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Build the documentation
         steps:
             - uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
             - run: pip install tox
             - run: tox -e docs
     lint:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Lint the package
         steps:
             - uses: actions/checkout@v4

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: '3.12'
 sphinx:


### PR DESCRIPTION
Github is warning that the `ubuntu-20.04` image will be removed on 2025-04-01.