### PR TITLE
Add .mailmap and update my CONTRIBUTORS.txt entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Delta Regeer <xistence@0x58.com> <bert.regeer@absio.com>
+Delta Regeer <xistence@0x58.com> <bertjw@regeer.org>
+Delta Regeer <xistence@0x58.com> <xistence@0x58.com>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -193,7 +193,7 @@ Contributors
 
 - John Anderson, 2012/11/14
 
-- Bert JW Regeer, 2013/02/01
+- Delta Regeer, 2013/02/01
 
 - Georges Dubus, 2013/03/21
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include CHANGES.rst HISTORY.rst BFG_HISTORY.rst
 include CONTRIBUTORS.txt LICENSE.txt COPYRIGHT.txt
 
 include .coveragerc .flake8 pyproject.toml
+include .mailmap
 include tox.ini .readthedocs.yaml
 include contributing.md RELEASING.txt HACKING.txt TODO.txt
 graft .github


### PR DESCRIPTION
Adds a `.mailmap` so my commits resolve to my current name and email. It maps
by commit email, which covers every historical variant. Display-only — the
commit objects themselves are unchanged.

Also updates my `CONTRIBUTORS.txt` entry to match.
`.mailmap` is added to `MANIFEST.in` so check-manifest stays happy.