### PR TITLE
Constrain setuptools to <81

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     'hupper >= 1.5',  # ignore_files support
     'plaster',
     'plaster_pastedeploy',
-    'setuptools',
+    'setuptools<81',
     'translationstring >= 0.4',  # py3 compat
     'venusian >= 1.0',  # ``ignore``
     'webob >= 1.8.3',  # Accept.parse_offer


### PR DESCRIPTION
`pkg_resources` is deprecated and `setuptools>=81` is slated to remove it entirely.  Preventing setuptools from upgrading to v81 will buy time while #3731 is unresolved.