### PR TITLE
chore: drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,14 +15,13 @@ jobs:
         strategy:
             matrix:
                 py:
-                    - "3.8"
                     - "3.9"
                     - "3.10"
                     - "3.11"
                     - "3.12"
-                    - "pypy-3.8"
+                    - "pypy-3.10"
                 os:
-                    - "ubuntu-20.04"
+                    - "ubuntu-24.04"
                     - "windows-2022"
                     - "macos-11"
                 architecture:
@@ -30,16 +29,16 @@ jobs:
                     - x86
 
                 include:
-                    # Only run coverage on ubuntu-20.04, except on pypy3
-                    - os: "ubuntu-20.04"
+                    # Only run coverage on ubuntu-24.04, except on pypy3
+                    - os: "ubuntu-24.04"
                       pytest-args: "--cov"
-                    - os: "ubuntu-20.04"
-                      py: "pypy-3.8"
+                    - os: "ubuntu-24.04"
+                      py: "pypy-3.10"
                       pytest-args: ""
 
                 exclude:
                     # Linux and macOS don't have x86 python
-                    - os: "ubuntu-20.04"
+                    - os: "ubuntu-24.04"
                       architecture: x86
                     - os: "macos-11"
                       architecture: x86
@@ -57,7 +56,7 @@ jobs:
             - name: Running tox
               run: tox -e py -- ${{ matrix.pytest-args }}
     coverage:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Validate coverage
         steps:
             - uses: actions/checkout@v4
@@ -69,26 +68,26 @@ jobs:
             - run: pip install tox
             - run: tox -e py312-cover,coverage
     docs:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Build the documentation
         steps:
             - uses: actions/checkout@v4
             - name: Setup python
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.8
+                  python-version: 3.12
                   architecture: x64
             - run: pip install tox
             - run: tox -e docs
     lint:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         name: Lint the package
         steps:
             - uses: actions/checkout@v4
             - name: Setup python
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.8
+                  python-version: 3.12
                   architecture: x64
             - run: pip install tox
             - run: tox -e lint

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,7 +55,7 @@ Bug Fixes
 Backward Incompatibilities
 --------------------------
 
-- Drop support for Python 3.6 and 3.7.
+- Drop support for Python 3.6 3.7, and 3.8.
 
 - Drop support for l*gettext() methods in the i18n module.
   These have been deprecated in Python's gettext module since 3.8, and

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py38,py39,py310,py311,py312,pypy3,
+    py39,py310,py311,py312,pypy3,
     py312-cover,coverage,
     docs
 


### PR DESCRIPTION
Update 'ubuntu-20.04' image to 'ubuntu-24.04' for Github CI.