### PR TITLE
fix debug log message when userid is None

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -362,3 +362,5 @@ Contributors
 - Camill Kaipf, 2022/08/12
 
 - Stefano Rivera, 2022/12/29
+
+- Eyetheekh SP, 2026/03/17

--- a/src/pyramid/authentication.py
+++ b/src/pyramid/authentication.py
@@ -241,7 +241,7 @@ class RepozeWho1AuthenticationPolicy(CallbackAuthenticationPolicy):
 
         if userid is None:
             self.debug and self._log(
-                'repoze.who.userid is None, returning None' % userid,
+                'repoze.who.userid is None, returning None',
                 'authenticated_userid',
                 request,
             )


### PR DESCRIPTION
## summary
The log message formats the string using `% userid`, but the string does not contain a formatting placeholder, which causes:
```python
TypeError: not all arguments converted during string formatting
```
This removes the ` % userid` from the log message since its None anyway.


#### to reproduce
```python
from pyramid.authentication import RepozeWho1AuthenticationPolicy

class DummyRequest:
    environ = {"repoze.who.identity": {"repoze.who.userid": None}}

def _log(msg, methodname, request):
    print(msg)

policy = RepozeWho1AuthenticationPolicy()
policy.debug = True
policy._log = _log

request = DummyRequest()
result = policy.authenticated_userid(request)  # raises type error
```
