### PR TITLE
Resolve asset APIs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ unreleased
 Features
 --------
 
+- Add `Configurator.resolve_asset` and `Request.resolve_asset` methods.  See
+  https://github.com/Pylons/pyramid/pull/3745.
+
 Bug Fixes
 ---------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Features
 --------
 
 - Add `Configurator.resolve_asset` and `Request.resolve_asset` methods.  See
-  https://github.com/Pylons/pyramid/pull/3745.
+  https://github.com/Pylons/pyramid/pull/3815.
 
 Bug Fixes
 ---------

--- a/docs/narr/assets.rst
+++ b/docs/narr/assets.rst
@@ -365,6 +365,40 @@ package. If the folder does exist, then the overriden folder is given priority,
 if the file's name exists in both locations.
 
 .. index::
+   single: Accessing Static Assets
+
+.. _accessing_assets:
+
+Accessing Static Assets
+-----------------------
+
+In addition to serving static assets, your application may need to access asset
+data.  Pyramid provides two methods for this:
+
+- During configuration, you can use :meth:`pyramid.config.Configuration.resolve_asset`.
+- During a request, you can use :meth:`pyramid.request.Request.resolve_asset`.
+
+Both these methods accept a single argument of a :term:`asset specification` as
+a string and return an :class:`pyramid.interfaces.IAssetDescriptor` instance.
+
+Asset descriptors provide a :meth:`pyramid.interfaces.IAssetDescriptor.stream`
+method which returns a binary file-like object.  You can use ``read()`` to
+return a bytestring of the asset contents.
+
+If you need the access the asset via the filesystem, you can use the
+:meth:`pyramid.interfaces.IAssetDescriptor.abspath` method.  However, this is
+discouraged, as assets in zip packages do not have a filesystem path and
+require extracting the asset to a temporary file for the lifetime of the
+application.
+
+Python provides first-party asset APIs via `importlib.resources`_, but this
+does not support :ref:`overriding assets <overriding_assets_section>`.
+Applications may choose to use ``importlib.resources`` if they do not need to
+support overrides, but add-ons should utilize Pyramid's APIs.
+
+.. _importlib.resources: https://docs.python.org/3/library/importlib.resources.html
+
+.. index::
    single: Cache Busting
 
 .. _cache_busting:
@@ -493,6 +527,7 @@ well:
 
 .. code-block:: python
     :linenos:
+
 
     import posixpath
 

--- a/src/pyramid/config/__init__.py
+++ b/src/pyramid/config/__init__.py
@@ -36,7 +36,12 @@ from pyramid.interfaces import (
     IDebugLogger,
     IExceptionResponse,
 )
-from pyramid.path import DottedNameResolver, caller_package, package_of
+from pyramid.path import (
+    AssetResolver,
+    DottedNameResolver,
+    caller_package,
+    package_of,
+)
 from pyramid.registry import Introspectable, Introspector, Registry
 from pyramid.router import Router
 from pyramid.settings import aslist
@@ -292,6 +297,7 @@ class Configurator(
         self.name_resolver = name_resolver
         self.package_name = name_resolver.get_package_name()
         self.package = name_resolver.get_package()
+        self.asset_resolver = AssetResolver(self.package)
         self.root_package = root_package
         self.registry = registry
         self.autocommit = autocommit
@@ -738,6 +744,15 @@ class Configurator(
         consider it relative to the ``package`` argument supplied to
         this Configurator's constructor."""
         return self.name_resolver.maybe_resolve(dotted)
+
+    def resolve_asset(self, spec):
+        """Resolve the given :term:`asset specification` string to a
+        :class:`pyramid.interfaces.IAssetDescriptor` instance.  Overrides
+        registered via :meth:`pyramid.config.Configurator.override_asset` will
+        change how this method resolves assets, which is described in detail in
+        :ref:`assets_chapter`.
+        """
+        return self.asset_resolver.resolve(spec)
 
     def absolute_asset_spec(self, relative_spec):
         """Resolve the potentially relative :term:`asset

--- a/src/pyramid/request.py
+++ b/src/pyramid/request.py
@@ -13,6 +13,7 @@ from pyramid.interfaces import (
     IResponse,
     ISessionFactory,
 )
+from pyramid.path import AssetResolver, caller_package
 from pyramid.response import Response, _get_response_factory
 from pyramid.security import AuthenticationAPIMixin, SecurityAPIMixin
 from pyramid.url import URLMethodsMixin
@@ -227,6 +228,16 @@ class Request(
         if adapted is None:
             return False
         return adapted is ob
+
+    def resolve_asset(self, spec):
+        """Resolve the given :term:`asset specification` string to a
+        :class:`pyramid.interfaces.IAssetDescriptor` instance.  Overrides
+        registered via :meth:`pyramid.config.Configurator.override_asset` will
+        change how this method resolves assets, which is described in detail in
+        :ref:`assets_chapter`.
+        """
+        package = caller_package()
+        return AssetResolver(package).resolve(spec)
 
 
 def route_request_iface(name, bases=()):

--- a/tests/test_config/test_init.py
+++ b/tests/test_config/test_init.py
@@ -396,6 +396,18 @@ class ConfiguratorTests(unittest.TestCase):
         result = config.maybe_dotted(tests.test_config)
         self.assertEqual(result, tests.test_config)
 
+    def test_resolve_asset(self):
+        config = self._makeOne()
+        asset = config.resolve_asset('tests:fixtures/minimal.txt')
+        self.assertEqual(asset.absspec(), 'tests:fixtures/minimal.txt')
+
+    def test_resolve_asset_relative(self):
+        import tests
+
+        config = self._makeOne(package=tests)
+        asset = config.resolve_asset('fixtures/minimal.txt')
+        self.assertEqual(asset.absspec(), 'tests:fixtures/minimal.txt')
+
     def test_absolute_asset_spec_already_absolute(self):
         import tests.test_config
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -386,6 +386,17 @@ class TestRequest(unittest.TestCase):
         self.assertEqual(1, request.db)
         self.assertEqual(1, request.db)
 
+    def test_resolve_asset(self):
+        request = self._makeOne()
+        asset = request.resolve_asset('tests:fixtures/minimal.txt')
+        self.assertEqual(asset.absspec(), 'tests:fixtures/minimal.txt')
+
+    def test_resolve_asset_relative(self):
+        # Relative to caller_package, which is `tests` for this test class.
+        request = self._makeOne()
+        asset = request.resolve_asset('fixtures/minimal.txt')
+        self.assertEqual(asset.absspec(), 'tests:fixtures/minimal.txt')
+
 
 class Test_route_request_iface(unittest.TestCase):
     def _callFUT(self, name):


### PR DESCRIPTION
This adds `Configurator.resolve_asset` and `Request.resolve_asset` methods.  For #3731.

Considerations for `Configurator.resolve_asset`

- Opted to put implementation in `config/__init__.py`, so it's next to `maybe_dotted` and `absolute_asset_spec`.  Could also make sense to put in `config/assets.py`.
- Set `Configurator.asset_resolver` at init-time rather than instantiating `AssetResolver` on-demand when the method is invoked.

Considerations for `Request.resolve_asset`:

- Was not sure best place to put it.  There wasn't a relevant mixin, so I put it in the base class.  Could add potentially add `AssetMethodsMixin`.